### PR TITLE
[codex] enforce owner namespace for PRs and issues

### DIFF
--- a/.github/workflows/namespace-audit-retro.yml
+++ b/.github/workflows/namespace-audit-retro.yml
@@ -1,0 +1,52 @@
+name: Namespace Audit Retro
+
+on:
+  schedule:
+    - cron: "0 3 * * 1"
+  workflow_dispatch:
+    inputs:
+      close_items:
+        description: "Close and keep comment on violating open PRs/issues"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  audit-open-items:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run namespace audit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CLOSE_ITEMS: ${{ github.event_name == 'workflow_dispatch' && inputs.close_items == true }}
+        run: |
+          set -euo pipefail
+
+          args=(
+            --repo "${{ github.repository }}"
+            --namespace KooshaPari
+            --json-report namespace-audit-report.json
+            --allowed-bots github-actions[bot],dependabot[bot],dependabot-preview[bot],renovate[bot],app/github-actions
+            --dry-run
+          )
+
+          if [[ "$CLOSE_ITEMS" == "true" ]]; then
+            args=("${args[@]/--dry-run/}")
+            args+=(--close)
+          fi
+
+          ./scripts/namespace-audit.sh "${args[@]}"
+
+      - name: Upload audit report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: namespace-audit-report
+          path: namespace-audit-report.json
+          if-no-files-found: ignore

--- a/.github/workflows/namespace-governance.yml
+++ b/.github/workflows/namespace-governance.yml
@@ -1,0 +1,105 @@
+name: Namespace Governance
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  issues:
+    types: [opened]
+
+jobs:
+  prune-non-owner-prs:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Enforce PR owner namespace
+        env:
+          ALLOWED_NAMESPACE: KooshaPari
+          ALLOWED_BOTS: github-actions[bot],dependabot[bot],dependabot-preview[bot],renovate[bot],app/github-actions
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          HEAD_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "$PR_AUTHOR" ]]; then
+            echo "Unable to read PR author from event payload."
+            exit 1
+          fi
+
+          is_bot_author=0
+          IFS=',' read -ra bots <<< "$ALLOWED_BOTS"
+          for bot in "${bots[@]}"; do
+            if [[ "$bot" == "$PR_AUTHOR" ]]; then
+              is_bot_author=1
+              break
+            fi
+          done
+
+          if [[ "$is_bot_author" -eq 1 ]]; then
+            echo "Allowed bot author detected: $PR_AUTHOR"
+            exit 0
+          fi
+
+          if [[ "$PR_AUTHOR" != "$ALLOWED_NAMESPACE" || "$HEAD_OWNER" != "$ALLOWED_NAMESPACE" ]]; then
+            echo "Blocked: PR must come from namespace '$ALLOWED_NAMESPACE'."
+            echo "Author: $PR_AUTHOR"
+            echo "Head repo owner: $HEAD_OWNER"
+            if [[ -n "${PR_URL}" ]]; then
+              COMMENT=$'This PR is outside the allowed namespace policy.\n\nAllowed namespace: **'"$ALLOWED_NAMESPACE"'**\n\nPlease move this change to a KooshaPari-owned repository and reopen there.'
+              echo "$COMMENT" | gh pr comment "$PR_NUMBER" --body-file - || true
+            fi
+            exit 1
+          fi
+
+          echo "Namespace check passed for PR #${{ github.event.pull_request.number }}"
+
+  prune-non-owner-issues:
+    if: github.event_name == 'issues'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Redirect and close outsider issues
+        env:
+          ALLOWED_NAMESPACE: KooshaPari
+          ALLOWED_BOTS: github-actions[bot],dependabot[bot],dependabot-preview[bot],renovate[bot],app/github-actions
+          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "$ISSUE_AUTHOR" ]]; then
+            echo "Unable to read issue author from event payload."
+            exit 1
+          fi
+
+          is_bot_author=0
+          IFS=',' read -ra bots <<< "$ALLOWED_BOTS"
+          for bot in "${bots[@]}"; do
+            if [[ "$bot" == "$ISSUE_AUTHOR" ]]; then
+              is_bot_author=1
+              break
+            fi
+          done
+
+          if [[ "$is_bot_author" -eq 1 ]]; then
+            echo "Allowed bot author detected: $ISSUE_AUTHOR"
+            exit 0
+          fi
+
+          if [[ "$ISSUE_AUTHOR" == "$ALLOWED_NAMESPACE" ]]; then
+            echo "Issue authored by allowed namespace owner."
+            exit 0
+          fi
+
+          COMMENT=$'This issue was opened outside the allowed namespace policy.\n\nAllowed namespace: **'"$ALLOWED_NAMESPACE"'**\n\nPlease open this issue in a KooshaPari-owned repository so it can be tracked by the right maintainer scope.\n\nIf this was accidental, please recreate it in the intended KooshaPari repo and close this one.'
+          echo "$COMMENT" | gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body-file -
+
+          gh issue close "$ISSUE_NUMBER" --repo "$REPO"
+          echo "Closed issue #$ISSUE_NUMBER from @$ISSUE_AUTHOR"

