### PR TITLE
chore: refresh Cargo.lock on integration branch

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1786,7 +1786,6 @@ dependencies = [
  "core_test_support",
  "csv",
  "ctor 0.6.3",
- "dashmap",
  "dirs",
  "dunce",
  "encoding_rs",
@@ -3196,20 +3195,6 @@ dependencies = [
  "darling_core 0.23.0",
  "quote",
  "syn 2.0.114",
-]
-
-[[package]]
-name = "dashmap"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
 ]
 
 [[package]]


### PR DESCRIPTION
Follow-up lockfile refresh for PR #317.

## Summary
- refresh `codex-rs/Cargo.lock` against current `merge/upstream-codex-main-20260301`

## Validation
- `cd codex-rs && cargo update -w`
- `cd codex-rs && cargo metadata --locked --format-version=1 >/dev/null`
