### PR TITLE
style(arg0): format apply-patch dispatch update

### DIFF
--- a/codex-rs/arg0/src/lib.rs
+++ b/codex-rs/arg0/src/lib.rs
@@ -87,9 +87,13 @@ pub fn arg0_dispatch() -> Option<Arg0PathEntryGuard> {
     }
 
     let argv: Vec<_> = args.collect();
-    let apply_patch_arg_index = argv.iter().position(|arg| arg == CODEX_CORE_APPLY_PATCH_ARG1);
+    let apply_patch_arg_index = argv
+        .iter()
+        .position(|arg| arg == CODEX_CORE_APPLY_PATCH_ARG1);
     if let Some(index) = apply_patch_arg_index {
-        let patch_arg = argv.get(index + 1).and_then(|s| s.to_str().map(str::to_owned));
+        let patch_arg = argv
+            .get(index + 1)
+            .and_then(|s| s.to_str().map(str::to_owned));
         let exit_code = match patch_arg {
             Some(patch_arg) => {
                 let mut stdout = std::io::stdout();


### PR DESCRIPTION
## Summary
- apply rustfmt to `codex-rs/arg0/src/lib.rs` after arg0 dispatch fix
- keep behavior unchanged; formatting-only follow-up to pass format checks

## Validation
- cd codex-rs && cargo fmt -- --config imports_granularity=Item