--- a/.github/workflows/policy-gate.yml
+++ b/.github/workflows/policy-gate.yml
@@ -18,6 +18,43 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Enforce namespace ownership
+        env:
+          ALLOWED_NAMESPACE: KooshaPari
+          ALLOWED_BOTS: github-actions[bot],dependabot[bot],dependabot-preview[bot],renovate[bot],app/github-actions
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          HEAD_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "$PR_AUTHOR" ]]; then
+            echo "ERROR: Unable to read PR author."
+            exit 1
+          fi
+
+          is_bot_author=0
+          IFS=',' read -ra bots <<< "$ALLOWED_BOTS"
+          for bot in "${bots[@]}"; do
+            if [[ "$bot" == "$PR_AUTHOR" ]]; then
+              is_bot_author=1
+              break
+            fi
+          done
+
+          if [[ "$is_bot_author" -eq 1 ]]; then
+            echo "Allowed bot author: $PR_AUTHOR"
+            exit 0
+          fi
+
+          if [[ "$PR_AUTHOR" != "$ALLOWED_NAMESPACE" || "$HEAD_OWNER" != "$ALLOWED_NAMESPACE" ]]; then
+            echo "ERROR: PR must come from namespace '$ALLOWED_NAMESPACE'."
+            echo "Author: $PR_AUTHOR"
+            echo "Head repo owner: $HEAD_OWNER"
+            exit 1
+          fi
+
+          echo "Namespace ownership policy passed."
+
       - name: Enforce layered fix PR policy
         shell: bash
         env:

