### PR TITLE
ci: fix drift-detection quoting regression

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -110,7 +110,7 @@ jobs:
         run: |
           set -euo pipefail
           if ! cargo metadata --locked --format-version=1 >/dev/null; then
-            echo "::error::Lockfile drift detected. Regenerate lockfile changes with `cargo update` and commit updated `Cargo.lock`."
+            echo "::error::Lockfile drift detected. Regenerate lockfile changes with cargo update -w and commit updated Cargo.lock."
             exit 1
           fi
 
@@ -127,8 +127,8 @@ jobs:
         if: ${{ needs.changed.outputs.rust_core == 'true' }}
         shell: bash
         run: |
-          echo "::error::Legacy `rust_core` path was edited."
-          echo "::error::This fork is de-mirrored. Use `codex-rs` as the active Rust workspace."
+          echo "::error::Legacy rust_core path was edited."
+          echo "::error::This fork is de-mirrored. Use codex-rs as the active Rust workspace."
           exit 1
 
   # --- CI that doesn't need specific targets ---------------------------------


### PR DESCRIPTION
Follow-up fix for PR #317 CI wave.

## Summary
- remove shell backticks from `rust-ci` drift-detection error output to prevent accidental command substitution under bash
- update legacy `rust_core` error text to avoid interpolation hazards

## Why
`Drift detection` failed with:
- `Cargo.lock: command not found`

The workflow emitted an error message containing backticks, which bash interpreted as command substitution.

## Validation
- reviewed failing job log: https://github.com/KooshaPari/helios-cli/actions/runs/22544022065/job/65303426468
- verified workflow script now emits plain text with no command substitution tokens
