### PR TITLE
fix(ci): use PR head SHA for merge commit detection

### DIFF
--- a/.github/workflows/policy-gate.yml
+++ b/.github/workflows/policy-gate.yml
@@ -44,9 +44,8 @@ jobs:
 
           # 2) Prevent merge commits in PR branch (exclude GitHub's synthetic merge commit).
           git fetch origin "$BASE_REF" --depth=1 || true
-          # Use the actual PR head ref, not the GitHub merge commit (HEAD).
-          git fetch origin "$HEAD_REF" --depth=50 || true
-          MERGES=$(git rev-list --merges "origin/$BASE_REF..origin/$HEAD_REF" 2>/dev/null || true)
+          PR_HEAD="${{ github.event.pull_request.head.sha }}"
+          MERGES=$(git rev-list --merges "origin/$BASE_REF..$PR_HEAD" || true)
           if [[ -n "$MERGES" ]]; then
             echo "ERROR: merge commits detected in PR branch:"
             echo "$MERGES"


### PR DESCRIPTION
## Summary
- Fixes false positive merge commit detection in policy-gate workflow
- GitHub Actions checks out a temporary merge commit as HEAD, which was being flagged by the linear history check
- Now uses the actual PR head SHA from the event payload instead

## Test plan
- [ ] Verify policy-gate passes on existing open PRs
- [ ] Verify policy-gate still catches real merge commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)