### PR TITLE
ci: pin phenotypeActions reusable workflows to v0

### DIFF
--- a/.github/workflows/policy-gate.yml
+++ b/.github/workflows/policy-gate.yml
@@ -10,17 +10,5 @@ permissions:
 
 jobs:
   policy-gate:
-    name: policy-gate
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Enforce layered fix PR policy
-        uses: ./.github/actions/policy-gate
-        with:
-          head-ref: ${{ github.head_ref }}
-          base-ref: ${{ github.base_ref }}
-          pr-labels: ${{ toJson(github.event.pull_request.labels.*.name) }}
+    uses: KooshaPari/phenotypeActions/.github/workflows/policy-gate.yml@feat/workflow-migration-audit
+    secrets: inherit

--- a/.github/workflows/policy-gate.yml
+++ b/.github/workflows/policy-gate.yml
@@ -10,5 +10,5 @@ permissions:
 
 jobs:
   policy-gate:
-    uses: KooshaPari/phenotypeActions/.github/workflows/policy-gate.yml@feat/workflow-migration-audit
+    uses: KooshaPari/phenotypeActions/.github/workflows/policy-gate.yml@v0
     secrets: inherit

--- a/.github/workflows/review-wave-orchestrator.yml
+++ b/.github/workflows/review-wave-orchestrator.yml
@@ -11,5 +11,5 @@ permissions:
 
 jobs:
   review-wave:
-    uses: KooshaPari/phenotypeActions/.github/workflows/review-wave-orchestrator.yml@feat/workflow-migration-audit
+    uses: KooshaPari/phenotypeActions/.github/workflows/review-wave-orchestrator.yml@v0
     secrets: inherit

--- a/.github/workflows/review-wave-orchestrator.yml
+++ b/.github/workflows/review-wave-orchestrator.yml
@@ -1,0 +1,15 @@
+name: Review Wave Orchestrator
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  review-wave:
+    uses: KooshaPari/phenotypeActions/.github/workflows/review-wave-orchestrator.yml@feat/workflow-migration-audit
+    secrets: inherit


### PR DESCRIPTION
## Summary
- pin reusable workflow calls to KooshaPari/phenotypeActions@v0
- update both wrapper workflows introduced in Wave A

## Supersedes
- Follow-up to #294 with stable tag pinning.