### PR TITLE
fix: enforce read-only sandbox for review threads

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -4743,7 +4743,11 @@ async fn spawn_review_thread(
         collaboration_mode: parent_turn_context.collaboration_mode.clone(),
         personality: parent_turn_context.personality,
         approval_policy: parent_turn_context.approval_policy.clone(),
-        sandbox_policy: parent_turn_context.sandbox_policy.clone(),
+        // Enforce read-only sandbox for review threads so the reviewer cannot
+        // modify files.
+        sandbox_policy: Constrained::allow_only(SandboxPolicy::ReadOnly {
+            access: Default::default(),
+        }),
         network: parent_turn_context.network.clone(),
         windows_sandbox_level: parent_turn_context.windows_sandbox_level,
         shell_environment_policy: parent_turn_context.shell_environment_policy.clone(),

--- a/codex-rs/core/src/tasks/review.rs
+++ b/codex-rs/core/src/tasks/review.rs
@@ -20,6 +20,7 @@ use crate::codex::TurnContext;
 use crate::codex_delegate::run_codex_thread_one_shot;
 use crate::config::Constrained;
 use crate::features::Feature;
+use crate::protocol::SandboxPolicy;
 use crate::review_format::format_review_findings_block;
 use crate::review_format::render_review_output_text;
 use crate::state::TaskKind;
@@ -100,6 +101,13 @@ async fn start_review_conversation(
     // Set explicit review rubric for the sub-agent
     sub_agent_config.base_instructions = Some(crate::REVIEW_PROMPT.to_string());
     sub_agent_config.permissions.approval_policy = Constrained::allow_only(AskForApproval::Never);
+    // Enforce read-only sandbox for the review child session.
+    sub_agent_config.permissions.sandbox_policy =
+        Constrained::allow_only(SandboxPolicy::ReadOnly {
+            access: Default::default(),
+        });
+    // Avoid loading project docs; reviewer only needs findings.
+    sub_agent_config.project_doc_max_bytes = 0;
 
     let model = config
         .review_model


### PR DESCRIPTION
## Summary
- Forces `SandboxPolicy::ReadOnly` on review `TurnContext` in `spawn_review_thread`
- Forces `SandboxPolicy::ReadOnly` on review sub-agent `Config` in `tasks/review.rs`
- Sets `project_doc_max_bytes = 0` for reviewer (only needs findings, not project docs)

Replayed from closed-not-merged PR #239.

## Test plan
- [ ] Verify review threads cannot write files
- [ ] Verify review output still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)