### PR TITLE
policy-gate: allow integration sync branches

### DIFF
--- a/.github/workflows/policy-gate.yml
+++ b/.github/workflows/policy-gate.yml
@@ -41,6 +41,12 @@ jobs:
             fi
           fi
 
+          # Integration sync branches may intentionally contain merge commits.
+          if [[ "$HEAD_REF" == merge/* || "$HEAD_REF" == sync/* ]]; then
+            echo "Skipping merge-commit policy check for integration branch: $HEAD_REF"
+            exit 0
+          fi
+
           git fetch origin "$BASE_REF" --depth=1 || true
           PR_HEAD="${{ github.event.pull_request.head.sha }}"
           MERGES=$(git rev-list --merges "origin/$BASE_REF..$PR_HEAD" || true)


### PR DESCRIPTION
Skip merge-commit enforcement for integration branches (merge/*, sync/*) so full upstream sync PRs can validate without failing policy-gate for intentional merge history.