### PR TITLE
fix: accept Ctrl as alternative to Alt for word-delete and queue restore

### DIFF
--- a/codex-rs/tui/src/bottom_pane/textarea.rs
+++ b/codex-rs/tui/src/bottom_pane/textarea.rs
@@ -312,11 +312,14 @@ impl TextArea {
                 modifiers,
                 ..
             } if is_altgr(modifiers) => self.insert_str(&c.to_string()),
+            // Some terminals encode Option+Backspace as Ctrl+Backspace.
             KeyEvent {
                 code: KeyCode::Backspace,
-                modifiers: KeyModifiers::ALT,
+                modifiers,
                 ..
-            } => self.delete_backward_word(),
+            } if modifiers.intersects(KeyModifiers::ALT | KeyModifiers::CONTROL) => {
+                self.delete_backward_word()
+            }
             KeyEvent {
                 code: KeyCode::Backspace,
                 ..
@@ -326,12 +329,15 @@ impl TextArea {
                 modifiers: KeyModifiers::CONTROL,
                 ..
             } => self.delete_backward(1),
+            // Some terminals encode Option+Delete as Ctrl+Delete.
             KeyEvent {
                 code: KeyCode::Delete,
-                modifiers: KeyModifiers::ALT,
+                modifiers,
                 ..
+            } if modifiers.intersects(KeyModifiers::ALT | KeyModifiers::CONTROL) => {
+                self.delete_forward_word()
             }
-            | KeyEvent {
+            KeyEvent {
                 code: KeyCode::Char('d'),
                 modifiers: KeyModifiers::ALT,
                 ..

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -1887,6 +1887,14 @@ impl ChatWidget {
         Some(combined)
     }
 
+    /// Returns true when the queued-message binding is Alt+Up and the event is
+    /// Ctrl+Up (common terminal encoding for Option+Up).
+    fn queued_message_ctrl_up_fallback_matches(&self, event: KeyEvent) -> bool {
+        self.queued_message_edit_binding == key_hint::alt(KeyCode::Up)
+            && event.code == KeyCode::Up
+            && event.modifiers == KeyModifiers::CONTROL
+    }
+
     fn restore_user_message_to_composer(&mut self, user_message: UserMessage) {
         let UserMessage {
             text,
@@ -3308,8 +3316,11 @@ impl ChatWidget {
             _ => {}
         }
 
+        // Terminals can encode Option+Up as Alt+Up or Ctrl+Up (e.g. CSI 1;5A),
+        // so accept either modifier for queued-message restore.
         if key_event.kind == KeyEventKind::Press
-            && self.queued_message_edit_binding.is_press(key_event)
+            && (self.queued_message_edit_binding.is_press(key_event)
+                || self.queued_message_ctrl_up_fallback_matches(key_event))
             && !self.queued_user_messages.is_empty()
         {
             if let Some(user_message) = self.queued_user_messages.pop_back() {


### PR DESCRIPTION
## Summary
- Accepts Ctrl+Backspace/Delete as word-delete (alternative to Alt+Backspace/Delete)
- Accepts Ctrl+Up as queued-message restore fallback (alternative to Alt+Up)
- Fixes terminals that encode Option key as Control modifier

Replayed from closed-not-merged PR #250.

## Test plan
- [ ] In Apple Terminal or other terminals, verify Ctrl+Backspace deletes a word
- [ ] Verify Ctrl+Up restores queued messages when a task is running

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard input handling for delete and backspace operations to support alternative terminal encodings
  * Enhanced compatibility for arrow key navigation when restoring queued messages across different terminal types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->