--- a/codex-rs/core/tests/common/lib.rs
+++ b/codex-rs/core/tests/common/lib.rs
@@ -241,14 +241,39 @@ pub async fn wait_for_event_with_timeout<F>(
 where
     F: FnMut(&codex_protocol::protocol::EventMsg) -> bool,
 {
-    use tokio::time::Duration;
-    use tokio::time::timeout;
+    use tokio::time::{timeout, Duration, Instant};
+
+    let per_event_timeout = wait_time.max(Duration::from_secs(10));
+    let overall_timeout = Instant::now() + Duration::from_secs(60);
+    let mut attempts = 0usize;
+    let mut seen_events = Vec::new();
     loop {
-        // Allow a bit more time to accommodate async startup work (e.g. config IO, tool discovery)
-        let ev = timeout(wait_time.max(Duration::from_secs(10)), codex.next_event())
-            .await
-            .expect("timeout waiting for event")
-            .expect("stream ended unexpectedly");
+        let remaining = overall_timeout
+            .checked_duration_since(Instant::now())
+            .unwrap_or_default();
+        if remaining.is_zero() {
+            panic!(
+                "timeout waiting for matching event after 60s (attempts={attempts}, per_event_timeout={per_event_timeout:?}, seen_events={seen_events:?})"
+            );
+        }
+
+        // Allow a bit more time to accommodate async startup work (e.g. config IO, tool discovery).
+        let ev = timeout(
+            std::cmp::min(per_event_timeout, remaining),
+            codex.next_event(),
+        )
+        .await
+        .unwrap_or_else(|_| {
+            panic!(
+                "timeout waiting for event (attempts={attempts}, per_event_timeout={per_event_timeout:?}, remaining={remaining:?}, seen_events={seen_events:?})"
+            )
+        })
+        .expect("stream ended unexpectedly");
+
+        attempts += 1;
+        if seen_events.len() < 16 {
+            seen_events.push(format!("{:?}", ev.msg));
+        }
         if predicate(&ev.msg) {
             return ev.msg;
         }

--- a/codex-rs/core/tests/common/lib.rs
+++ b/codex-rs/core/tests/common/lib.rs
@@ -241,7 +241,9 @@ pub async fn wait_for_event_with_timeout<F>(
 where
     F: FnMut(&codex_protocol::protocol::EventMsg) -> bool,
 {
-    use tokio::time::{Duration, Instant, timeout};
+    use tokio::time::Duration;
+    use tokio::time::Instant;
+    use tokio::time::timeout;
 
     let per_event_timeout = wait_time.max(Duration::from_secs(10));
     let overall_timeout = Instant::now() + Duration::from_secs(60);

--- a/codex-rs/core/tests/common/lib.rs
+++ b/codex-rs/core/tests/common/lib.rs
@@ -241,7 +241,7 @@ pub async fn wait_for_event_with_timeout<F>(
 where
     F: FnMut(&codex_protocol::protocol::EventMsg) -> bool,
 {
-    use tokio::time::{timeout, Duration, Instant};
+    use tokio::time::{Duration, Instant, timeout};
 
     let per_event_timeout = wait_time.max(Duration::from_secs(10));
     let overall_timeout = Instant::now() + Duration::from_secs(60);

--- a/codex-rs/core/tests/suite/compact_resume_fork.rs
+++ b/codex-rs/core/tests/suite/compact_resume_fork.rs
@@ -378,7 +378,10 @@ async fn compact_resume_after_second_compaction_preserves_history() {
         vec!["AFTER_FORK".to_string(), summary_after_second_compact];
     expected_after_second_compact_user_texts.extend_from_slice(seeded_user_prefix);
     expected_after_second_compact_user_texts.push("AFTER_COMPACT_2".to_string());
-    let final_user_texts = json_message_input_texts(&requests[requests.len() - 1], "user");
+    let final_user_texts = json_message_input_texts(&requests[requests.len() - 1], "user")
+        .into_iter()
+        .filter(|text| !text.trim_start().starts_with("<ghost_snapshot>"))
+        .collect::<Vec<_>>();
     let (final_last, final_prefix) = final_user_texts
         .split_last()
         .unwrap_or_else(|| panic!("after-second-resume request missing user messages"));
@@ -498,15 +501,11 @@ async fn mount_second_compact_flow(server: &MockServer) -> Vec<ResponseMock> {
     ]);
     let sse7 = sse(vec![ev_completed("r7")]);
 
-    // Keep this matcher broad enough to survive prompt-shape differences across
-    // platforms/config (history may include either marker text or compact prompt
-    // fragments), but explicitly exclude the final resume turn so these two
-    // one-shot mocks cannot race for the same request.
+    // Match the compact request after `AFTER_COMPACT_2`; this keeps the matcher
+    // specific to the expected second compact round-trip and avoids mock races.
     let match_second_compact = |req: &wiremock::Request| {
         let body = std::str::from_utf8(&req.body).unwrap_or("");
-        (body.contains("AFTER_FORK")
-            || body_contains_text(body, SUMMARIZATION_PROMPT)
-            || body.contains(&json_fragment(FIRST_REPLY)))
+        body.contains("\"text\":\"AFTER_COMPACT_2\"")
             && !body.contains(&format!("\"text\":\"{AFTER_SECOND_RESUME}\""))
     };
     let second_compact = mount_sse_once_match(server, match_second_compact, sse6).await;

--- a/codex-rs/core/tests/suite/compact_resume_fork.rs
+++ b/codex-rs/core/tests/suite/compact_resume_fork.rs
@@ -501,11 +501,12 @@ async fn mount_second_compact_flow(server: &MockServer) -> Vec<ResponseMock> {
     ]);
     let sse7 = sse(vec![ev_completed("r7")]);
 
-    // Match the compact request after `AFTER_COMPACT_2`; this keeps the matcher
-    // specific to the expected second compact round-trip and avoids mock races.
+    // Match the second compaction request by the summarization prompt plus the
+    // forked-history marker, while excluding the later resume turn.
     let match_second_compact = |req: &wiremock::Request| {
         let body = std::str::from_utf8(&req.body).unwrap_or("");
-        body.contains("\"text\":\"AFTER_COMPACT_2\"")
+        body_contains_text(body, SUMMARIZATION_PROMPT)
+            && body.contains("\"text\":\"AFTER_FORK\"")
             && !body.contains(&format!("\"text\":\"{AFTER_SECOND_RESUME}\""))
     };
     let second_compact = mount_sse_once_match(server, match_second_compact, sse6).await;

--- a/codex-rs/tui/src/theme_picker.rs
+++ b/codex-rs/tui/src/theme_picker.rs
@@ -296,7 +296,7 @@ fn theme_picker_subtitle(codex_home: Option<&Path>, terminal_width: Option<u16>)
 ///
 /// `current_name` should be the value of `Config::tui_theme` (the persisted
 /// preference).  When it names a theme that is currently available the picker
-/// pre-selects it; otherwise the picker falls back to the configured name (or
+/// preselects it; otherwise the picker falls back to the configured name (or
 /// adaptive default) so opening the picker without a persisted preference still
 /// highlights the most likely intended entry.
 pub(crate) fn build_theme_picker_params(
@@ -321,7 +321,7 @@ pub(crate) fn build_theme_picker_params(
         highlight::configured_theme_name()
     };
 
-    // Track the index of the current theme so we can pre-select it.
+    // Track the index of the current theme so we can preselect it.
     let mut initial_idx = None;
 
     let items: Vec<SelectionItem> = entries

--- a/config/patch_superset.json
+++ b/config/patch_superset.json
@@ -1,0 +1,44 @@
+{
+  "allowed_secondary_root": "../../helios-cli",
+  "patches": [
+    {
+      "id": "toolchains_llvm_bootstrapped_resource_dir",
+      "category": "workspace-bootstrap",
+      "path": "patches/toolchains_llvm_bootstrapped_resource_dir.patch",
+      "integration": "bazel_module_override",
+      "module_reference": "//patches:toolchains_llvm_bootstrapped_resource_dir.patch",
+      "secondary_policy": "prefer_primary"
+    },
+    {
+      "id": "aws_lc_sys_memcmp_check",
+      "category": "platform-linker",
+      "path": "patches/aws-lc-sys_memcmp_check.patch",
+      "integration": "bazel_crate_annotation",
+      "module_reference": "//patches:aws-lc-sys_memcmp_check.patch",
+      "secondary_policy": "must_match"
+    },
+    {
+      "id": "windows_link",
+      "category": "platform-linker",
+      "path": "patches/windows-link.patch",
+      "integration": "bazel_crate_annotation",
+      "module_reference": "//patches:windows-link.patch",
+      "secondary_policy": "must_match"
+    },
+    {
+      "id": "bash_exec_wrapper",
+      "category": "shell-tool",
+      "path": "shell-tool-mcp/patches/bash-exec-wrapper.patch",
+      "integration": "shell_readme_reference",
+      "readme_reference": "patches/bash-exec-wrapper.patch",
+      "secondary_policy": "must_match"
+    },
+    {
+      "id": "zsh_exec_wrapper",
+      "category": "shell-tool",
+      "path": "shell-tool-mcp/patches/zsh-exec-wrapper.patch",
+      "integration": "artifact_only",
+      "secondary_policy": "must_match"
+    }
+  ]
+}

--- a/docs/reference/PATCH_SUPERSET_QUICK_REFERENCE.md
+++ b/docs/reference/PATCH_SUPERSET_QUICK_REFERENCE.md
@@ -1,0 +1,28 @@
+# Patch Superset Quick Reference
+
+The patch superset is now compiled into a machine-readable manifest at `config/patch_superset.json`.
+
+Use the canonical command surface:
+
+```bash
+just patch-superset-inventory
+just patch-superset-check
+just patch-superset-compare-secondary
+```
+
+Purpose:
+
+- `inventory`: list the current patch superset with category and digest
+- `check`: verify manifest entries still match live repo references
+- `compare-secondary`: compare `heliosCLI` patches to the secondary rewrite repo (`../helios-cli` by default)
+
+Cross-rewrite policy:
+
+- `must_match`: secondary copy must stay byte-identical
+- `prefer_primary`: `heliosCLI` is the source of truth and secondary divergence is reported but allowed
+
+Current patch groups:
+
+- `workspace-bootstrap`
+- `platform-linker`
+- `shell-tool`

--- a/justfile
+++ b/justfile
@@ -107,3 +107,12 @@ surface-fmt:
 
 surface-quality:
     bash ../scripts/task_surface.sh quality
+
+patch-superset-inventory:
+    python3 ../scripts/patch_superset.py inventory
+
+patch-superset-check:
+    python3 ../scripts/patch_superset.py check
+
+patch-superset-compare-secondary *args:
+    python3 ../scripts/patch_superset.py compare-secondary "$@"

--- a/scripts/namespace-audit.sh
+++ b/scripts/namespace-audit.sh
@@ -1,0 +1,321 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO=""
+NAMESPACE="KooshaPari"
+ALLOWED_BOTS="github-actions[bot],dependabot[bot],dependabot-preview[bot],renovate[bot],app/github-actions"
+CLOSE_OFFENDERS=0
+DO_COMMENT=1
+DRY_RUN=0
+SCAN_PRS=1
+SCAN_ISSUES=1
+JSON_REPORT=""
+REDIRECT_TEMPLATE=""
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/namespace-audit.sh --repo org/repo [options]
+
+Options:
+  --repo <org/repo>               Repository to scan.
+  --namespace <owner>              Allowed owner namespace.
+  --close                          Close offending items after commenting.
+  --no-comment                     Skip comment. Default: comment enabled.
+  --only-prs                       Only scan open pull requests.
+  --only-issues                    Only scan open issues.
+  --dry-run                        Report offenses without making mutations.
+  --allowed-bots <a,b,c>           Comma-separated bot allowlist.
+  --redirect-template <text>        Custom redirect message.
+  --json-report <path>             Write JSON report to this file.
+  --help                           Show this help.
+USAGE
+}
+
+require_cmds() {
+  local missing=0
+  for cmd in gh jq; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+      echo "Missing required command: $cmd" >&2
+      missing=1
+    fi
+  done
+  if [[ "$missing" -ne 0 ]]; then
+    exit 1
+  fi
+}
+
+infer_repo_from_remote() {
+  local remote_url
+  remote_url=$(git config --get remote.origin.url || true)
+  if [[ -z "$remote_url" ]]; then
+    return 1
+  fi
+
+  if [[ "$remote_url" == git@github.com:* ]]; then
+    REPO="${remote_url#git@github.com:}"
+    REPO="${REPO%.git}"
+    return 0
+  fi
+
+  if [[ "$remote_url" == https://github.com/* ]]; then
+    REPO="${remote_url#https://github.com/}"
+    REPO="${REPO%.git}"
+    return 0
+  fi
+
+  return 1
+}
+
+is_author_allowed() {
+  local author=$1
+  [[ "$author" == "$NAMESPACE" ]] && return 0
+
+  local bot
+  IFS=',' read -r -a bot <<< "$ALLOWED_BOTS"
+  for allowed in "${bot[@]}"; do
+    [[ -z "$allowed" ]] && continue
+    [[ "$author" == "$allowed" ]] && return 0
+  done
+
+  return 1
+}
+
+is_head_owner_allowed() {
+  local owner=$1
+  [[ -n "$owner" && "$owner" == "$NAMESPACE" ]]
+}
+
+default_template() {
+  cat <<TEMPLATE
+This item was created outside the allowed namespace policy.
+
+Allowed namespace: **${NAMESPACE}**
+
+To keep this workstream clean, please open this PR/issue in a KooshaPari-owned repository.
+
+If this item was created accidentally, close and recreate it in one of the KooshaPari repos,
+and link back to this reference for continuity.
+TEMPLATE
+}
+
+comment_and_close_pr() {
+  local number=$1
+  local author=$2
+  local title=$3
+  local url=$4
+
+  echo "Offending PR: #$number by @$author - $title"
+  echo "  -> $url"
+
+  if [[ "$DO_COMMENT" -eq 1 && "$DRY_RUN" -eq 0 ]]; then
+    gh pr comment "$number" --repo "$REPO" --body "$REDIRECT_TEMPLATE" >/dev/null
+  fi
+
+  if [[ "$CLOSE_OFFENDERS" -eq 1 && "$DRY_RUN" -eq 0 ]]; then
+    gh pr close "$number" --repo "$REPO" >/dev/null
+    echo "  -> closed"
+  fi
+}
+
+comment_and_close_issue() {
+  local number=$1
+  local author=$2
+  local title=$3
+  local url=$4
+
+  echo "Offending issue: #$number by @$author - $title"
+  echo "  -> $url"
+
+  if [[ "$DO_COMMENT" -eq 1 && "$DRY_RUN" -eq 0 ]]; then
+    gh issue comment "$number" --repo "$REPO" --body "$REDIRECT_TEMPLATE" >/dev/null
+  fi
+
+  if [[ "$CLOSE_OFFENDERS" -eq 1 && "$DRY_RUN" -eq 0 ]]; then
+    gh issue close "$number" --repo "$REPO" >/dev/null
+    echo "  -> closed"
+  fi
+}
+
+run_scan() {
+  local offenders_json='[]'
+  local offender_count=0
+
+  if [[ "$SCAN_PRS" -eq 1 ]]; then
+    local prs_json
+    prs_json=$(gh pr list --repo "$REPO" --state open --limit 200 --json number,title,url,author,headRepositoryOwner || true)
+
+    while IFS= read -r item; do
+      [[ -z "$item" ]] && continue
+
+      local number title author url head_owner reason=""
+      number=$(jq -r '.number // 0' <<<"$item")
+      title=$(jq -r '.title // ""' <<<"$item")
+      url=$(jq -r '.url // ""' <<<"$item")
+      author=$(jq -r '.author.login // ""' <<<"$item")
+      head_owner=$(jq -r '.headRepositoryOwner.login // .headRepository.owner.login // ""' <<<"$item")
+
+      local bad=0
+      if ! is_author_allowed "$author"; then
+        bad=1
+        reason="author"
+      fi
+      if ! is_head_owner_allowed "$head_owner"; then
+        if [[ "$bad" -eq 1 ]]; then
+          reason="author, source-repo-owner"
+        else
+          bad=1
+          reason="source-repo-owner"
+        fi
+      fi
+
+      if [[ "$bad" -eq 1 ]]; then
+        offender_count=$((offender_count + 1))
+        offenders_json=$(
+          printf '%s' "$offenders_json" | jq --compact-output \
+            --arg number "$number" \
+            --arg author "$author" \
+            --arg reason "$reason" \
+            --arg url "$url" \
+            '. + [{type:"pr", number: ($number|tonumber), author: $author, reason: $reason, url: $url}]'
+        )
+
+        if [[ "$DRY_RUN" -eq 1 ]]; then
+          echo "[DRY-RUN] would enforce PR #$number by @$author ($reason)"
+        else
+          comment_and_close_pr "$number" "$author" "$title" "$url"
+        fi
+      fi
+    done < <(jq -c '.[]' <<<"$prs_json")
+  fi
+
+  if [[ "$SCAN_ISSUES" -eq 1 ]]; then
+    local issues_json
+    issues_json=$(gh issue list --repo "$REPO" --state open --limit 200 --json number,title,url,author || true)
+
+    while IFS= read -r item; do
+      [[ -z "$item" ]] && continue
+      if jq -e '.pull_request' <<<"$item" >/dev/null 2>&1; then
+        continue
+      fi
+
+      local number title author url reason
+      number=$(jq -r '.number // 0' <<<"$item")
+      title=$(jq -r '.title // ""' <<<"$item")
+      url=$(jq -r '.url // ""' <<<"$item")
+      author=$(jq -r '.author.login // ""' <<<"$item")
+      reason="author"
+
+      if ! is_author_allowed "$author"; then
+        offender_count=$((offender_count + 1))
+        offenders_json=$(
+          printf '%s' "$offenders_json" | jq --compact-output \
+            --arg number "$number" \
+            --arg author "$author" \
+            --arg reason "$reason" \
+            --arg url "$url" \
+            '. + [{type:"issue", number: ($number|tonumber), author: $author, reason: $reason, url: $url}]'
+        )
+
+        if [[ "$DRY_RUN" -eq 1 ]]; then
+          echo "[DRY-RUN] would enforce issue #$number by @$author"
+        else
+          comment_and_close_issue "$number" "$author" "$title" "$url"
+        fi
+      fi
+    done < <(jq -c '.[]' <<<"$issues_json")
+  fi
+
+  if [[ -n "$JSON_REPORT" ]]; then
+    jq -n \
+      --arg repo "$REPO" \
+      --arg namespace "$NAMESPACE" \
+      --argjson scan_prs "$SCAN_PRS" \
+      --argjson scan_issues "$SCAN_ISSUES" \
+      --argjson total "$offender_count" \
+      --arg generated "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+      --argjson offenders "$offenders_json" \
+      '{repository:$repo, namespace:$namespace, scan_pulls: $scan_prs,
+        scan_issues:$scan_issues, total_offenders:$total,
+        generated_at:$generated, offenders:$offenders}' \
+      > "$JSON_REPORT"
+  fi
+
+  echo "Total namespace violations: $offender_count"
+}
+
+if [[ "$#" -eq 0 ]]; then
+  usage
+  exit 1
+fi
+
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      REPO="$2"
+      shift 2
+      ;;
+    --namespace)
+      NAMESPACE="$2"
+      shift 2
+      ;;
+    --close)
+      CLOSE_OFFENDERS=1
+      shift
+      ;;
+    --no-comment)
+      DO_COMMENT=0
+      shift
+      ;;
+    --only-prs)
+      SCAN_PRS=1
+      SCAN_ISSUES=0
+      shift
+      ;;
+    --only-issues)
+      SCAN_PRS=0
+      SCAN_ISSUES=1
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --allowed-bots)
+      ALLOWED_BOTS="$2"
+      shift 2
+      ;;
+    --redirect-template)
+      REDIRECT_TEMPLATE="$2"
+      shift 2
+      ;;
+    --json-report)
+      JSON_REPORT="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+require_cmds
+
+if [[ -z "$REPO" ]]; then
+  if ! infer_repo_from_remote; then
+    echo "Unable to infer repository from remote. Use --repo." >&2
+    exit 1
+  fi
+fi
+
+if [[ -z "$REDIRECT_TEMPLATE" ]]; then
+  REDIRECT_TEMPLATE="$(default_template)"
+fi
+
+run_scan

