### PR TITLE
ci: fix drift matrix and helios bazel alias

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -121,19 +121,12 @@ jobs:
 
       - name: Run feature-matrix guard for feature-sensitive changes
         if: ${{ needs.changed.outputs.feature_drift == 'true' }}
-        shell: bash
         run: |
-          set -euo pipefail
-          if ! command -v just >/dev/null 2>&1; then
-            if command -v apt-get >/dev/null 2>&1; then
-              sudo apt-get update -y
-              sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends just || true
-            fi
-          fi
-          if ! command -v just >/dev/null 2>&1; then
-            cargo install just --locked
-          fi
-          just feature-matrix
+          cargo check -p codex-tui --no-default-features
+          cargo check -p codex-tui --no-default-features --features debug-logs
+          cargo check -p codex-cloud-tasks-client --no-default-features
+          cargo check -p codex-cloud-tasks-client --no-default-features --features mock
+          cargo check -p codex-otel --features disable-default-metrics-exporter
 
       - name: Enforce no rust_core edits
         if: ${{ needs.changed.outputs.rust_core == 'true' }}

--- a/helios-rs/cli/BUILD.bazel
+++ b/helios-rs/cli/BUILD.bazel
@@ -1,8 +1,8 @@
-load("//:defs.bzl", "helios_rust_crate", "multiplatform_binaries")
+load("//:defs.bzl", "multiplatform_binaries")
 
-helios_rust_crate(
-    name = "cli",
-    crate_name = "helios_cli",
+alias(
+    name = "helios",
+    actual = "//codex-rs/cli:codex",
 )
 
 multiplatform_binaries(


### PR DESCRIPTION
Follow-up unblock for PR #317.

## Summary
- remove `just` invocation from `rust-ci` drift feature-matrix guard and run the equivalent `cargo check` matrix directly
- replace `helios-rs/cli` Bazel crate macro usage with an alias to `//codex-rs/cli:codex` for `:helios`

## Why
Latest failures included:
- Drift detection failing on justfile incompatibility (`Unknown setting 'working-directory'`)
- Bazel experimental failures while compiling `helios-rs/cli` as a partial crate missing expected module/dependency metadata

## Validation
- `cd codex-rs && cargo metadata --locked --format-version=1 >/dev/null`
- `./scripts/check-module-bazel-lock.sh`
- `bazel query //helios-rs/cli:helios`
- `bazel cquery //helios-rs/cli:helios --noimplicit_deps`
