### PR TITLE
fix(cli): dispatch arg0 before clap parsing

### DIFF
--- a/codex-rs/arg0/src/lib.rs
+++ b/codex-rs/arg0/src/lib.rs
@@ -87,9 +87,13 @@ pub fn arg0_dispatch() -> Option<Arg0PathEntryGuard> {
     }
 
     let argv: Vec<_> = args.collect();
-    let apply_patch_arg_index = argv.iter().position(|arg| arg == CODEX_CORE_APPLY_PATCH_ARG1);
+    let apply_patch_arg_index = argv
+        .iter()
+        .position(|arg| arg == CODEX_CORE_APPLY_PATCH_ARG1);
     if let Some(index) = apply_patch_arg_index {
-        let patch_arg = argv.get(index + 1).and_then(|s| s.to_str().map(str::to_owned));
+        let patch_arg = argv
+            .get(index + 1)
+            .and_then(|s| s.to_str().map(str::to_owned));
         let exit_code = match patch_arg {
             Some(patch_arg) => {
                 let mut stdout = std::io::stdout();

--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -550,8 +550,8 @@ fn stage_str(stage: codex_core::features::Stage) -> &'static str {
 }
 
 fn main() -> anyhow::Result<()> {
-    let cli = MultitoolCli::parse();
     arg0_dispatch_or_else(|codex_linux_sandbox_exe: Arg0DispatchPaths| async move {
+        let cli = MultitoolCli::parse();
         cli_main(cli, codex_linux_sandbox_exe).await?;
         Ok(())
     })


### PR DESCRIPTION
## Summary
- run `arg0_dispatch_or_else` before any `clap` parsing in `codex-rs/cli/src/main.rs`
- ensures internal `--codex-run-as-apply-patch` invocations are handled by arg0 dispatch instead of rejected by clap

## Why
- PR #317 failures showed apply_patch invocations exiting with:
  - `error: unexpected argument '--codex-run-as-apply-patch' found`
- this broke many `apply_patch_cli` tests on Linux and Windows

## Validation
- `cargo test -p codex-exec suite::apply_patch -- --nocapture`
- `cargo run -p codex-cli -- --codex-run-as-apply-patch "*** Begin Patch\n*** End Patch"`
