### PR TITLE
fix(ci): fix PR 435 CI failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           set -euo pipefail
           # Use a rust-release version that includes all native binaries.
-          CODEX_VERSION=0.74.0
+          CODEX_VERSION=0.117.0-alpha.17
           OUTPUT_DIR="${RUNNER_TEMP}"
           python3 ./scripts/stage_npm_packages.py \
             --release-version "$CODEX_VERSION" \

--- a/scripts/stage_npm_packages.py
+++ b/scripts/stage_npm_packages.py
@@ -84,6 +84,8 @@ def resolve_release_workflow(version: str) -> dict:
             "gh",
             "run",
             "list",
+            "--repo",
+            GITHUB_REPO,
             "--branch",
             f"rust-v{version}",
             "--json",


### PR DESCRIPTION
This PR fixes the CI failures in PR #435 by pointing stage_npm_packages to openai/codex and updating the version.

Made with [Cursor](https://cursor.com)