### PR TITLE
fix: handle apply_patch marker with prepended args

### DIFF
--- a/codex-rs/arg0/src/lib.rs
+++ b/codex-rs/arg0/src/lib.rs
@@ -86,9 +86,10 @@ pub fn arg0_dispatch() -> Option<Arg0PathEntryGuard> {
         codex_apply_patch::main();
     }
 
-    let argv1 = args.next().unwrap_or_default();
-    if argv1 == CODEX_CORE_APPLY_PATCH_ARG1 {
-        let patch_arg = args.next().and_then(|s| s.to_str().map(str::to_owned));
+    let argv: Vec<_> = args.collect();
+    let apply_patch_arg_index = argv.iter().position(|arg| arg == CODEX_CORE_APPLY_PATCH_ARG1);
+    if let Some(index) = apply_patch_arg_index {
+        let patch_arg = argv.get(index + 1).and_then(|s| s.to_str().map(str::to_owned));
         let exit_code = match patch_arg {
             Some(patch_arg) => {
                 let mut stdout = std::io::stdout();


### PR DESCRIPTION
Follow-up fix for PR #317 test regressions in apply_patch flows.

## Summary
- update arg0 dispatch logic to detect `--codex-run-as-apply-patch` anywhere in argv

## Why
The tests job showed many apply_patch failures with:
- `error: unexpected argument '--codex-run-as-apply-patch' found`

Runtime/sandbox options are now prepended in some paths, so apply_patch marker is no longer guaranteed to be `argv[1]`.

## Validation
- `cd codex-rs && cargo test -p codex-core suite::shell_serialization::apply_patch_custom_tool_call_creates_file -- --nocapture`
- `cd codex-rs && cargo test -p codex-core suite::apply_patch_cli::apply_patch_cli_add_overwrites_existing_file -- --nocapture`
