### PR TITLE
feat: Cmd+Shift+V verbatim paste bypasses large-paste placeholder

### DIFF
--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -783,6 +783,18 @@ impl ChatComposer {
         true
     }
 
+    /// Integrate pasted text as literal text, without creating large-paste placeholders.
+    ///
+    /// This powers the Cmd+Shift+V shortcut so users can intentionally paste large blocks while
+    /// keeping the full text visible/editable in the textarea.
+    pub(crate) fn handle_verbatim_paste(&mut self, pasted: String) -> bool {
+        let pasted = pasted.replace("\r\n", "\n").replace('\r', "\n");
+        self.textarea.insert_str(&pasted);
+        self.paste_burst.clear_after_explicit_paste();
+        self.sync_popups();
+        true
+    }
+
     pub fn handle_paste_image_path(&mut self, pasted: String) -> bool {
         let Some(path_buf) = normalize_pasted_path(&pasted) else {
             return false;

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -465,6 +465,23 @@ impl BottomPane {
         }
     }
 
+    pub fn handle_verbatim_paste(&mut self, pasted: String) {
+        if let Some(view) = self.view_stack.last_mut() {
+            let needs_redraw = view.handle_paste(pasted);
+            if view.is_complete() {
+                self.on_active_view_complete();
+            }
+            if needs_redraw {
+                self.request_redraw();
+            }
+        } else {
+            let needs_redraw = self.composer.handle_verbatim_paste(pasted);
+            if needs_redraw {
+                self.request_redraw();
+            }
+        }
+    }
+
     pub(crate) fn insert_str(&mut self, text: &str) {
         self.composer.insert_str(text);
         self.composer.sync_popups();

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -3281,6 +3281,28 @@ impl ChatWidget {
                 self.quit_shortcut_expires_at = None;
                 self.quit_shortcut_key = None;
             }
+            // Cmd+Shift+V: verbatim paste (bypass large-paste placeholder).
+            KeyEvent {
+                code: KeyCode::Char(c),
+                modifiers,
+                kind: KeyEventKind::Press,
+                ..
+            } if modifiers.contains(KeyModifiers::SUPER)
+                && modifiers.contains(KeyModifiers::SHIFT)
+                && !modifiers.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
+                && c.eq_ignore_ascii_case(&'v') =>
+            {
+                match crate::clipboard_paste::paste_text() {
+                    Ok(text) => self.bottom_pane.handle_verbatim_paste(text),
+                    Err(err) => {
+                        tracing::warn!("failed to paste text: {err}");
+                        self.add_to_history(history_cell::new_error_event(format!(
+                            "Failed to paste text: {err}",
+                        )));
+                    }
+                }
+                return;
+            }
             KeyEvent {
                 code: KeyCode::Char(c),
                 modifiers,

--- a/codex-rs/tui/src/clipboard_paste.rs
+++ b/codex-rs/tui/src/clipboard_paste.rs
@@ -22,6 +22,23 @@ impl std::fmt::Display for PasteImageError {
 }
 impl std::error::Error for PasteImageError {}
 
+#[derive(Debug, Clone)]
+pub enum PasteTextError {
+    ClipboardUnavailable(String),
+    NoText(String),
+}
+
+impl std::fmt::Display for PasteTextError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PasteTextError::ClipboardUnavailable(msg) => write!(f, "clipboard unavailable: {msg}"),
+            PasteTextError::NoText(msg) => write!(f, "no text on clipboard: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for PasteTextError {}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EncodedImageFormat {
     Png,
@@ -233,6 +250,22 @@ pub fn paste_image_to_temp_png() -> Result<(PathBuf, PastedImageInfo), PasteImag
     // Keep error consistent with paste_image_as_png.
     Err(PasteImageError::ClipboardUnavailable(
         "clipboard image paste is unsupported on Android".into(),
+    ))
+}
+
+#[cfg(not(target_os = "android"))]
+pub fn paste_text() -> Result<String, PasteTextError> {
+    let mut cb = arboard::Clipboard::new()
+        .map_err(|e| PasteTextError::ClipboardUnavailable(e.to_string()))?;
+    cb.get()
+        .text()
+        .map_err(|e| PasteTextError::NoText(e.to_string()))
+}
+
+#[cfg(target_os = "android")]
+pub fn paste_text() -> Result<String, PasteTextError> {
+    Err(PasteTextError::ClipboardUnavailable(
+        "clipboard text paste is unsupported on Android".into(),
     ))
 }
 


### PR DESCRIPTION
## Summary
- Adds `paste_text()` clipboard helper in `clipboard_paste.rs`
- Adds `handle_verbatim_paste()` on `ChatComposer` and `BottomPane`
- Adds Cmd+Shift+V key handler in `chatwidget.rs` that pastes text without creating placeholders

Replayed from closed-not-merged PR #248.

## Test plan
- [ ] Paste a large block of text with Cmd+Shift+V and verify it appears inline
- [ ] Verify normal Cmd+V still creates placeholder for large text

🤖 Generated with [Claude Code](https://claude.com/claude-code)