### PR TITLE
ci: install libcap deps in drift feature-matrix

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -121,7 +121,13 @@ jobs:
 
       - name: Run feature-matrix guard for feature-sensitive changes
         if: ${{ needs.changed.outputs.feature_drift == 'true' }}
+        shell: bash
         run: |
+          set -euo pipefail
+          if command -v apt-get >/dev/null 2>&1; then
+            sudo apt-get update -y
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends pkg-config libcap-dev
+          fi
           cargo check -p codex-tui --no-default-features
           cargo check -p codex-tui --no-default-features --features debug-logs
           cargo check -p codex-cloud-tasks-client --no-default-features


### PR DESCRIPTION
Follow-up drift-detection fix for PR #317.

## Summary
- install Linux build dependencies (`pkg-config`, `libcap-dev`) before running the drift-detection feature-matrix checks in `rust-ci`

## Why
The drift job was failing during `cargo check -p codex-tui --no-default-features` with `codex-linux-sandbox` complaining `libcap not available via pkg-config`.

## Validation
- `cd codex-rs && cargo metadata --locked --format-version=1 >/dev/null`
- `cd codex-rs && cargo check -p codex-tui --no-default-features`
