### PR TITLE
chore: remove unsupported CodeRabbit keys

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -10,17 +10,3 @@ reviews:
 # Stage intent is preserved operationally outside this file:
 # - branch and CI stage gates continue to define review strictness by lane.
 # - switch `reviews.profile` to `assertive` for release/hotfix hardening passes.
-
-pre_merge_checks:
-  docstrings:
-    mode: warning
-  title:
-    mode: warning
-  description:
-    mode: warning
-  issue_assessment:
-    mode: warning
-
-pr_validation:
-  block_on:
-    severity: info


### PR DESCRIPTION
Removes unsupported codrabbit config keys pre_merge_checks and pr_validation that are currently generating strict parsing warnings in PR review comments.