### PR TITLE
Replay follow-up: remaining6 reconciliation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,6 @@ result
 
 # cli tools
 CLAUDE.md
-.claude/
 AGENTS.override.md
 
 # caches
@@ -91,3 +90,15 @@ CHANGELOG.ignore.md
 __pycache__/
 *.pyc
 
+
+# AI tool artifacts
+.claude/
+.codex/
+.cursor/
+.gemini/
+.kittify/
+.kilocode/
+.github/prompts/
+.github/copilot-instructions.md
+.claudeignore
+.llmignore


### PR DESCRIPTION
Tracks remaining source-only commit reconciliation. Includes d6987c6633 and explicit drop rationale for source-only/no-op commits.