### PR TITLE
chore: migrate tooling-dispatch to bun strictly

### DIFF
--- a/scripts/tooling-dispatch.sh
+++ b/scripts/tooling-dispatch.sh
@@ -22,19 +22,11 @@ command_exists() {
 }
 
 select_pm() {
-  if [[ "${HELIOS_USE_BUN:-0}" == "1" ]] && command_exists bun; then
-    echo "bun"
-    return
-  fi
-  if command_exists pnpm; then
-    echo "pnpm"
-    return
-  fi
   if command_exists bun; then
     echo "bun"
     return
   fi
-  echo "error: neither pnpm nor bun found in PATH" >&2
+  echo "error: bun is required. Install from https://bun.sh/" >&2
   exit 127
 }
 


### PR DESCRIPTION
Migrates tooling-dispatch to bun only. Cleaned up version of PR #396. Other changes in #396 were already in main.

Made with [Cursor](https://cursor.com)