### PR TITLE
fix: case-insensitive SKILL.md discovery with record_skill_from_path helper

### DIFF
--- a/codex-rs/core/src/skills/loader.rs
+++ b/codex-rs/core/src/skills/loader.rs
@@ -446,20 +446,11 @@ fn discover_skills_under_root(root: &Path, scope: SkillScope, outcome: &mut Skil
                     continue;
                 }
 
-                if metadata.is_file() && file_name == SKILLS_FILENAME {
-                    match parse_skill_file(&path, scope) {
-                        Ok(skill) => {
-                            outcome.skills.push(skill);
-                        }
-                        Err(err) => {
-                            if scope != SkillScope::System {
-                                outcome.errors.push(SkillError {
-                                    path,
-                                    message: err.to_string(),
-                                });
-                            }
-                        }
-                    }
+                if metadata.is_file()
+                    && (file_name == SKILLS_FILENAME
+                        || file_name.eq_ignore_ascii_case(SKILLS_FILENAME))
+                {
+                    record_skill_from_path(&path, scope, outcome);
                 }
 
                 continue;
@@ -479,20 +470,11 @@ fn discover_skills_under_root(root: &Path, scope: SkillScope, outcome: &mut Skil
                 continue;
             }
 
-            if file_type.is_file() && file_name == SKILLS_FILENAME {
-                match parse_skill_file(&path, scope) {
-                    Ok(skill) => {
-                        outcome.skills.push(skill);
-                    }
-                    Err(err) => {
-                        if scope != SkillScope::System {
-                            outcome.errors.push(SkillError {
-                                path,
-                                message: err.to_string(),
-                            });
-                        }
-                    }
-                }
+            if file_type.is_file()
+                && (file_name == SKILLS_FILENAME
+                    || file_name.eq_ignore_ascii_case(SKILLS_FILENAME))
+            {
+                record_skill_from_path(&path, scope, outcome);
             }
         }
     }
@@ -503,6 +485,22 @@ fn discover_skills_under_root(root: &Path, scope: SkillScope, outcome: &mut Skil
             MAX_SKILLS_DIRS_PER_ROOT,
             root.display()
         );
+    }
+}
+
+fn record_skill_from_path(path: &Path, scope: SkillScope, outcome: &mut SkillLoadOutcome) {
+    match parse_skill_file(path, scope) {
+        Ok(skill) => {
+            outcome.skills.push(skill);
+        }
+        Err(err) => {
+            if scope != SkillScope::System {
+                outcome.errors.push(SkillError {
+                    path: path.to_path_buf(),
+                    message: err.to_string(),
+                });
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds case-insensitive matching for `SKILL.md` filenames (e.g. `skill.md`, `Skill.MD`) in both symlink and regular file paths
- Extracts `record_skill_from_path` helper to deduplicate skill parsing error handling

Replayed from closed-not-merged PRs #243 and #247.

## Test plan
- [ ] Create a skill directory with `skill.md` (lowercase) and verify it loads
- [ ] Verify standard `SKILL.md` still loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)