### PR TITLE
fix: update schema fixture and windows clippy

### DIFF
--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
@@ -1248,54 +1248,6 @@
             },
             "method": {
               "enum": [
-                "externalAgentConfig/detect"
-              ],
-              "title": "ExternalAgentConfig/detectRequestMethod",
-              "type": "string"
-            },
-            "params": {
-              "$ref": "#/definitions/v2/ExternalAgentConfigDetectParams"
-            }
-          },
-          "required": [
-            "id",
-            "method",
-            "params"
-          ],
-          "title": "ExternalAgentConfig/detectRequest",
-          "type": "object"
-        },
-        {
-          "properties": {
-            "id": {
-              "$ref": "#/definitions/RequestId"
-            },
-            "method": {
-              "enum": [
-                "externalAgentConfig/import"
-              ],
-              "title": "ExternalAgentConfig/importRequestMethod",
-              "type": "string"
-            },
-            "params": {
-              "$ref": "#/definitions/v2/ExternalAgentConfigImportParams"
-            }
-          },
-          "required": [
-            "id",
-            "method",
-            "params"
-          ],
-          "title": "ExternalAgentConfig/importRequest",
-          "type": "object"
-        },
-        {
-          "properties": {
-            "id": {
-              "$ref": "#/definitions/RequestId"
-            },
-            "method": {
-              "enum": [
                 "config/value/write"
               ],
               "title": "Config/value/writeRequestMethod",

--- a/codex-rs/tui/src/clipboard_paste.rs
+++ b/codex-rs/tui/src/clipboard_paste.rs
@@ -306,17 +306,21 @@ pub fn normalize_pasted_path(pasted: &str) -> Option<PathBuf> {
     // shell-escaped single path → unescaped
     let parts: Vec<String> = shlex::Shlex::new(pasted).collect();
     if parts.len() == 1 {
-        let mut part = parts.into_iter().next()?;
+        let part = parts.into_iter().next()?;
         if let Some(path) = normalize_windows_path(&part) {
             return Some(path);
         }
 
-        #[cfg(not(windows))]
+        #[cfg(windows)]
         {
-            part = fixup_unix_root_relative_path(part);
+            return Some(PathBuf::from(part));
         }
 
-        return Some(PathBuf::from(part));
+        #[cfg(not(windows))]
+        {
+            let part = fixup_unix_root_relative_path(part);
+            return Some(PathBuf::from(part));
+        }
     }
 
     None


### PR DESCRIPTION
Follow-up unblock for PR #317 failures from run 22544637899.

## Summary
- regenerate vendored app-server protocol schema fixture
- fix Windows clippy `unused_mut` warning in `clipboard_paste.rs`

## Why
Failing checks reported:
- Tests on linux/macos/windows: schema fixture mismatch (`write-app-server-schema` required)
- Lint/Build on windows: `variable does not need to be mutable` in `tui/src/clipboard_paste.rs`

## Validation
- `cd codex-rs && cargo run -p codex-app-server-protocol --bin write_schema_fixtures`
- `cd codex-rs && cargo clippy --manifest-path Cargo.toml -p codex-tui -- -D warnings`
