### PR TITLE
ci: pin phenotypeActions workflow refs to immutable SHA

### DIFF
--- a/.github/workflows/policy-gate.yml
+++ b/.github/workflows/policy-gate.yml
@@ -10,5 +10,5 @@ permissions:
 
 jobs:
   policy-gate:
-    uses: KooshaPari/phenotypeActions/.github/workflows/policy-gate.yml@v0
+    uses: KooshaPari/phenotypeActions/.github/workflows/policy-gate.yml@c7e43facecdef5942f591ee72cb204b076ba23fd # v0
     secrets: inherit

--- a/.github/workflows/policy-gate.yml
+++ b/.github/workflows/policy-gate.yml
@@ -10,17 +10,5 @@ permissions:
 
 jobs:
   policy-gate:
-    name: policy-gate
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Enforce layered fix PR policy
-        uses: ./.github/actions/policy-gate
-        with:
-          head-ref: ${{ github.head_ref }}
-          base-ref: ${{ github.base_ref }}
-          pr-labels: ${{ toJson(github.event.pull_request.labels.*.name) }}
+    uses: KooshaPari/phenotypeActions/.github/workflows/policy-gate.yml@feat/workflow-migration-audit
+    secrets: inherit

--- a/.github/workflows/policy-gate.yml
+++ b/.github/workflows/policy-gate.yml
@@ -10,5 +10,5 @@ permissions:
 
 jobs:
   policy-gate:
-    uses: KooshaPari/phenotypeActions/.github/workflows/policy-gate.yml@feat/workflow-migration-audit
+    uses: KooshaPari/phenotypeActions/.github/workflows/policy-gate.yml@v0
     secrets: inherit

--- a/.github/workflows/review-wave-orchestrator.yml
+++ b/.github/workflows/review-wave-orchestrator.yml
@@ -11,5 +11,5 @@ permissions:
 
 jobs:
   review-wave:
-    uses: KooshaPari/phenotypeActions/.github/workflows/review-wave-orchestrator.yml@feat/workflow-migration-audit
+    uses: KooshaPari/phenotypeActions/.github/workflows/review-wave-orchestrator.yml@v0
     secrets: inherit

--- a/.github/workflows/review-wave-orchestrator.yml
+++ b/.github/workflows/review-wave-orchestrator.yml
@@ -1,0 +1,15 @@
+name: Review Wave Orchestrator
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  review-wave:
+    uses: KooshaPari/phenotypeActions/.github/workflows/review-wave-orchestrator.yml@feat/workflow-migration-audit
+    secrets: inherit

--- a/.github/workflows/review-wave-orchestrator.yml
+++ b/.github/workflows/review-wave-orchestrator.yml
@@ -11,5 +11,5 @@ permissions:
 
 jobs:
   review-wave:
-    uses: KooshaPari/phenotypeActions/.github/workflows/review-wave-orchestrator.yml@v0
+    uses: KooshaPari/phenotypeActions/.github/workflows/review-wave-orchestrator.yml@c7e43facecdef5942f591ee72cb204b076ba23fd # v0
     secrets: inherit


### PR DESCRIPTION
## Summary
- replace mutable v0 refs with immutable commit SHA pins
- keep human-readable version annotation (# v0) on each call
- target SHA: c7e43facecdef5942f591ee72cb204b076ba23fd

## Why
- addresses review feedback that v0 is mutable and not a true pin
- keeps Wave A migration secure and deterministic