--- a/scripts/patch_superset.py
+++ b/scripts/patch_superset.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parent.parent
+MANIFEST_PATH = ROOT / "config" / "patch_superset.json"
+MODULE_BAZEL_PATH = ROOT / "MODULE.bazel"
+SHELL_README_PATH = ROOT / "codex-rs" / "shell-escalation" / "README.md"
+
+
+def load_manifest() -> dict:
+    return json.loads(MANIFEST_PATH.read_text())
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def resolve_secondary_root(manifest: dict, secondary_root: str | None) -> Path:
+    if secondary_root:
+        return (ROOT / secondary_root).resolve() if not Path(secondary_root).is_absolute() else Path(secondary_root)
+    return (ROOT / manifest["allowed_secondary_root"]).resolve()
+
+
+def inventory(manifest: dict) -> int:
+    print("Patch superset inventory:")
+    for patch in manifest["patches"]:
+        path = ROOT / patch["path"]
+        digest = sha256(path)[:12] if path.exists() else "missing"
+        print(
+            f"- {patch['id']} | category={patch['category']} integration={patch['integration']} "
+            f"policy={patch['secondary_policy']} path={patch['path']} sha256={digest}"
+        )
+    return 0
+
+
+def check(manifest: dict) -> int:
+    errors: list[str] = []
+    module_bazel = MODULE_BAZEL_PATH.read_text()
+    shell_readme = SHELL_README_PATH.read_text()
+
+    for patch in manifest["patches"]:
+        path = ROOT / patch["path"]
+        if not path.exists():
+            errors.append(f"missing patch file: {patch['path']}")
+            continue
+
+        module_reference = patch.get("module_reference")
+        if module_reference and module_reference not in module_bazel:
+            errors.append(f"missing MODULE.bazel reference for {patch['id']}: {module_reference}")
+
+        readme_reference = patch.get("readme_reference")
+        if readme_reference and readme_reference not in shell_readme:
+            errors.append(f"missing shell escalation README reference for {patch['id']}: {readme_reference}")
+
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+    print(f"Verified {len(manifest['patches'])} patch entries.")
+    return 0
+
+
+def compare_secondary(manifest: dict, secondary_root: Path) -> int:
+    print(f"Comparing against secondary root: {secondary_root}")
+    mismatches = 0
+
+    for patch in manifest["patches"]:
+        primary_path = ROOT / patch["path"]
+        secondary_path = secondary_root / patch["path"]
+        if not secondary_path.exists():
+            print(f"- {patch['id']} | secondary=missing")
+            mismatches += 1
+            continue
+
+        primary_hash = sha256(primary_path)
+        secondary_hash = sha256(secondary_path)
+        if primary_hash == secondary_hash:
+            status = "match"
+        elif patch["secondary_policy"] == "prefer_primary":
+            status = "prefer_primary"
+        else:
+            status = "mismatch"
+        print(
+            f"- {patch['id']} | secondary={status} primary={primary_hash[:12]} "
+            f"secondary={secondary_hash[:12]}"
+        )
+        if status not in {"match", "prefer_primary"}:
+            mismatches += 1
+
+    return 1 if mismatches else 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Inventory and verify the heliosCLI patch superset.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser("inventory", help="List the compiled patch superset.")
+    subparsers.add_parser("check", help="Verify manifest entries against live repo references.")
+
+    compare_parser = subparsers.add_parser(
+        "compare-secondary",
+        help="Compare manifest patch files against the secondary rewrite repo.",
+    )
+    compare_parser.add_argument("--secondary-root", default=None)
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    manifest = load_manifest()
+
+    if args.command == "inventory":
+        return inventory(manifest)
+    if args.command == "check":
+        return check(manifest)
+    if args.command == "compare-secondary":
+        return compare_secondary(manifest, resolve_secondary_root(manifest, args.secondary_root))
+
+    parser.error(f"unsupported command: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Supersedes #378 because the workflow formatter uses `cargo fmt -- --config imports_granularity=Item --check`, which required a final item-granularity import split after #378 was already rule-frozen by `GH013`.

This replacement branch carries the namespace-policy work, the compact/resume CI fix, and the exact formatter-compatible import layout.

Validation:
- `cargo fmt -- --config imports_granularity=Item --check`
- `cargo test --manifest-path codex-rs/core/Cargo.toml --package codex-core --test all suite::compact_resume_fork -- --nocapture`
- `python3 scripts/patch_superset.py check`
- `bash scripts/namespace-audit.sh --repo KooshaPari/helios-cli --dry-run --only-prs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated namespace governance enforcement for pull requests and issues.
  * Introduced patch superset management tools with inventory, validation, and comparison capabilities.

* **Documentation**
  * Added Patch Superset Quick Reference guide.

* **Tests**
  * Enhanced event timeout handling with improved debugging information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->