### PR TITLE
chore: migrate kitty-specs to AgilePlus format (rebased)

### DIFF
--- a/agileplus-specs/codex-tui-renderer-optimization/checklists/requirements.md
+++ b/agileplus-specs/codex-tui-renderer-optimization/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Codex TUI Renderer Optimization
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-02-28
+**Feature**: /Users/kooshapari/CodeProjects/Phenotype/repos/heliosCLI/kitty-specs/001-codex-tui-renderer-optimization/spec.md
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation pass completed in one iteration.
+- `spec-kitty agent feature create-feature` returned an environment/setup error in this repository; feature directory was scaffolded manually to unblock planning artifacts.
+- Items marked incomplete require spec updates before `/spec-kitty.clarify` or `/spec-kitty.plan`

--- a/agileplus-specs/codex-tui-renderer-optimization/data-model.md
+++ b/agileplus-specs/codex-tui-renderer-optimization/data-model.md
@@ -1,0 +1,54 @@
+# Data Model: Codex TUI Renderer Optimization Research
+
+## Entities
+
+### RendererStage
+- id: string
+- name: string
+- category: enum(input, schedule, compose, draw, flush)
+- owner_module: string
+- measurable_outputs: list[string]
+
+### BackendStage
+- id: string
+- name: string
+- category: enum(entrypoint, thread, model_client, protocol, ui_dispatch)
+- owner_module: string
+- measurable_outputs: list[string]
+
+### EventClass
+- id: string
+- source: string
+- priority: enum(critical, normal, low)
+- burst_profile: enum(low, medium, high)
+- coalescible: boolean
+
+### OptimizationCandidate
+- id: string
+- title: string
+- layer: string
+- expected_impact: enum(low, medium, high)
+- risk_level: enum(low, medium, high)
+- dependencies: list[string]
+- evidence_refs: list[string]
+
+### LayeredPR
+- id: string
+- name: string
+- order_index: integer
+- objective: string
+- success_signal: string
+- depends_on: list[string]
+
+### EvidenceRecord
+- evidence_id: string
+- source_id: string
+- claim: string
+- confidence: enum(low, medium, high)
+
+## Relationships
+- RendererStage emits EventClass.
+- BackendStage emits EventClass.
+- OptimizationCandidate targets one or more RendererStage or BackendStage entries.
+- LayeredPR implements one or more OptimizationCandidate entries.
+- EvidenceRecord supports OptimizationCandidate and LayeredPR rationale.

--- a/agileplus-specs/codex-tui-renderer-optimization/meta.json
+++ b/agileplus-specs/codex-tui-renderer-optimization/meta.json
@@ -1,0 +1,8 @@
+{
+  "feature_number": "001",
+  "slug": "codex-tui-renderer-optimization",
+  "friendly_name": "Codex TUI Renderer Optimization",
+  "created_at": "2026-02-28T09:49:48Z",
+  "target_branch": "main",
+  "vcs": "git"
+}

--- a/agileplus-specs/codex-tui-renderer-optimization/pr-layered-strategy.md
+++ b/agileplus-specs/codex-tui-renderer-optimization/pr-layered-strategy.md
@@ -1,0 +1,37 @@
+# Draft PR Description: Layered TUI Optimization Program
+
+## Title
+Layered research-backed plan for Codex TUI renderer and backend optimization
+
+## Summary
+This PR introduces research artifacts and a dependency-aware plan for layered performance work in the Codex TUI stack. It does not change runtime behavior. It establishes architecture baselines, optimization candidates, and auditable evidence for follow-on implementation PRs.
+
+## Why
+- Current performance work lacks a single architecture baseline.
+- Follow-on optimization work needs explicit slicing to reduce risk and improve reviewability.
+- Reviewers need source-backed rationale for each optimization layer.
+
+## Scope
+- Adds `kitty-specs/001-codex-tui-renderer-optimization/spec.md`.
+- Adds checklist validation results.
+- Adds research outputs: architecture walkthrough, ASCII diagrams, evidence log, source register, and data model.
+- Adds proposed layered PR sequence (PR-A through PR-E).
+
+## Requested Follow-Up (Agent)
+Please open a layered implementation PR series based on this research package:
+1. PR-A instrumentation and benchmark baselines.
+2. PR-B render workload reduction.
+3. PR-C event backpressure/coalescing.
+4. PR-D data-structure efficiency changes.
+5. PR-E progressive rendering UX.
+
+Each PR should include clear success signals and should not skip prerequisite layers.
+
+## Risk Management
+- Research-only PR keeps behavior unchanged.
+- Layering allows rollback and isolated validation per concern.
+
+## Reviewer Checklist
+- Confirm architecture diagrams match current code paths.
+- Confirm optimization rationale is evidence-backed.
+- Confirm layer sequence is dependency-safe.

--- a/agileplus-specs/codex-tui-renderer-optimization/research.md
+++ b/agileplus-specs/codex-tui-renderer-optimization/research.md
@@ -1,0 +1,174 @@
+# Research: Codex TUI Renderer Optimization
+
+## Objective
+Create an evidence-backed architecture baseline for the Codex TUI renderer and backend flow, then recommend phased optimizations and layered PR slicing.
+
+## Current-State Architecture
+
+### Renderer Flow (Current)
+
+```text
+[Terminal Input/Event Stream]
+            |
+            v
+   TuiEvent (key/paste/draw/resize)
+            |
+            v
++-------------------------------+
+| App::run main select loop     |
+| - AppEvent channel            |
+| - Codex protocol events       |
+| - TuiEvent stream             |
++-------------------------------+
+            |
+            v
+  App::handle_tui_event / handle_event
+            |
+            v
++-------------------------------+
+| ChatWidget state mutation     |
+| - history cells               |
+| - bottom pane state machine   |
+| - status + overlays           |
++-------------------------------+
+            |
+            v
+ FrameRequester::schedule_frame
+            |
+            v
+ FrameScheduler (coalesce/throttle)
+            |
+            v
+          Tui::draw
+            |
+            v
+   ratatui Terminal::draw
+   (buffer diff flush only)
+```
+
+### Backend Flow (Current)
+
+```text
+codex CLI entry
+(main.rs -> lib.rs::run_main)
+            |
+            v
+TUI App runtime (app.rs)
+            |
+            v
+ThreadManager (core)
+- thread lifecycle
+- event fan-in/out
+            |
+            v
+Codex + ModelClient session
+- provider auth/session
+- stream transport
+            |
+            v
+Responses/protocol events
+(codex_protocol Event/EventMsg)
+            |
+            v
+AppEvent + UI channels
+            |
+            v
+ChatWidget render state
+            |
+            v
+Terminal frame updates
+
+Parallel control-plane exposure:
+app-server JSON-RPC API emits the same thread/turn/item event model
+for external clients and automation.
+```
+
+## Key Findings
+1. Frame scheduling is already centralized and coalesced, which is a strong base for dirty-region and adaptive-rate improvements.
+2. Render cost is dominated by state-to-view transformation and high-frequency redraw triggers, not just terminal flush.
+3. Backend event throughput can outpace UI consumption under heavy streaming unless queue bounds and batching policies are explicit.
+4. Current architecture supports incremental optimization because render orchestration and backend protocol flow are cleanly separated.
+
+## External Optimization Evidence (Rust TUI)
+
+### Reviewed article: octorus 300K-line diff rendering
+- Multi-layer caches to separate session data, diff precompute, and active view caches.
+- Background precompute to reduce first-open latency.
+- Viewport-restricted rendering to avoid whole-document work.
+- String interning and structured token reuse to reduce allocation and memory churn.
+- Deferred/lazy composition for secondary decorations (for example, comments/markers).
+
+### Additional references and implications
+- ratatui uses double buffers and writes only changed cells, so avoid forcing full redraw semantics.
+- crossterm polling/event APIs can be used to control event loop wake behavior.
+- Tokio bounded channels provide explicit backpressure and should be preferred in high-rate producer paths.
+- Rope/interner data structures (for large text/token workloads) can constrain memory and copy overhead.
+
+## Recommended Optimization Layers
+
+### Layer 1: Observability and Baseline (low risk)
+- Add renderer timing spans by stage (event ingest, state mutation, compose, draw).
+- Add queue-depth and event-lag metrics for UI-facing channels.
+- Produce reproducible benchmark fixtures for large transcript and high-stream turns.
+
+### Layer 2: Render Work Reduction (medium risk)
+- Introduce viewport/dirty-range constrained state-to-view transformation.
+- Cache expensive layout/text shaping outputs keyed by stable state signatures.
+- Batch low-priority cosmetic updates behind frame budget checks.
+
+### Layer 3: Event Pressure Control (medium risk)
+- Enforce bounded channels on high-volume paths.
+- Add coalescing policies for bursty protocol deltas.
+- De-prioritize non-critical event classes during sustained load.
+
+### Layer 4: Data-Structure Efficiency (higher risk)
+- Evaluate rope/interner-backed buffers for large scrollback and diff-like payloads.
+- Minimize transient allocations in render preparation paths.
+- Add zero-copy borrowing contracts where lifetimes are already naturally scoped.
+
+### Layer 5: UX-Protective Progressive Rendering (higher risk)
+- Progressive display modes for large payloads (fast plain path, enriched path when ready).
+- Deferred decoration composition for non-blocking first paint.
+
+## Layered PR Strategy Draft
+
+### PR-A: Instrumentation and Benchmarks
+- Scope: metrics, traces, baseline harness, no behavior change.
+- Exit: stable measurements for frame times and event lag.
+
+### PR-B: Render Pipeline Caching + Viewport Constraint
+- Scope: reduce compose work and unnecessary redraw preparation.
+- Exit: measurable reduction in p95 frame time under heavy transcript scenarios.
+
+### PR-C: Event Backpressure + Coalescing
+- Scope: bounded channel policies and burst handling.
+- Exit: no runaway queue growth under sustained streaming.
+
+### PR-D: Large-Text Data Structure Enhancements
+- Scope: targeted interning/rope introduction where evidence shows clear benefit.
+- Exit: lower memory growth and allocation churn for large-content sessions.
+
+### PR-E: Progressive Enrichment UX
+- Scope: plain-first fast path, deferred enrichments.
+- Exit: improved first-meaningful-display latency on large payloads.
+
+## Open Questions
+- Which user workflows should define canonical performance SLOs (chat streaming, diff-like browsing, or both)?
+- Which event classes can be safely coalesced without degrading perceived responsiveness?
+- What benchmark dataset should become the long-term regression gate?
+
+## Risks
+- Premature optimization without benchmark baselines may introduce complexity with weak impact.
+- Backpressure tuning may affect perceived responsiveness if thresholds are set too aggressively.
+- Data-structure migrations can expand code complexity and require careful rollback boundaries.
+
+## Sources
+- DEV article: https://dev.to/ushironoko/how-octorus-renders-300k-lines-of-diff-at-high-speed-h4p
+- ratatui rendering concepts: https://ratatui.rs/concepts/rendering/
+- ratatui Terminal buffering: https://docs.rs/ratatui/latest/ratatui/struct.Terminal.html
+- crossterm poll API: https://docs.rs/crossterm/latest/crossterm/event/fn.poll.html
+- tokio bounded channels/backpressure: https://docs.rs/tokio/latest/tokio/sync/mpsc/index.html
+- tokio channel backpressure guidance: https://tokio.rs/tokio/tutorial/channels
+- ropey rope performance model: https://docs.rs/ropey/latest/ropey/struct.Rope.html
+- lasso interning model: https://docs.rs/lasso/latest/lasso/
+- local code: `codex-rs/tui/src/app.rs`, `codex-rs/tui/src/chatwidget.rs`, `codex-rs/tui/src/tui.rs`, `codex-rs/tui/src/tui/frame_requester.rs`, `codex-rs/core/src/thread_manager.rs`, `codex-rs/core/src/client.rs`, `codex-rs/core/src/model_provider_info.rs`, `codex-rs/app-server/README.md`

--- a/agileplus-specs/codex-tui-renderer-optimization/research/evidence-log.csv
+++ b/agileplus-specs/codex-tui-renderer-optimization/research/evidence-log.csv
@@ -1,0 +1,7 @@
+evidence_id,source_id,claim,claim_type,confidence,notes
+E-001,SRC-EXT-001,"octorus uses layered caching and viewport-restricted rendering to keep large diff interaction responsive",external-observation,high,"From DEV article summary"
+E-002,SRC-EXT-003,"ratatui Terminal compares current and previous buffers and writes only diffs",external-fact,high,"Direct API documentation behavior"
+E-003,SRC-INT-001,"App::run funnels AppEvent, protocol event, and TuiEvent streams in one select loop",internal-architecture,high,"app.rs line references"
+E-004,SRC-INT-002,"ChatWidget centralizes state mutation before render and key handling",internal-architecture,high,"chatwidget.rs line references"
+E-005,SRC-EXT-005,"bounded tokio mpsc channels provide backpressure under load",external-fact,high,"tokio docs"
+E-006,SRC-EXT-007,"rope-based text storage offers O(log N) operations for large texts",external-fact,medium,"ropey docs"

--- a/agileplus-specs/codex-tui-renderer-optimization/research/source-register.csv
+++ b/agileplus-specs/codex-tui-renderer-optimization/research/source-register.csv
@@ -1,0 +1,17 @@
+source_id,source_type,title_or_path,url_or_path,accessed_utc,relevance
+SRC-EXT-001,web,"How octorus Renders 300K Lines of Diff at High Speed",https://dev.to/ushironoko/how-octorus-renders-300k-lines-of-diff-at-high-speed-h4p,2026-02-28T00:00:00Z,high
+SRC-EXT-002,web,"Ratatui Rendering Concepts",https://ratatui.rs/concepts/rendering/,2026-02-28T00:00:00Z,high
+SRC-EXT-003,web,"ratatui::Terminal docs",https://docs.rs/ratatui/latest/ratatui/struct.Terminal.html,2026-02-28T00:00:00Z,high
+SRC-EXT-004,web,"crossterm poll docs",https://docs.rs/crossterm/latest/crossterm/event/fn.poll.html,2026-02-28T00:00:00Z,medium
+SRC-EXT-005,web,"tokio mpsc docs",https://docs.rs/tokio/latest/tokio/sync/mpsc/index.html,2026-02-28T00:00:00Z,high
+SRC-EXT-006,web,"tokio channels tutorial",https://tokio.rs/tokio/tutorial/channels,2026-02-28T00:00:00Z,medium
+SRC-EXT-007,web,"ropey Rope docs",https://docs.rs/ropey/latest/ropey/struct.Rope.html,2026-02-28T00:00:00Z,medium
+SRC-EXT-008,web,"lasso docs",https://docs.rs/lasso/latest/lasso/,2026-02-28T00:00:00Z,medium
+SRC-INT-001,code,"codex-rs/tui/src/app.rs",/Users/kooshapari/CodeProjects/Phenotype/repos/heliosCLI/codex-rs/tui/src/app.rs,2026-02-28T00:00:00Z,high
+SRC-INT-002,code,"codex-rs/tui/src/chatwidget.rs",/Users/kooshapari/CodeProjects/Phenotype/repos/heliosCLI/codex-rs/tui/src/chatwidget.rs,2026-02-28T00:00:00Z,high
+SRC-INT-003,code,"codex-rs/tui/src/tui.rs",/Users/kooshapari/CodeProjects/Phenotype/repos/heliosCLI/codex-rs/tui/src/tui.rs,2026-02-28T00:00:00Z,high
+SRC-INT-004,code,"codex-rs/tui/src/tui/frame_requester.rs",/Users/kooshapari/CodeProjects/Phenotype/repos/heliosCLI/codex-rs/tui/src/tui/frame_requester.rs,2026-02-28T00:00:00Z,high
+SRC-INT-005,code,"codex-rs/core/src/thread_manager.rs",/Users/kooshapari/CodeProjects/Phenotype/repos/heliosCLI/codex-rs/core/src/thread_manager.rs,2026-02-28T00:00:00Z,high
+SRC-INT-006,code,"codex-rs/core/src/client.rs",/Users/kooshapari/CodeProjects/Phenotype/repos/heliosCLI/codex-rs/core/src/client.rs,2026-02-28T00:00:00Z,high
+SRC-INT-007,code,"codex-rs/core/src/model_provider_info.rs",/Users/kooshapari/CodeProjects/Phenotype/repos/heliosCLI/codex-rs/core/src/model_provider_info.rs,2026-02-28T00:00:00Z,high
+SRC-INT-008,doc,"codex-rs/app-server/README.md",/Users/kooshapari/CodeProjects/Phenotype/repos/heliosCLI/codex-rs/app-server/README.md,2026-02-28T00:00:00Z,high

--- a/agileplus-specs/codex-tui-renderer-optimization/spec.md
+++ b/agileplus-specs/codex-tui-renderer-optimization/spec.md
@@ -1,0 +1,74 @@
+# Feature Specification: Codex TUI Renderer Optimization
+
+**Feature Branch**: `001-codex-tui-renderer-optimization`  
+**Created**: 2026-02-28  
+**Status**: Draft  
+**Mission**: research
+
+## Summary
+Produce a research-grade architecture walkthrough of the current Codex TUI renderer and its backend event/runtime architecture, then define a layered optimization roadmap informed by octorus and Rust TUI performance practices.
+
+## Problem Statement
+Current renderer and backend behavior are distributed across multiple modules, making it hard to reason about frame scheduling, event flow, and optimization leverage points. This blocks reliable prioritization for high-impact performance work.
+
+## Goals
+- Deliver an architecture walkthrough for current TUI rendering and backend event flow.
+- Provide ASCII diagrams that can be used directly in planning and PR discussions.
+- Produce optimization research grounded in concrete evidence and source tracking.
+- Define a layered PR strategy that can be executed incrementally with clear outcomes.
+
+## Non-Goals
+- Implementing renderer changes in this feature.
+- Executing benchmark harness changes in this feature.
+- Merging any runtime refactor in this feature.
+
+## Actors
+- CLI maintainers prioritizing performance work.
+- Agent implementers executing follow-on layered PRs.
+- Reviewers validating architecture and optimization rationale.
+
+## User Scenarios & Testing
+### Primary Scenario
+A maintainer needs a trusted architecture baseline and optimization sequence before authoring implementation PRs.
+
+### Acceptance Scenarios
+1. Given the feature artifacts, maintainers can trace render lifecycle from input event to frame flush.
+2. Given the backend diagram, maintainers can trace how model events become UI updates.
+3. Given optimization findings, maintainers can identify phased PRs with measurable expected impact.
+4. Given source logs, reviewers can audit every major claim against recorded evidence.
+
+## Functional Requirements
+- **FR-001**: The feature MUST provide a current-state TUI renderer architecture walkthrough.
+- **FR-002**: The feature MUST provide a current-state backend architecture walkthrough relevant to TUI rendering.
+- **FR-003**: The feature MUST include ASCII diagrams for both renderer and backend flows.
+- **FR-004**: The feature MUST capture optimization opportunities prioritized by expected user-visible impact.
+- **FR-005**: The feature MUST include a layered PR strategy with explicit sequencing and dependency intent.
+- **FR-006**: The feature MUST maintain an auditable evidence trail with source register and finding log.
+- **FR-007**: The feature MUST record open questions and risks for follow-on planning.
+
+## Success Criteria
+- 100% of major architecture claims map to at least one source entry in the evidence logs.
+- Maintainers can identify at least 3 independent optimization PR layers without additional discovery.
+- The produced diagrams are sufficient for review discussion without requiring code navigation for basic flow understanding.
+- At least 5 optimization recommendations are ranked with rationale and expected impact class.
+
+## Key Entities
+- **Renderer Path**: Ordered stages from input/event to frame scheduling and terminal flush.
+- **Backend Event Path**: Ordered stages from protocol/model events to UI state updates.
+- **Optimization Candidate**: A measurable improvement hypothesis with impact and risk level.
+- **Layered PR Slice**: A bounded change unit in a dependency-aware sequence.
+- **Evidence Entry**: A traceable source-backed finding record.
+
+## Dependencies
+- Access to current `heliosCLI` codebase paths under `codex-rs/`.
+- Public references for Rust TUI optimization practices.
+
+## Assumptions
+- Target branch for follow-on execution is `main`.
+- This feature remains research-only and does not include code behavior changes.
+- Layered PR execution will be performed in a later implementation phase.
+
+## Risks
+- Architecture drift if code changes significantly before follow-on PRs begin.
+- Overfitting recommendations to one workload profile without benchmark baselines.
+

--- a/agileplus-specs/phenotype-modular-arch/meta.json
+++ b/agileplus-specs/phenotype-modular-arch/meta.json
@@ -1,0 +1,8 @@
+{
+  "feature_number": "002",
+  "slug": "phenotype-modular-arch",
+  "friendly_name": "Phenotype Ecosystem Modularization & Plugin Architecture",
+  "created_at": "2026-03-03T00:00:00Z",
+  "target_branch": "main",
+  "vcs": "git"
+}

--- a/agileplus-specs/phenotype-modular-arch/plan.md
+++ b/agileplus-specs/phenotype-modular-arch/plan.md
@@ -1,0 +1,205 @@
+# Implementation Plan: Phenotype Ecosystem Modularization & Plugin Architecture
+
+**Branch**: `feat/phenotype-modular-arch` | **Date**: 2026-03-03 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `kitty-specs/002-phenotype-modular-arch/spec.md`
+
+---
+
+## Technical Context
+
+| Decision | Choice | Source |
+|----------|--------|--------|
+| Shared code strategy | Polyrepo micro-packages, flat dep graph | `docs/governance/project_decomposition_governance.md` |
+| Plugin architecture | Two-tier microkernel (compile-time native + runtime Extism/WASM) | `docs/governance/plugin_architecture_governance.md` |
+| Cross-language types | Protobuf + buf codegen | `docs/engineering/language_governance_framework.md` |
+| CQRS scope | Full audit across all 6 repos | User decision |
+| codex/helios merge | Feature flags in single workspace | Research finding E001 |
+| Package managers | Go modules, cargo, uv/pip, pnpm | Language governance |
+
+## Constitution Check
+
+No constitution file exists. Skipped.
+
+---
+
+## Phase 0: Research (COMPLETE)
+
+Research was completed prior to planning. All findings documented in:
+- `kitty-specs/002-phenotype-modular-arch/research.md` — 6 decisions with rationale
+- `kitty-specs/002-phenotype-modular-arch/data-model.md` — Target architecture, shared package registry
+- `kitty-specs/002-phenotype-modular-arch/research/evidence-log.csv` — 12 findings
+- `kitty-specs/002-phenotype-modular-arch/research/source-register.csv` — 7 sources
+
+All NEEDS CLARIFICATION items resolved. No outstanding unknowns.
+
+---
+
+## Phase 1: Design
+
+### Architecture Overview
+
+```
+                    ┌─────────────────────────┐
+                    │    phenotype-proto/      │  (Protobuf definitions)
+                    │  domain/v1/ plugin/v1/   │
+                    └──────────┬──────────────┘
+                               │ buf generate
+          ┌────────┬───────────┼───────────┬──────────┐
+          ▼        ▼           ▼           ▼          ▼
+    ┌─────────┐ ┌──────┐ ┌────────┐ ┌─────────┐ ┌────────┐
+    │  Go     │ │ Rust │ │ Python │ │   TS    │ │  Go    │
+    │ authkit │ │proto-│ │ infra  │ │audit-  │ │httpkit │
+    │executor │ │ col  │ │agentpr │ │core    │ │        │
+    └────┬────┘ └──┬───┘ └───┬────┘ └───┬────┘ └───┬───┘
+         │         │         │          │           │
+    ┌────┴────┐┌───┴────┐┌───┴───┐┌────┴────┐┌────┴────┐┌────────┐
+    │cliproxy ││helios- ││thegent││helios-  ││agentapi ││portage │
+    │   ++    ││  CLI   ││       ││  App    ││   ++    ││        │
+    └─────────┘└────────┘└───────┘└─────────┘└─────────┘└────────┘
+```
+
+### Work Lanes (All Parallel)
+
+Each lane is independent. No lane blocks another except:
+- `phenotype-proto` must exist before repos can consume generated types
+- Shared packages must be published before app repos import them
+
+#### Lane 0: Foundation (phenotype-proto + shared package repos)
+
+| Task | Description | Depends On |
+|------|-------------|------------|
+| L0.1 | Create `phenotype-proto` repo with buf config, initial .proto files | — |
+| L0.2 | Define `domain/v1/session.proto`, `agent.proto`, `routing.proto`, `audit.proto` | L0.1 |
+| L0.3 | Define `plugin/v1/executor.proto`, `tool.proto`, `adapter.proto` | L0.1 |
+| L0.4 | Configure `buf generate` for Rust, Go, Python, TypeScript | L0.2, L0.3 |
+| L0.5 | Create empty repos: `phenotype-go-authkit`, `phenotype-go-executor-core`, `phenotype-go-httpkit` | — |
+| L0.6 | Create empty repos: `phenotype-rs-protocol`, `phenotype-py-infra`, `@helios/audit-core`, `@helios/protocol-types` | — |
+| L0.7 | CI: buf lint + buf breaking on phenotype-proto | L0.4 |
+
+#### Lane 1: heliosCLI (Rust + TypeScript)
+
+| Task | Description | Depends On |
+|------|-------------|------------|
+| L1.1 | Merge codex-rs + helios-rs into single Cargo workspace with feature flags | — |
+| L1.2 | Gate variant-specific code behind `#[cfg(feature = "codex-runtime")]` / `helios-runtime` | L1.1 |
+| L1.3 | Remove helios-rs directory, update CI to build both variants | L1.2 |
+| L1.4 | Extract `protocol` crate types to `phenotype-rs-protocol` shared repo | L0.6 |
+| L1.5 | Implement Tier 1 plugin: `ToolPlugin` trait + `inventory` registration | L1.1 |
+| L1.6 | Prototype Tier 2 plugin: Extism host SDK integration for user-defined tools | L1.5 |
+| L1.7 | Emit audit events from codex-core session lifecycle | L0.4 |
+
+#### Lane 2: cliproxyapi++ (Go)
+
+| Task | Description | Depends On |
+|------|-------------|------------|
+| L2.1 | Extract `sdk/executor-core`: `ExecutorInterface`, `BaseExecutor`, retry/HTTP helpers | — |
+| L2.2 | Refactor all 15 executors to use `executor-core` base | L2.1 |
+| L2.3 | Extract auth logic to `phenotype-go-authkit` shared repo | L0.5 |
+| L2.4 | Extract HTTP helpers to `phenotype-go-httpkit` shared repo | L0.5 |
+| L2.5 | Implement Tier 1 plugin: `Executor` interface + `init()` registration | L2.1 |
+| L2.6 | Prototype Tier 2 plugin: Extism host for third-party executor .wasm | L2.5 |
+| L2.7 | Translator matrix builder: codegen or shared builder to reduce N×M duplication | L2.1 |
+| L2.8 | Formalize executor + translator as hexagonal ports | L2.2 |
+| L2.9 | Emit audit events from proxy routing decisions | L0.4 |
+
+#### Lane 3: thegent (Python)
+
+| Task | Description | Depends On |
+|------|-------------|------------|
+| L3.1 | Extract `thegent-config` package from `src/thegent/config*.py` | — |
+| L3.2 | Extract `thegent-infra` package from `src/thegent/infra/` (11K LOC) | — |
+| L3.3 | Extract `thegent-governance` from `src/thegent/governance/` | — |
+| L3.4 | Merge `thegent-protocols` + `thegent-mcp` into `thegent-mcp` | — |
+| L3.5 | Publish `thegent-infra` internals to `phenotype-py-infra` shared repo | L0.6, L3.2 |
+| L3.6 | Formalize `AdapterPort` pattern across all adapters | L3.3 |
+| L3.7 | Implement Tier 1 plugin: `entry_points` registration for agents and adapters | L3.6 |
+| L3.8 | Prototype Tier 2 plugin: Extism host for user-defined skills | L3.7 |
+| L3.9 | Emit audit events from agent execution lifecycle | L0.4 |
+| L3.10 | Make `src/thegent/` a thin re-export layer | L3.1-L3.4 |
+
+#### Lane 4: heliosApp (TypeScript)
+
+| Task | Description | Depends On |
+|------|-------------|------------|
+| L4.1 | Extract `@helios/audit-core` from `apps/runtime/src/audit/` | — |
+| L4.2 | Extract `@helios/protocol-types` from `apps/runtime/src/protocol/types.ts` | — |
+| L4.3 | Extract service interfaces to `@helios/service-contracts` | — |
+| L4.4 | Publish packages to npm/GitHub Packages | L4.1, L4.2, L4.3 |
+| L4.5 | Refactor runtime to consume extracted packages | L4.4 |
+| L4.6 | Implement aggregated audit trail view (consuming events from all repos) | L4.1, L0.4 |
+
+#### Lane 5: portage (Python)
+
+| Task | Description | Depends On |
+|------|-------------|------------|
+| L5.1 | Formalize ports: `typing.Protocol` for executor, reporter, loader | — |
+| L5.2 | Emit trial events: `TrialStarted`, `TrialCheckpoint`, `TrialCompleted` | L0.4 |
+| L5.3 | Implement benchmark adapter plugin registry (Tier 1) | L5.1 |
+| L5.4 | Prototype Tier 2 plugin: Extism host for user-defined adapters | L5.3 |
+| L5.5 | Consume `phenotype-py-infra` for shared utilities | L3.5 |
+
+#### Lane 6: agentapi++ (Go)
+
+| Task | Description | Depends On |
+|------|-------------|------------|
+| L6.1 | Extract `internal/domain/` package: Agent, Session, RoutingRule, BenchmarkData | — |
+| L6.2 | Consume `phenotype-go-authkit` for auth logic | L2.3 |
+| L6.3 | Consume `phenotype-go-httpkit` for HTTP helpers | L2.4 |
+| L6.4 | Implement `AgentDriver` interface (Tier 1 plugin) | L6.1 |
+| L6.5 | Emit routing audit events: `AgentRouted`, `SessionCreated` | L0.4 |
+
+### Dependency DAG (Critical Path)
+
+```
+L0.1 ──▶ L0.2 ──▶ L0.4 ──▶ L1.7, L2.9, L3.9, L5.2, L6.5  (audit events)
+L0.1 ──▶ L0.3 ──▶ L0.4
+L0.5 ──────────────────▶ L2.3, L2.4 ──▶ L6.2, L6.3
+L0.6 ──────────────────▶ L1.4, L3.5, L4.1, L4.2
+
+L1.1 ──▶ L1.2 ──▶ L1.3  (helios merge — independent, no external deps)
+L2.1 ──▶ L2.2 ──▶ L2.5 ──▶ L2.6  (executor plugin — independent)
+L3.1-L3.4 ──▶ L3.10  (thegent migration — independent)
+L4.1-L4.3 ──▶ L4.4 ──▶ L4.5  (heliosApp extraction — independent)
+```
+
+**Critical path:** L0.1 → L0.2/L0.3 → L0.4 → audit event integration across all repos.
+
+All other work (helios merge, executor extraction, thegent migration, heliosApp extraction) runs fully parallel with no cross-lane dependencies.
+
+### Execution Strategy
+
+- **Batch 1** (parallel, no deps): L0.1-L0.7, L1.1-L1.3, L2.1-L2.2, L3.1-L3.4, L4.1-L4.3, L5.1, L6.1
+- **Batch 2** (after shared repos exist): L1.4, L2.3-L2.4, L3.5, L4.4-L4.5, L5.5, L6.2-L6.3
+- **Batch 3** (after proto codegen): L1.7, L2.9, L3.9, L5.2, L6.5 (audit events)
+- **Batch 4** (plugin systems): L1.5-L1.6, L2.5-L2.8, L3.6-L3.8, L5.3-L5.4, L6.4
+- **Batch 5** (integration): L4.6, L3.10
+
+### Risk Mitigation
+
+| Risk | Mitigation |
+|------|------------|
+| Extism WASM perf insufficient | Prototype in L2.6 first (cliproxyapi++ executor); fall back to HashiCorp go-plugin if needed |
+| buf codegen quality issues | Validate generated types compile in all 4 languages during L0.4 |
+| codex/helios merge breaks tests | Feature-flag approach preserves both build paths; run full test suites per variant |
+| thegent migration breaks imports | Re-export layer (L3.10) maintains backward compatibility |
+| Shared package versioning overhead | Start at v0.1.0; accept breaking changes freely pre-v1.0 |
+
+---
+
+## Artifacts Generated
+
+| Artifact | Path | Status |
+|----------|------|--------|
+| Research | `kitty-specs/002-phenotype-modular-arch/research.md` | Complete |
+| Data Model | `kitty-specs/002-phenotype-modular-arch/data-model.md` | Complete |
+| Evidence Log | `kitty-specs/002-phenotype-modular-arch/research/evidence-log.csv` | Complete |
+| Source Register | `kitty-specs/002-phenotype-modular-arch/research/source-register.csv` | Complete |
+| Spec | `kitty-specs/002-phenotype-modular-arch/spec.md` | Complete |
+| Plan | `kitty-specs/002-phenotype-modular-arch/plan.md` | This document |
+| Governance: Decomposition | `docs/governance/project_decomposition_governance.md` | Complete |
+| Governance: Language/Framework | `docs/engineering/language_governance_framework.md` | Complete |
+| Governance: Plugin Architecture | `docs/governance/plugin_architecture_governance.md` | Complete |
+
+---
+
+**Next step**: `/spec-kitty.tasks` to generate work packages from this plan.

--- a/agileplus-specs/phenotype-modular-arch/research/codebase-quality-analysis.md
+++ b/agileplus-specs/phenotype-modular-arch/research/codebase-quality-analysis.md
@@ -1,0 +1,164 @@
+# Codebase Quality Analysis — All Repos
+
+**Date**: 2026-03-03
+**Purpose**: Direct LOC/complexity/quality metrics to inform work packages.
+
+---
+
+## Cross-Repo Summary
+
+| Repo | Canonical LOC | God Modules (>500L) | Largest File | Worst Function | unwrap/panic | Test Gap |
+|------|-------------|-------------------|-------------|---------------|-------------|---------|
+| heliosCLI | 422K Rust + 0.6K TS | 70+ | codex.rs (9,571) | — | 934 unwrap() | 41% coverage, 11 crates untested |
+| cliproxyapi++ | 166K Go | 61 | kiro_executor.go (4,691) | executeClaudeNonStream (205L) | 3 panics (defensible) | 35+ pkgs untested |
+| agentapi++ | 8.4K Go (unique) | 2 | server.go (788) | — | 14 panics (init-time) | 9 pkgs untested |
+| thegent | ~160K Python (unique) | 40+ | project.py (2,012) | run_impl_core (1,022L!) | — | 469 dup files, 221 circular dep files |
+| portage | 103K Python | 20 | terminus_2.py (1,838) | create_app (1,164L) | — | 47.5% modules untested, 8 dup BaseAdapter |
+| heliosApp | 78K TS | 8 | index.ts (1,089) | — | 0 any | audit subsystem (2,577L) untested |
+| trace | 678K (Go+Py+TS) | 98+ | api/main.py (9,274) | — | 390 type suppressions | 1,847L hand-rolled parsers |
+
+---
+
+## heliosCLI (422K Rust)
+
+### Critical Findings
+- **65 crates** in workspace, 956 .rs files
+- **Top god modules**: codex.rs (9,571), chat_composer.rs (9,499), codex_message_processor.rs (8,460), chatwidget.rs (8,146), config/mod.rs (6,218), app.rs (5,463)
+- **934 `unwrap()` in production code** — crash risk surface. Worst: apply-patch (74), network-proxy/runtime.rs (38), turn_diff_tracker.rs (37)
+- **54 `#[allow(dead_code)]`** suppressions, 100 `// TODO` comments
+- **Connector duplication**: ollama, lmstudio, chatgpt, backend-client crates implement near-identical model list/connect interfaces
+- **41.3% file-level test coverage**, 11 crates with zero tests (incl. codex-backend-openapi-models at 14 files)
+
+### Complexity Hotspots (branch keyword density)
+1. chat_composer.rs: 469 branches
+2. chatwidget.rs: 457
+3. codex_message_processor.rs: 423
+4. codex.rs: 369
+5. app.rs: 270
+
+---
+
+## cliproxyapi++ (166K Go)
+
+### Critical Findings
+- **15 executor files** totaling 15,403 LOC — each reimplements HTTP/retry/streaming independently
+- **21,441 LOC of auth code** across 14 provider subdirectories, 6 distinct auth mechanisms
+- **kiro_executor.go at 4,691 LOC** — 3x the next largest executor
+- **Functions exceeding 200 lines**: executeClaudeNonStream (205L), ExecuteStream (198L), Execute (149L)
+- **Zero shared executor base** — only logging_helpers.go + usage_helpers.go (612L combined) are extracted
+- **internal/auth/ (~600L)** appears dead — superseded by pkg/llmproxy/auth/
+- Error handling excellent: 0 suppressed errors, 3 defensible panics
+
+### Executor Size Distribution
+| Executor | LOC |
+|----------|-----|
+| kiro | 4,691 |
+| antigravity | 1,783 |
+| codex_websockets | 1,432 |
+| claude | 1,352 |
+| github_copilot | 1,173 |
+| gemini_vertex | 1,032 |
+| gemini_cli | 961 |
+| codex | 827 |
+| kimi | 596 |
+| iflow | 557 |
+| gemini | 539 |
+| aistudio | 495 |
+| kilo | 432 |
+| openai_compat | 377 |
+| qwen | 356 |
+
+---
+
+## agentapi++ (8.4K Go unique)
+
+### Critical Findings
+- **Inner duplication**: repo contains a full copy of itself under `agentapi-plusplus/agentapi-plusplus/` — ~50% of LOC is duplicate
+- Only 2 god modules (server.go 788L, pty_conversation.go 523L) — healthy
+- **Not a reimplementation of cliproxy**: thin agent lifecycle manager + SSE bridge that proxies to cliproxy
+- 9 packages with zero tests but all small (1-2 files each)
+
+---
+
+## thegent (~160K Python unique)
+
+### Critical Findings
+- **469 exact duplicate files** between src/thegent/ and packages/thegent-*/ — migration artifact, not cleaned up
+- **run_impl_core at 1,022 lines** — single largest function in entire ecosystem
+- **221 files (15%) use TYPE_CHECKING** — massive circular dependency surface
+- **Migration 32% complete**: 469/1,467 src files migrated but not deleted
+- **run_execution_core_helpers.py exists in 3 locations** — diverged tri-copy
+- **Packages by LOC**: thegent-cli (89K), thegent-agents (37K), thegent-audit (20K), thegent-protocols (18K), thegent-sync (16K), thegent-mcp (16K)
+- Test files (1,309) are mostly auto-generated coverage-wave tests, not organic unit tests
+- Type annotation coverage excellent at 96%
+
+---
+
+## portage (103K Python)
+
+### Critical Findings
+- **8 independent BaseAdapter definitions** across 41 adapters — no shared base infrastructure
+- **create_app at 1,164 lines** — god function (entire FastAPI app in one function)
+- **jobs.py::start at 856 lines** — another god function
+- **47.5% of source modules untested** including all environment backends (gke, e2b, modal, runloop)
+- **41 benchmark adapters** totaling 34,939 LOC with heavy pattern duplication
+- Type annotation coverage at 72% (lower than thegent)
+- Only 4 TYPE_CHECKING files — clean layering despite other issues
+- **terminus_2.py (1,838L)** needs split into parser/renderer/state
+
+---
+
+## heliosApp (78K TypeScript)
+
+### Critical Findings
+- **Bun-native, NOT Electron** — 3 processes: desktop (13K), renderer (1.3K), runtime (63K)
+- **Audit subsystem (2,577L) entirely untested** — 12 source files, 0 tests
+- **Protocol bus (805L) untested** — critical IPC layer
+- **48 IPC topics** in pub/sub channel registry
+- **Zero `any` usage**, zero `console.log` in prod — excellent TypeScript discipline
+- **11 of 17 runtime modules have zero tests**
+- 10 meaningful TODOs (integration stubs, not throwaway)
+- All deps current, no deprecated packages
+
+---
+
+## trace (678K Go+Python+TS)
+
+### Critical Findings
+- **api/main.py at 9,274 LOC** — most severe god module in entire ecosystem
+- **1,847 LOC of hand-rolled parsers** (python.go 653L, golang_declarations.go 391L, typescript_declarations.go 307L) — tree-sitter replacement candidates
+- **43 Go files exceed 500 LOC**, 55 Python files exceed 500 LOC
+- **390 Python type suppressions** (type: ignore + noqa) — retrofitted typing
+- **gorilla/mux (archived/deprecated)** + echo both in use — redundant routers
+- **182 HTTP routes** in Go backend
+- **No tree-sitter dependency** — all parsing is regex/string manipulation
+- **5 `.go.bak` files** in handlers/ — dead backup artifacts
+- Go test coverage excellent at 92% test-to-source ratio
+- Neo4j client wrappers: 3,416 LOC in internal/graph/
+- NATS integration: 1,262 LOC in internal/nats/
+- Embeddings: 2,228 LOC using pgvector (not chromem-go)
+
+---
+
+## Top Priority Actions by Impact
+
+### Tier 1: Highest LOC/Quality Impact
+1. **thegent**: Delete 469 duplicate files (immediate ~100K LOC reduction)
+2. **cliproxy**: Bifrost adoption replaces 9+ executors (25-40K LOC)
+3. **trace**: tree-sitter replaces hand-rolled parsers (1,847L direct + enables scip-go)
+4. **trace**: Split api/main.py (9,274L god module)
+5. **heliosCLI**: Split codex.rs (9,571L), chat_composer.rs (9,499L), codex_message_processor.rs (8,460L)
+
+### Tier 2: Quality/Safety Critical
+6. **heliosCLI**: Fix 934 unwrap() in production → `?` propagation
+7. **portage**: Extract shared BaseAdapter (eliminates 8-way duplication)
+8. **thegent**: Decompose run_impl_core (1,022L function)
+9. **cliproxy**: Split kiro_executor.go (4,691L)
+10. **heliosApp**: Test audit subsystem (2,577L untested)
+
+### Tier 3: Structural Health
+11. **thegent**: Break 221-file circular dep surface
+12. **portage**: Split create_app (1,164L), jobs::start (856L)
+13. **trace**: Remove gorilla/mux, consolidate on echo
+14. **agentapi++**: Remove inner directory duplication
+15. **cliproxy**: Consolidate 21K LOC auth → x/oauth2+Goth

--- a/agileplus-specs/phenotype-modular-arch/research/external-library-leverage.md
+++ b/agileplus-specs/phenotype-modular-arch/research/external-library-leverage.md
@@ -1,0 +1,147 @@
+# External Library Leverage Research
+
+**Date**: 2026-03-03
+**Purpose**: Identify OSS libraries/frameworks that can replace custom code across the Phenotype ecosystem, reducing LOC while maintaining or growing feature coverage.
+**Constraint**: Every removed line must result in feature growth/maintenance (>=0) and maintainability/quality growth (>=1).
+
+---
+
+## Executive Summary
+
+Across ~410K LOC in 7 repos, we identified **94-153K LOC** of potential reduction through aggressive library adoption. The top 5 highest-leverage swaps:
+
+1. **Bifrost** (Go LLM gateway) → replaces cliproxy++ 15 executors: **25-40K LOC**
+2. **Inspect AI** (Python eval framework) → replaces portage benchmark harness: **15-25K LOC**
+3. **Temporal** (durable workflows) → replaces thegent dispatcher+Redis locks: **6-10K LOC**
+4. **OPA + Guardrails AI** → replaces thegent governance: **6-10K LOC**
+5. **x/oauth2 + Goth + go-sse** → replaces cliproxy++ auth+streaming: **9-22K LOC**
+
+---
+
+## Per-Repo Adoption Plan
+
+### cliproxyapi++ (~80K LOC → ~25-40K LOC)
+
+| Library | What It Replaces | LOC Saved | Complexity | Risk |
+|---------|-----------------|-----------|------------|------|
+| **maximhq/bifrost** | 15 provider executors + translation matrix + retry + streaming | 25-40K | Medium | Kiro/Copilot/Cursor not covered; per-user OAuth needs wrapper |
+| **golang.org/x/oauth2** | 3 parallel auth systems → 1 TokenSource registry | 3-8K | Low-Medium | Machine-to-machine flows need custom TokenSource impls |
+| **markbates/goth** | Web OAuth callback handlers (75+ providers) | 3-6K | Low-Medium | Browser flows only |
+| **tmaxmax/go-sse** | Custom SSE parsers + reconnect logic | 2-5K | Low | Provider JSON envelopes still per-provider |
+| **coder/websocket** | Custom WebSocket streaming parsers | 1-3K | Low | None |
+| **avast/retry-go** | Per-executor retry loops (15x duplicated) | 1-3K | Very Low | None |
+| **hashicorp/go-retryablehttp** | HTTP retry wrappers in executors | 1.5-4K | Very Low | MPL-2.0 license review |
+| **sony/gobreaker** | Circuit breaking / provider health | 0.5-2K | Very Low | None |
+
+**Strategy**: Embed Bifrost as Go package for standard providers (OpenAI, Anthropic, Gemini, Bedrock, Azure, Cohere, Mistral, Groq, Ollama). Keep Kiro/Copilot/Cursor as thin custom executors using go-retryablehttp. Collapse 3 auth systems to x/oauth2 + Goth.
+
+### thegent (~100K LOC → ~60-75K LOC)
+
+| Library | What It Replaces | LOC Saved | Complexity | Risk |
+|---------|-----------------|-----------|------------|------|
+| **temporalio/sdk-python** | Hierarchical dispatcher + Redis locks + scheduler | 6-10K | High | Temporal server dependency |
+| **pydantic/pydantic-ai** | Agent classes, tool registration, OTel wiring | 5-8K | Medium | v0.x API |
+| **guardrails-ai/guardrails** | Semantic firewall, output validation | 4-6K | Medium | Flask-based daemon |
+| **open-policy-agent/opa** | Policy engine, compliance, RBAC | 4-7K | Medium | Sidecar process, Rego DSL |
+| **modelcontextprotocol/python-sdk** | Custom MCP handler | 2-4K | Low-Medium | v2 API changes Q1 2026 |
+| **pydantic/pydantic-settings** | Custom config loaders | 2-4K | Very Low | None |
+| **BerriAI/litellm** (proxy mode) | Custom LiteLLM wrapper | 1K | Very Low | Network hop |
+| **Textualize/textual** | Custom TUI | 1-8K | Medium | v0.x, asyncio-only |
+
+**Strategy**: Temporal for durable orchestration (eliminates Redis lock complexity). PydanticAI for agent definitions. OPA for policy-as-code + Guardrails AI for semantic validation. LiteLLM proxy shared with portage.
+
+### portage (~40K LOC → ~13-23K LOC)
+
+| Library | What It Replaces | LOC Saved | Complexity | Risk |
+|---------|-----------------|-----------|------------|------|
+| **UKGovernmentBEIS/inspect_ai** | 40 benchmark adapters + BaseAgent + task harness | 15-25K | High | UK AISI continuity; Docker-first |
+| **BerriAI/litellm** (proxy) | Duplicate LiteLLM wrapper | 0.7K | Very Low | Shared with thegent |
+| **pydantic/pydantic-settings** | Config loaders | 1K | Very Low | None |
+| **Bogdanp/dramatiq** or **samuelcolvin/arq** | Job queue orchestrator | 0.5-0.7K | Low | None |
+
+**Strategy**: Port new benchmarks as Inspect AI Task definitions. Retain custom environment drivers (Modal, Runloop, Daytona, E2B, GKE). Share LiteLLM proxy with thegent.
+
+### heliosCLI (~110K LOC → ~102-106K LOC)
+
+| Library | What It Replaces | LOC Saved | Complexity | Risk |
+|---------|-----------------|-----------|------------|------|
+| **0xPlaygrounds/rig** | thegent-router, thegent-runtime, provider crates | 2-4.5K | Medium | Pre-1.0 |
+| **rmcp 0.16** (#[tool] macros) | MCP schema boilerplate | 200-500 | Very Low | None |
+| **@modelcontextprotocol/sdk** | Hand-rolled MCP transport in codex-cli | 500-1.5K | Low | None |
+| **hakoniwa** | Linux bwrap orchestration | 500-1K | Medium | Linux-only |
+
+**Already adopted correctly**: landlock crate, gix (gitoxide), rmcp 0.15, Extism (planned).
+**Do NOT adopt**: Cap'n Proto/FlatBuffers (negative ROI), oclif (startup penalty).
+
+### heliosApp (~77K LOC → ~66-73K LOC)
+
+| Library | What It Replaces | LOC Saved | Complexity | Risk |
+|---------|-----------------|-----------|------------|------|
+| **event-driven-io/emmett** | Custom audit ledger/replay/snapshot | 2-5K | Medium | Pre-1.0 |
+| **jsonnull/electron-trpc** | Custom Envelope/Command/Response IPC | 1-3K | Medium | Pre-1.0, tRPC v11 fork |
+| Tauri 2.0 (long-term) | Electron runtime | 3-8K | HIGH | 6-12 month migration |
+
+**Strategy**: Emmett + electron-trpc now. Tauri evaluation on greenfield companion app later.
+
+### trace (Go+Python+React)
+
+| Library | What It Replaces | LOC Saved | Complexity | Risk |
+|---------|-----------------|-----------|------------|------|
+| **tree-sitter/go-tree-sitter** | Custom code indexer/parsers | 2-6K | Medium | CGo build requirement |
+| **sourcegraph/scip-go** | Deep Go cross-reference indexing | 3-8K | High | Sourcegraph commercial interests |
+| **philippgille/chromem-go** | Custom embedding service | 1-3K | Low | Brute-force search only |
+| **neo4j/neo4j-go-driver v5** | Custom Neo4j client wrappers | 0.5-1.5K | Low | None |
+| **nats-io/nats.go** (JetStream) | Custom message routing | 0.5-2K | Low | Already on NATS |
+
+**No OSS replacement exists for trace itself** — its code-semantic + requirement traceability with graph storage is differentiated.
+
+---
+
+## Cross-Repo Deduplication via Libraries
+
+| Duplication | Current State | Solution |
+|------------|--------------|---------|
+| LiteLLM wrappers | thegent 1K + portage 700 LOC | Shared LiteLLM proxy instance |
+| cliproxy clients | thegent Python + agentapi++ Go + trace Go | Publish cliproxy++ Go SDK; create Python SDK |
+| Auth patterns | cliproxy++ 3 systems + agentapi++ local | phenotype-go-authkit backed by x/oauth2 |
+| Provider abstractions | cliproxy++ executors + heliosApp ProviderAdapter + thegent ad-hoc | Bifrost (Go) + Rig (Rust) + PydanticAI (Python) |
+| Event sourcing | heliosApp custom + proto AuditEvent | Emmett (TS) + proto schema |
+
+---
+
+## Do NOT Adopt (Negative ROI)
+
+| Library | Why Not |
+|---------|---------|
+| Cap'n Proto / FlatBuffers | Negative ROI for moderate-frequency CLI messages |
+| oclif | 70-100ms startup penalty in agent loops |
+| NeMo Guardrails | Colang DSL lock-in, overkill |
+| Tauri (now) | 6-12 month migration for uncertain gains |
+| Wails | Smaller ecosystem than Tauri, Go-first mismatch |
+| AutoGen | v0.4 instability, Microsoft dependency |
+| wolkenkit | AGPL license incompatibility |
+
+---
+
+## Migration Priority (Phased)
+
+### Phase A: Drop-in / Very Low Complexity
+1. LiteLLM Proxy (shared gateway) — 1.7K LOC, config change
+2. Pydantic Settings — 3K LOC, standard pattern
+3. rmcp 0.16 upgrade — 200-500 LOC, version bump
+4. avast/retry-go — 1-3K LOC, loop replacement
+5. sony/gobreaker — 0.5-2K LOC, add circuit breaking
+6. Official MCP Python SDK — 2-4K LOC, protocol swap
+
+### Phase B: Medium Complexity, High Reward
+7. x/oauth2 + Goth — 6-14K LOC, auth consolidation
+8. Bifrost — 25-40K LOC, executor replacement
+9. Emmett + electron-trpc — 3-8K LOC, heliosApp modernization
+10. PydanticAI — 5-8K LOC, agent class replacement
+11. Rig — 2-4.5K LOC, Rust provider consolidation
+
+### Phase C: High Complexity, Transformative
+12. Temporal — 6-10K LOC, orchestration replacement
+13. OPA + Guardrails AI — 6-10K LOC, governance as code
+14. Inspect AI — 15-25K LOC, eval framework adoption
+15. tree-sitter + chromem-go — 3-9K LOC, trace modernization

--- a/agileplus-specs/phenotype-modular-arch/spec.md
+++ b/agileplus-specs/phenotype-modular-arch/spec.md
@@ -1,0 +1,15 @@
+# Feature Specification: Phenotype Ecosystem Modularization & Plugin Architecture
+
+**Status**: Draft
+**Created**: 2026-03-03
+
+## Summary
+
+Modularization and plugin architecture for the Phenotype ecosystem spanning 6 repositories. Covers polyrepo shared package extraction, protobuf contract system, two-tier plugin architecture (compile-time + WASM), hexagonal architecture enforcement, and cross-repo audit event integration.
+
+## Artifacts
+
+- `plan.md` — Phased implementation plan with 6 parallel lanes and 28 work packages
+- `tasks/tasks.md` — 85 subtasks organized into 28 work packages
+- `tasks/WP*.md` — Individual work package implementation guides
+- `research/` — Evidence logs and source registers

--- a/agileplus-specs/phenotype-modular-arch/tasks/WP01-protobuf-contract-system.md
+++ b/agileplus-specs/phenotype-modular-arch/tasks/WP01-protobuf-contract-system.md
@@ -1,0 +1,205 @@
+---
+work_package_id: "WP01"
+title: "Protobuf Contract System (phenotype-proto)"
+lane: "planned"
+dependencies: []
+subtasks: ["T001", "T002", "T003", "T004", "T005"]
+history:
+  - date: "2026-03-03"
+    event: "created"
+    by: "spec-kitty.tasks"
+---
+
+# WP01: Protobuf Contract System (phenotype-proto)
+
+**Implementation command**: `spec-kitty implement WP01`
+
+## Objective
+
+Create the `phenotype-proto` repository containing all shared Protobuf type definitions for the Phenotype ecosystem. Configure `buf` for multi-language codegen (Rust, Go, Python, TypeScript) and add CI for lint + breaking change detection.
+
+This is the **critical path foundation** — audit event integration across all 6 repos depends on these proto definitions existing.
+
+## Context
+
+- Currently zero cross-repo type sharing; each repo defines its own session, agent, audit types
+- Target: single source of truth in Protobuf, codegen to all 4 languages
+- Consumers: all 6 Phenotype repos (heliosCLI, cliproxyapi++, thegent, heliosApp, portage, agentapi++)
+- See `kitty-specs/002-phenotype-modular-arch/research.md` Decision 2 and `docs/governance/plugin_architecture_governance.md`
+
+## Subtasks
+
+### T001: Create `phenotype-proto` repo with buf config
+
+**Purpose**: Bootstrap the proto repo with buf.build toolchain.
+
+**Steps**:
+1. Create new repo `phenotype-proto` (GitHub via `gh repo create`)
+2. Initialize `buf.yaml` at repo root:
+   ```yaml
+   version: v2
+   modules:
+     - path: proto
+   lint:
+     use:
+       - STANDARD
+   breaking:
+     use:
+       - FILE
+   ```
+3. Create directory structure:
+   ```
+   phenotype-proto/
+   ├── proto/
+   │   ├── domain/v1/    # Domain types
+   │   └── plugin/v1/    # Plugin contracts
+   ├── buf.yaml
+   ├── buf.gen.yaml      # Codegen config (T004)
+   ├── buf.lock
+   └── README.md
+   ```
+4. Add `.gitignore` for generated output dirs (`gen/`)
+
+**Files**: New repo — all files new
+**Validation**: `buf lint` passes on empty proto structure
+
+### T002: Define domain/v1/ protos
+
+**Purpose**: Define shared domain types used across all repos.
+
+**Steps**:
+1. Create `proto/domain/v1/session.proto`:
+   ```protobuf
+   syntax = "proto3";
+   package domain.v1;
+
+   message Session {
+     string id = 1;
+     string agent_id = 2;
+     SessionStatus status = 3;
+     google.protobuf.Timestamp created_at = 4;
+     google.protobuf.Timestamp updated_at = 5;
+     map<string, string> metadata = 6;
+   }
+
+   enum SessionStatus {
+     SESSION_STATUS_UNSPECIFIED = 0;
+     SESSION_STATUS_ACTIVE = 1;
+     SESSION_STATUS_COMPLETED = 2;
+     SESSION_STATUS_FAILED = 3;
+   }
+   ```
+
+2. Create `proto/domain/v1/agent.proto`:
+   - `Agent` message: id, name, type (enum: codex, helios, cursor, crew, etc.), capabilities, config
+   - `AgentCapability` enum
+
+3. Create `proto/domain/v1/routing.proto`:
+   - `RoutingRule` message: id, agent_id, pattern, priority, conditions
+   - `RoutingDecision` message: selected_agent, reason, latency_ms
+
+4. Create `proto/domain/v1/audit.proto`:
+   - `AuditEvent` message: id, timestamp, source_repo, event_type, actor, payload (google.protobuf.Any), correlation_id, parent_event_id
+   - `EventType` enum: SESSION_CREATED, SESSION_COMPLETED, AGENT_ROUTED, TOOL_EXECUTED, TRIAL_STARTED, TRIAL_COMPLETED, etc.
+   - This is the **core event schema** consumed by WP12
+
+**Files**:
+- `proto/domain/v1/session.proto` (~40 lines)
+- `proto/domain/v1/agent.proto` (~50 lines)
+- `proto/domain/v1/routing.proto` (~35 lines)
+- `proto/domain/v1/audit.proto` (~60 lines)
+
+**Validation**: `buf lint` passes on all domain protos
+
+### T003: Define plugin/v1/ protos
+
+**Purpose**: Define plugin contract types for the two-tier plugin architecture.
+
+**Steps**:
+1. Create `proto/plugin/v1/executor.proto`:
+   - `ExecutorContract` message: name, version, supported_models, capabilities
+   - `ExecuteRequest` / `ExecuteResponse` messages
+   - `StreamChunk` message for streaming responses
+
+2. Create `proto/plugin/v1/tool.proto`:
+   - `ToolSpec` message: name, description, parameters (JSON schema as string), return_type
+   - `ToolInvocation` / `ToolResult` messages
+
+3. Create `proto/plugin/v1/adapter.proto`:
+   - `AdapterContract` message: name, version, port_type, capabilities
+   - `AdapterHealth` message for lifecycle management
+
+**Files**:
+- `proto/plugin/v1/executor.proto` (~70 lines)
+- `proto/plugin/v1/tool.proto` (~50 lines)
+- `proto/plugin/v1/adapter.proto` (~40 lines)
+
+**Validation**: `buf lint` passes; no breaking changes detected
+
+### T004: Configure buf generate for 4 languages
+
+**Purpose**: Set up codegen so `buf generate` produces idiomatic types in Rust (prost), Go (protoc-gen-go), Python (betterproto), TypeScript (ts-proto).
+
+**Steps**:
+1. Create `buf.gen.yaml`:
+   ```yaml
+   version: v2
+   managed:
+     enabled: true
+     override:
+       - file_option: go_package_prefix
+         value: github.com/KooshaPari/phenotype-proto/gen/go
+   plugins:
+     - remote: buf.build/protocolbuffers/go
+       out: gen/go
+       opt: paths=source_relative
+     - remote: buf.build/community/neoeinstein-prost
+       out: gen/rust
+     - local: protoc-gen-ts_proto
+       out: gen/ts
+       opt:
+         - outputServices=false
+         - esModuleInterop=true
+     - local: python-betterproto
+       out: gen/python
+   ```
+2. Run `buf generate` and verify output in `gen/{go,rust,ts,python}/`
+3. Ensure generated types compile in each language (basic smoke test)
+4. Add `gen/` to `.gitignore` — consumers run `buf generate` themselves or consume published packages
+
+**Files**: `buf.gen.yaml` (~30 lines)
+**Validation**: `buf generate` succeeds; generated Go compiles with `go build`, Rust with `cargo check`, TS with `tsc`, Python with `python -c "import ..."`
+
+### T005: CI: buf lint + buf breaking
+
+**Purpose**: Prevent proto regressions.
+
+**Steps**:
+1. Create `.github/workflows/proto-ci.yml`:
+   - Trigger on push/PR to `main`
+   - Steps: checkout, install buf, `buf lint`, `buf breaking --against .git#branch=main`
+   - Add `buf generate` step to verify codegen works
+2. Add branch protection requiring this workflow
+
+**Files**: `.github/workflows/proto-ci.yml` (~40 lines)
+**Validation**: CI passes on initial commit; intentional breaking change is caught
+
+## Definition of Done
+
+- [ ] phenotype-proto repo exists on GitHub with all proto files
+- [ ] `buf lint` passes with zero warnings
+- [ ] `buf generate` produces compilable types in all 4 languages
+- [ ] CI workflow runs lint + breaking checks on every PR
+- [ ] README documents repo purpose, structure, and usage
+
+## Risks
+
+- **betterproto Python codegen quality**: May need to fall back to standard protoc-gen-python if betterproto has issues. Test early.
+- **ts-proto configuration**: Many options; ensure esModuleInterop and paths match heliosApp's tsconfig.
+- **prost Rust codegen**: Ensure generated types derive Serialize/Deserialize if needed (may need prost-serde or manual impls).
+
+## Reviewer Guidance
+
+- Verify proto field numbering follows conventions (no gaps, no reuse)
+- Check that AuditEvent schema is general enough for all 6 repos' event types
+- Ensure buf.gen.yaml plugins are pinned to specific versions for reproducibility

--- a/agileplus-specs/phenotype-modular-arch/tasks/WP02-shared-package-scaffolding.md
+++ b/agileplus-specs/phenotype-modular-arch/tasks/WP02-shared-package-scaffolding.md
@@ -1,0 +1,122 @@
+---
+work_package_id: "WP02"
+title: "Shared Package Scaffolding"
+lane: "planned"
+dependencies: []
+subtasks: ["T006", "T007"]
+history:
+  - date: "2026-03-03"
+    event: "created"
+    by: "spec-kitty.tasks"
+---
+
+# WP02: Shared Package Scaffolding
+
+**Implementation command**: `spec-kitty implement WP02`
+
+## Objective
+
+Create 7 empty shared package repositories with proper structure, CI, README, and package manager configuration. These repos will be populated by downstream WPs (WP04, WP07, WP10, WP11).
+
+## Context
+
+- Polyrepo strategy per `docs/governance/project_decomposition_governance.md`
+- Naming: `phenotype-{lang}-{concern}` for Go/Rust/Python, `@helios/{concern}` for TypeScript
+- Flat dependency graph: shared packages never depend on each other
+- All start at v0.1.0; accept breaking changes freely pre-v1.0
+
+## Subtasks
+
+### T006: Create Go shared repos
+
+**Purpose**: Scaffold 3 Go module repos.
+
+**Steps** (repeat for each):
+
+1. **phenotype-go-authkit**:
+   - `gh repo create KooshaPari/phenotype-go-authkit --public`
+   - `go mod init github.com/KooshaPari/phenotype-go-authkit`
+   - Create `authkit.go` with package declaration + doc comment
+   - Create `.github/workflows/go-ci.yml` (build, test, vet, lint)
+   - README: purpose (token storage, refresh, provider auth), consumers (cliproxy++, agent++)
+
+2. **phenotype-go-executor-core**:
+   - Same scaffold
+   - `go mod init github.com/KooshaPari/phenotype-go-executor-core`
+   - README: purpose (ExecutorInterface, BaseExecutor, retry/HTTP helpers)
+
+3. **phenotype-go-httpkit**:
+   - Same scaffold
+   - `go mod init github.com/KooshaPari/phenotype-go-httpkit`
+   - README: purpose (defaultHttpRequest, proxy helpers, cache helpers)
+
+**Common CI template** (`.github/workflows/go-ci.yml`):
+```yaml
+name: Go CI
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with: { go-version: '1.22' }
+      - run: go build ./...
+      - run: go test ./...
+      - run: go vet ./...
+```
+
+**Files per repo**: go.mod, {name}.go, README.md, .github/workflows/go-ci.yml, .gitignore, LICENSE
+**Validation**: `go build ./...` passes in each repo
+
+### T007: Create non-Go shared repos
+
+**Purpose**: Scaffold 4 shared repos (1 Rust, 1 Python, 2 TypeScript).
+
+**Steps**:
+
+1. **phenotype-rs-protocol** (Rust):
+   - `cargo init --lib phenotype-rs-protocol`
+   - Add `prost` dependency in Cargo.toml
+   - Create `src/lib.rs` with doc comment
+   - CI: `cargo build`, `cargo test`, `cargo clippy`
+
+2. **phenotype-py-infra** (Python):
+   - `uv init phenotype-py-infra`
+   - Create `pyproject.toml` with package metadata
+   - Create `src/phenotype_py_infra/__init__.py`
+   - CI: `uv sync`, `pytest`, `ruff check`
+
+3. **@helios/audit-core** (TypeScript):
+   - Create repo `helios-audit-core`
+   - `pnpm init`
+   - Set `"name": "@helios/audit-core"` in package.json
+   - Create `src/index.ts` with placeholder export
+   - CI: `pnpm build` (tsup or tsc), `pnpm test` (vitest)
+   - tsconfig.json with strict mode
+
+4. **@helios/protocol-types** (TypeScript):
+   - Same scaffold as audit-core
+   - `"name": "@helios/protocol-types"`
+
+**Files per repo**: language-specific config, src/ entry point, README.md, CI workflow, .gitignore, LICENSE
+**Validation**: Each repo builds clean with its language toolchain
+
+## Definition of Done
+
+- [ ] All 7 repos exist on GitHub with proper structure
+- [ ] Each repo has CI workflow that passes
+- [ ] Each repo has README documenting purpose and consumers
+- [ ] Go modules resolve (`go mod tidy`), Cargo builds, pnpm builds, uv syncs
+- [ ] All repos are at v0.1.0 initial state
+
+## Risks
+
+- **GitHub API rate limits**: Creating 7 repos in sequence. Use `gh` CLI with auth token.
+- **Package registry setup**: npm scope `@helios` may need org-level config. Verify publishing permissions.
+
+## Reviewer Guidance
+
+- Verify naming follows `phenotype-{lang}-{concern}` convention
+- Ensure no repo has dependencies on other shared repos (flat graph)
+- Check that LICENSE is consistent across all repos

--- a/agileplus-specs/phenotype-modular-arch/tasks/WP03-helioscli-workspace-merge.md
+++ b/agileplus-specs/phenotype-modular-arch/tasks/WP03-helioscli-workspace-merge.md
@@ -1,0 +1,150 @@
+---
+work_package_id: "WP03"
+title: "heliosCLI: codex/helios Workspace Merge"
+lane: "planned"
+dependencies: []
+subtasks: ["T008", "T009", "T010"]
+history:
+  - date: "2026-03-03"
+    event: "created"
+    by: "spec-kitty.tasks"
+---
+
+# WP03: heliosCLI — codex/helios Workspace Merge
+
+**Implementation command**: `spec-kitty implement WP03`
+
+## Objective
+
+Merge the dual codex-rs + helios-rs Cargo workspaces (134 crates, ~80% identical) into a single workspace with feature flags. Eliminate ~50 redundant crate definitions. Both `codex` and `helios` binaries continue to build and pass tests.
+
+## Context
+
+- heliosCLI currently has 67 crates in codex-rs/ and 67 near-identical crates in helios-rs/
+- helios-rs was forked from codex-rs; differences are primarily branding and a few runtime-specific behaviors
+- Research finding E001 confirmed merge via feature flags is the correct approach
+- See `kitty-specs/002-phenotype-modular-arch/research.md` Decision 3
+
+**Key constraint**: Both `cargo build --features codex-runtime` and `cargo build --features helios-runtime` must produce working binaries after this WP.
+
+## Subtasks
+
+### T008: Merge into single Cargo workspace
+
+**Purpose**: Combine two workspace roots into one.
+
+**Steps**:
+1. **Audit differences** between codex-rs/ and helios-rs/:
+   - Run `diff -rq codex-rs/ helios-rs/` to identify files that actually differ
+   - Categorize: (a) identical files, (b) branding-only diffs, (c) behavioral diffs
+   - Expected: ~80% identical, ~15% branding, ~5% behavioral
+
+2. **Create unified workspace** at `codex-rs/` (keep codex-rs as the canonical location):
+   - Update root `Cargo.toml` workspace members to include all unique crates
+   - For identical crates: keep single copy in codex-rs/
+   - For branding diffs: parameterize via feature flags or build-time config
+   - For behavioral diffs: use `#[cfg(feature = "...")]` (see T009)
+
+3. **Update internal crate dependencies**:
+   - All `path = "../helios-rs/..."` references → point to unified locations
+   - Verify `cargo check --workspace` passes
+
+**Files**:
+- `Cargo.toml` (workspace root — updated members list)
+- Various `*/Cargo.toml` (path dependency updates)
+
+**Validation**: `cargo check --workspace` succeeds with all crates resolving
+
+### T009: Gate variant code behind feature flags
+
+**Purpose**: Use Cargo features to select codex vs helios runtime behavior.
+
+**Steps**:
+1. Define features in the relevant binary/lib crate Cargo.toml:
+   ```toml
+   [features]
+   default = ["helios-runtime"]
+   codex-runtime = []
+   helios-runtime = []
+   ```
+
+2. Gate variant-specific code:
+   ```rust
+   #[cfg(feature = "codex-runtime")]
+   mod codex_specifics { /* ... */ }
+
+   #[cfg(feature = "helios-runtime")]
+   mod helios_specifics { /* ... */ }
+   ```
+
+3. Gate branding constants:
+   ```rust
+   #[cfg(feature = "codex-runtime")]
+   pub const BINARY_NAME: &str = "codex";
+
+   #[cfg(feature = "helios-runtime")]
+   pub const BINARY_NAME: &str = "helios";
+   ```
+
+4. Ensure no `#[cfg]` blocks contain more than ~50 lines; if larger, extract to separate modules
+
+**Files**: Primarily binary entry points and any crate with runtime-specific behavior
+**Validation**:
+- `cargo build --features codex-runtime` produces working codex binary
+- `cargo build --features helios-runtime` produces working helios binary
+- `cargo test --workspace` passes for both feature sets
+
+### T010: Remove helios-rs, update CI
+
+**Purpose**: Delete the redundant workspace directory and update CI to build both variants.
+
+**Steps**:
+1. Verify all helios-rs code is accounted for in the merged workspace
+2. Delete `helios-rs/` directory entirely
+3. Update `.github/workflows/rust-ci.yml`:
+   - Add matrix strategy to build both variants:
+     ```yaml
+     strategy:
+       matrix:
+         features: [codex-runtime, helios-runtime]
+     steps:
+       - run: cargo build --features ${{ matrix.features }}
+       - run: cargo test --features ${{ matrix.features }}
+     ```
+4. Update `BUILD.bazel` if Bazel targets reference helios-rs paths
+5. Update any scripts in `scripts/` that reference helios-rs
+
+**Files**:
+- Delete `helios-rs/` (entire directory)
+- `.github/workflows/rust-ci.yml` (update)
+- `BUILD.bazel` / `MODULE.bazel` (update if needed)
+- `scripts/*` (update references)
+
+**Validation**:
+- `helios-rs/` no longer exists
+- CI passes for both feature variants
+- `cargo test --workspace` passes
+- Bazel build still works
+
+## Definition of Done
+
+- [ ] Single Cargo workspace with all unique crates
+- [ ] `cargo build --features codex-runtime` produces codex binary
+- [ ] `cargo build --features helios-runtime` produces helios binary
+- [ ] All existing tests pass for both variants
+- [ ] helios-rs/ directory deleted
+- [ ] CI updated to test both variants
+- [ ] ~50 fewer crate definitions than before
+
+## Risks
+
+- **Subtle behavioral differences**: Some helios-rs changes may be more than branding. The diff audit in T008 step 1 is critical — do not skip it.
+- **Bazel integration**: Bazel BUILD files may have hardcoded helios-rs paths. Check `MODULE.bazel` and all `BUILD.bazel` files.
+- **Test isolation**: Some tests may implicitly depend on which variant is active. Run full test suite under both feature flags.
+
+## Reviewer Guidance
+
+- Verify the diff audit was thorough — every helios-rs file accounted for
+- Check that feature flags are mutually exclusive where needed
+- Ensure no `#[cfg]` blocks duplicate large amounts of code (extract to modules instead)
+- Confirm CI matrix covers both variants

--- a/agileplus-specs/phenotype-modular-arch/tasks/WP04-helioscli-protocol-extraction.md
+++ b/agileplus-specs/phenotype-modular-arch/tasks/WP04-helioscli-protocol-extraction.md
@@ -1,0 +1,76 @@
+---
+work_package_id: WP04
+title: 'heliosCLI: Protocol Extraction to Shared Repo'
+lane: planned
+dependencies: []
+subtasks: [T011]
+history:
+- date: '2026-03-03'
+  event: created
+  by: spec-kitty.tasks
+---
+
+# WP04: heliosCLI — Protocol Extraction to Shared Repo
+
+**Implementation command**: `spec-kitty implement WP04 --base WP03`
+
+## Objective
+
+Extract the `protocol` crate types from the heliosCLI Cargo workspace to the `phenotype-rs-protocol` shared repo. heliosCLI then consumes it as a dependency.
+
+## Context
+
+- `phenotype-rs-protocol` repo scaffolded in WP02
+- heliosCLI workspace merged in WP03
+- The protocol crate contains: ModelConfig, ToolSpec, MessageHistory, ApprovalPolicy (~8K LOC)
+- Consumers: heliosCLI (today), future Rust-based agents
+
+## Subtasks
+
+### T011: Extract protocol crate to phenotype-rs-protocol
+
+**Steps**:
+1. Identify the protocol crate in the merged workspace (likely `codex-rs/core/` or a dedicated `protocol` crate)
+2. Copy relevant types to `phenotype-rs-protocol/src/`:
+   - `lib.rs` — re-exports
+   - `model.rs` — ModelConfig, model-related types
+   - `tool.rs` — ToolSpec, DynamicToolSpec
+   - `message.rs` — MessageHistory, conversation types
+   - `policy.rs` — ApprovalPolicy, approval-related types
+3. Add dependencies to `phenotype-rs-protocol/Cargo.toml` (serde, prost if proto-generated)
+4. In heliosCLI, replace local protocol types with `phenotype-rs-protocol` dependency:
+   ```toml
+   [dependencies]
+   phenotype-rs-protocol = { git = "https://github.com/KooshaPari/phenotype-rs-protocol", branch = "main" }
+   ```
+5. Update all `use protocol::*` imports across heliosCLI crates
+6. Remove the local protocol crate from heliosCLI workspace
+
+**Files**:
+- `phenotype-rs-protocol/src/*.rs` (new, ~8K LOC total)
+- `phenotype-rs-protocol/Cargo.toml` (updated deps)
+- heliosCLI `Cargo.toml` (workspace members, add git dep)
+- All heliosCLI files importing protocol types (import path updates)
+
+**Validation**:
+- `cargo build` in phenotype-rs-protocol succeeds
+- `cargo build --workspace` in heliosCLI succeeds with external dep
+- `cargo test --workspace` passes
+
+## Definition of Done
+
+- [ ] phenotype-rs-protocol contains all shared protocol types
+- [ ] heliosCLI consumes phenotype-rs-protocol as git dependency
+- [ ] Local protocol crate removed from heliosCLI workspace
+- [ ] All tests pass in both repos
+- [ ] No duplicate type definitions remain
+
+## Risks
+
+- **Circular dependencies**: Protocol types may reference heliosCLI-internal types. Extract only types with no internal deps; leave heliosCLI-specific extensions in the local codebase.
+- **Breaking API surface**: Consumer imports change. Search all `use` statements.
+
+## Reviewer Guidance
+
+- Verify extracted types have no dependencies on heliosCLI internals
+- Check that the shared crate's public API is minimal and well-documented

--- a/agileplus-specs/phenotype-modular-arch/tasks/WP05-helioscli-plugin-system.md
+++ b/agileplus-specs/phenotype-modular-arch/tasks/WP05-helioscli-plugin-system.md
@@ -1,0 +1,96 @@
+---
+work_package_id: WP05
+title: 'heliosCLI: Plugin System (Tier 1 + Tier 2)'
+lane: planned
+dependencies: []
+subtasks: [T012, T013]
+history:
+- date: '2026-03-03'
+  event: created
+  by: spec-kitty.tasks
+---
+
+# WP05: heliosCLI — Plugin System (Tier 1 + Tier 2)
+
+**Implementation command**: `spec-kitty implement WP05 --base WP03`
+
+## Objective
+
+Implement the two-tier plugin architecture for heliosCLI tools. Tier 1: compile-time native trait registration via `inventory` crate. Tier 2: runtime Extism/WASM plugins for user-defined tools.
+
+## Context
+
+- heliosCLI already has `DynamicToolSpec` as an ad-hoc extension point
+- See `docs/governance/plugin_architecture_governance.md` for the two-tier microkernel decision
+- Tier 1 is the primary mechanism for built-in tools; Tier 2 is for user/third-party extensions
+- **Library leverage (from research/external-library-leverage.md)**:
+  - **0xPlaygrounds/rig** provides trait-based provider abstraction that can replace `thegent-router`, `thegent-runtime`, and provider crates (2-4.5K LOC saved). Rig's agent/tool registration model complements the ToolPlugin system — rig handles provider routing while ToolPlugin handles tool extension.
+  - **rmcp 0.16** `#[tool]` proc-macros eliminate MCP schema boilerplate (200-500 LOC saved). This is a drop-in version bump from rmcp 0.15 already in use.
+
+## Subtasks
+
+### T012: Tier 1 — ToolPlugin trait + inventory registration
+
+> **Quick win**: Upgrade rmcp from 0.15 → 0.16 as a prerequisite. The `#[tool]` proc-macros in 0.16 auto-generate MCP tool schema from Rust doc comments + types, eliminating 200-500 LOC of hand-written `ToolSpec` JSON. This is a version bump with no architectural change.
+
+> **Rig adoption note**: Evaluate `0xPlaygrounds/rig` for provider-level abstraction alongside the ToolPlugin trait. Rig's `Agent` + `Tool` traits can sit above ToolPlugin — rig routes to providers and orchestrates agent loops, while ToolPlugin defines the tool extension contract. If adopted, `thegent-router` and `thegent-runtime` crates can be replaced (2-4.5K LOC). Rig is pre-1.0; pin to an exact version.
+
+**Steps**:
+1. Add `inventory` crate to workspace dependencies
+2. Define the `ToolPlugin` trait:
+   ```rust
+   pub trait ToolPlugin: Send + Sync + 'static {
+       fn name(&self) -> &str;
+       fn description(&self) -> &str;
+       fn spec(&self) -> ToolSpec;
+       fn execute(&self, input: serde_json::Value) -> Result<serde_json::Value>;
+   }
+   inventory::collect!(Box<dyn ToolPlugin>);
+   ```
+3. Create `plugin/` module in the core crate with:
+   - `registry.rs` — `PluginRegistry` that collects all `inventory` submissions
+   - `trait.rs` — `ToolPlugin` trait definition
+4. Convert 1-2 existing built-in tools to use `ToolPlugin` trait as proof of concept
+5. Wire registry into tool discovery/execution path
+
+**Validation**: Built-in tools register and execute via the new trait
+
+### T013: Tier 2 — Extism host for user tools
+
+**Steps**:
+1. Add `extism` crate to workspace dependencies
+2. Create `plugin/wasm_host.rs`:
+   - Load `.wasm` plugin files from a configurable directory (`~/.helios/plugins/`)
+   - Validate plugin implements the ToolPlugin contract (check exported functions)
+   - Wrap WASM plugin in a `WasmToolPlugin` that implements `ToolPlugin` trait
+3. Implement sandbox constraints:
+   - Memory limit per plugin (default: 256MB)
+   - No filesystem access (use Extism PDK for controlled I/O)
+   - Timeout per invocation (default: 30s)
+4. Add plugin discovery: scan plugin directory on startup, load valid `.wasm` files
+5. Merge WASM-loaded plugins into the same `PluginRegistry` as Tier 1
+
+**Validation**:
+- Create a minimal test `.wasm` plugin (e.g., a tool that returns a static response)
+- Plugin loads, validates, and executes correctly
+- Invalid/crashing plugins don't affect host
+
+## Definition of Done
+
+- [ ] `ToolPlugin` trait defined with inventory registration
+- [ ] At least 1 built-in tool refactored to use the trait
+- [ ] Extism host loads .wasm plugins from plugin directory
+- [ ] WASM plugins are sandboxed (memory limit, timeout)
+- [ ] Plugin registry merges both tiers
+- [ ] Failing WASM plugin doesn't crash host
+
+## Risks
+
+- **Extism performance**: WASM invocation overhead may be noticeable for latency-sensitive tools. Benchmark the prototype.
+- **inventory crate compatibility**: Ensure it works with the Cargo workspace structure and Bazel builds.
+
+## Reviewer Guidance
+
+- Verify sandbox constraints are properly enforced (test with a malicious plugin)
+- Check that the ToolPlugin trait is general enough for diverse tool types
+- Ensure error handling wraps all WASM host calls

--- a/agileplus-specs/phenotype-modular-arch/tasks/WP06-cliproxy-executor-core.md
+++ b/agileplus-specs/phenotype-modular-arch/tasks/WP06-cliproxy-executor-core.md
@@ -1,0 +1,129 @@
+---
+work_package_id: "WP06"
+title: "cliproxyapi++: Executor Core Extraction"
+lane: "planned"
+dependencies: []
+subtasks: ["T015", "T016"]
+history:
+  - date: "2026-03-03"
+    event: "created"
+    by: "spec-kitty.tasks"
+  - date: "2026-03-03"
+    event: "revised"
+    by: "agent"
+    note: "Incorporate external-library-leverage research: Bifrost for standard providers, retry-go, gobreaker, go-retryablehttp"
+---
+
+# WP06: cliproxyapi++ — Executor Core Extraction
+
+**Implementation command**: `spec-kitty implement WP06`
+
+## Objective
+
+Define the `ExecutorInterface` port and integrate **maximhq/bifrost** as the primary adapter for all standard LLM providers. Bifrost replaces 9+ custom executors (OpenAI, Anthropic, Gemini, Bedrock, Azure, Cohere, Mistral, Groq, Ollama) with a single unified gateway at 11µs overhead. Keep thin custom executors only for providers Bifrost does not cover (Kiro, Copilot, Cursor). Adopt **avast/retry-go**, **sony/gobreaker**, and **hashicorp/go-retryablehttp** for resilience primitives.
+
+**Estimated LOC savings**: 25-40K (Bifrost) + 1-3K (retry-go) + 0.5-2K (gobreaker).
+
+## Context
+
+- cliproxyapi++ has 15 LLM provider executors (Claude, Codex, Gemini, Kiro, Copilot, etc.)
+- Each executor duplicates: retry logic, HTTP request construction, streaming response handling, error wrapping, timeout management
+- Code reduction phase already extracted `RefreshWithRetry` and `defaultHttpRequest` — build on that
+- See `kitty-specs/002-phenotype-modular-arch/research.md` Decision 5
+- **Library research**: `kitty-specs/002-phenotype-modular-arch/research/external-library-leverage.md` — Bifrost identified as top-1 leverage swap (25-40K LOC)
+
+## Subtasks
+
+### T015: Bifrost integration + ExecutorInterface port + resilience primitives
+
+**Steps**:
+1. Create `sdk/executor-core/` directory in cliproxyapi++
+2. Add Go dependencies:
+   - `github.com/maximhq/bifrost` — unified LLM gateway
+   - `github.com/avast/retry-go/v4` — generic retry with backoff
+   - `github.com/sony/gobreaker` — circuit breaker
+   - `github.com/hashicorp/go-retryablehttp` — HTTP retry client
+3. Define `ExecutorInterface` as a hexagonal port:
+   ```go
+   type ExecutorInterface interface {
+       Execute(ctx context.Context, req *ExecuteRequest) (*ExecuteResponse, error)
+       Stream(ctx context.Context, req *ExecuteRequest) (<-chan StreamChunk, error)
+       Name() string
+       SupportedModels() []string
+       Health() HealthStatus
+   }
+   ```
+4. Implement `BifrostAdapter` wrapping Bifrost as the primary ExecutorInterface implementation:
+   - Configure Bifrost with provider credentials for: OpenAI, Anthropic, Gemini, Bedrock, Azure, Cohere, Mistral, Groq, Ollama
+   - Map `ExecuteRequest`/`ExecuteResponse` to/from Bifrost's unified request/response types
+   - Wire streaming through Bifrost's native streaming support
+   - Expose per-provider health via Bifrost's built-in provider health tracking
+5. Implement `ThinCustomExecutor` base for providers Bifrost does not cover (Kiro, Copilot, Cursor):
+   - Uses `go-retryablehttp` for HTTP transport with automatic retry
+   - Uses `retry-go` for non-HTTP retry loops (e.g., token refresh)
+   - Uses `gobreaker` for circuit breaking on repeated failures
+   - Minimal struct — only provider-specific request/response mapping
+6. Create `go.mod` for `sdk/executor-core` (internal module, not yet extracted to separate repo)
+
+**Validation**:
+- `go build ./sdk/executor-core/...` passes
+- BifrostAdapter can initialize with at least one provider config
+- ThinCustomExecutor base compiles with retry-go + gobreaker wired in
+
+### T016: Migrate standard executors to Bifrost; keep Kiro/Copilot/Cursor as custom
+
+**Steps**:
+1. **Delete** the 9+ standard provider executor files (Claude, Codex/OpenAI, Gemini, Bedrock, Azure, Cohere, Mistral, Groq, Ollama) — Bifrost replaces them entirely
+2. Configure Bifrost provider settings from existing executor configs (API keys, endpoints, model lists)
+3. For each deleted executor, verify the BifrostAdapter produces equivalent request/response behavior:
+   - Same model name resolution
+   - Same streaming chunk format (or mapped to common StreamChunk)
+   - Same error codes and retry semantics
+4. Implement the 3 custom executors (Kiro, Copilot, Cursor) using `ThinCustomExecutor` base:
+   ```go
+   type KiroExecutor struct {
+       ThinCustomExecutor
+       sessionToken string
+   }
+
+   func (e *KiroExecutor) Execute(ctx context.Context, req *ExecuteRequest) (*ExecuteResponse, error) {
+       return retry.Do(func() (*ExecuteResponse, error) {
+           httpReq := e.BuildRequest("POST", kiroEndpoint, req.ToKiroFormat())
+           return e.DoRequest(ctx, httpReq)
+       }, retry.Attempts(3), retry.Delay(500*time.Millisecond))
+   }
+   ```
+5. Update executor factory/registry:
+   - Standard providers → single BifrostAdapter registration (one adapter, multiple provider names)
+   - Kiro, Copilot, Cursor → individual ThinCustomExecutor registrations
+6. Run full test suite after migration (incremental per-provider, not big-bang)
+
+**Validation**:
+- All provider routing works through BifrostAdapter or ThinCustomExecutor
+- No duplicated retry/HTTP/streaming code remains
+- Custom executor files (Kiro, Copilot, Cursor) are each <200 LOC
+- Existing executor tests pass (adapted to new adapter surface)
+
+## Definition of Done
+
+- [ ] `sdk/executor-core` package with ExecutorInterface port, BifrostAdapter, ThinCustomExecutor base
+- [ ] Bifrost handles 9+ standard providers (OpenAI, Anthropic, Gemini, Bedrock, Azure, Cohere, Mistral, Groq, Ollama)
+- [ ] Only Kiro, Copilot, Cursor remain as thin custom executors
+- [ ] `avast/retry-go`, `sony/gobreaker`, `hashicorp/go-retryablehttp` wired into custom executor base
+- [ ] No duplicated retry/HTTP/streaming patterns across executors
+- [ ] All existing executor tests pass (adapted)
+- [ ] `go build ./...` and `go test ./...` pass
+
+## Risks
+
+- **Bifrost provider coverage gaps**: If Bifrost drops support for a provider or has bugs, we may need to temporarily add a custom executor. Monitor Bifrost releases.
+- **Bifrost streaming fidelity**: Verify that Bifrost's streaming output matches the exact chunk format executors previously emitted. May need a thin mapping layer.
+- **Kiro/Copilot/Cursor edge cases**: These providers have non-standard APIs; the ThinCustomExecutor base must be flexible enough for their auth and streaming patterns.
+- **go-retryablehttp license**: MPL-2.0 — confirm license compatibility before adoption.
+
+## Reviewer Guidance
+
+- Verify Bifrost configuration covers all previously-supported models per provider
+- Check that BifrostAdapter streaming produces the same StreamChunk shape as old executors
+- Confirm custom executors (Kiro, Copilot, Cursor) use retry-go and gobreaker correctly
+- Ensure no executor test was deleted or weakened during migration — adapted tests must cover the same behavior

--- a/agileplus-specs/phenotype-modular-arch/tasks/WP07-cliproxy-shared-extraction.md
+++ b/agileplus-specs/phenotype-modular-arch/tasks/WP07-cliproxy-shared-extraction.md
@@ -1,0 +1,99 @@
+---
+work_package_id: WP07
+title: 'cliproxyapi++: Shared Package Extraction (authkit + httpkit)'
+lane: planned
+dependencies: []
+subtasks: [T017, T018]
+history:
+- date: '2026-03-03'
+  event: created
+  by: spec-kitty.tasks
+- date: '2026-03-03'
+  event: revised
+  by: agent
+  note: 'Incorporate external-library-leverage research: x/oauth2, markbates/goth for auth consolidation'
+---
+
+# WP07: cliproxyapi++ — Shared Package Extraction
+
+**Implementation command**: `spec-kitty implement WP07 --base WP02`
+
+## Objective
+
+Extract auth logic to `phenotype-go-authkit` and HTTP helpers to `phenotype-go-httpkit` shared repos. cliproxyapi++ and agentapi++ will consume these as Go module dependencies.
+
+## Context
+
+- Shared repos scaffolded in WP02
+- cliproxyapi++ `internal/auth/` has ~4K LOC of token storage, refresh, provider auth — used by 20+ importers within cliproxy++
+- HTTP helpers (`defaultHttpRequest`, proxy helpers) identified during code reduction phase
+- agentapi++ also needs auth and HTTP patterns (WP14 will consume these)
+- **Library research**: `kitty-specs/002-phenotype-modular-arch/research/external-library-leverage.md` — cliproxyapi++ has 3 parallel auth systems that should collapse to **golang.org/x/oauth2** + **markbates/goth** (6-14K LOC saved)
+
+## Subtasks
+
+### T017: Extract auth logic to phenotype-go-authkit (backed by x/oauth2 + Goth)
+
+**Library guidance**:
+- **golang.org/x/oauth2** — use as the foundation for all token management. The 3 parallel auth systems in cliproxyapi++ (OAuth2 flows, API key rotation, session-based) should collapse to a single `oauth2.TokenSource` registry. Each provider gets a `TokenSource` implementation; `RefreshWithRetry` becomes a thin wrapper around `oauth2.ReuseTokenSource`. Estimated LOC savings: 3-8K.
+- **markbates/goth** — use for web OAuth callback handlers (75+ providers supported out of the box). This replaces custom OAuth callback routes and provider-specific redirect logic. Estimated LOC savings: 3-6K. Note: Goth covers browser-based flows only; machine-to-machine flows still need custom `oauth2.TokenSource` implementations.
+
+**Steps**:
+1. Identify all auth-related types in cliproxyapi++ `internal/auth/`:
+   - `TokenStore`, `BaseTokenStorage`, `RefreshWithRetry`
+   - Provider-specific auth (OAuth2, API key, session-based)
+2. Add dependencies to `phenotype-go-authkit`:
+   - `golang.org/x/oauth2`
+   - `github.com/markbates/goth`
+3. Implement `phenotype-go-authkit/` with x/oauth2 as core:
+   - `tokenregistry.go` — `TokenSourceRegistry` mapping provider name to `oauth2.TokenSource`; replaces `TokenStore` + `BaseTokenStorage`
+   - `refresh.go` — thin wrapper around `oauth2.ReuseTokenSource` with logging; replaces `RefreshWithRetry`
+   - `oauth2_web.go` — Goth-backed web OAuth callback handlers (provider init, callback route, session extraction)
+   - `apikey.go` — API key management (simple `TokenSource` that returns static keys)
+   - `m2m.go` — machine-to-machine `TokenSource` implementations for providers without browser flows
+4. Ensure no cliproxyapi++-internal imports in extracted code
+5. In cliproxyapi++, replace `internal/auth` imports with `phenotype-go-authkit`:
+   ```go
+   import authkit "github.com/KooshaPari/phenotype-go-authkit"
+   ```
+6. Collapse the 3 parallel auth systems to the single `TokenSourceRegistry`
+7. Update `go.mod` with new dependency
+8. Run `go mod tidy` and verify all imports resolve
+
+**Validation**: `go build ./...` and `go test ./...` pass in both repos; all 3 former auth systems exercised through the unified registry
+
+### T018: Extract HTTP helpers to phenotype-go-httpkit
+
+**Steps**:
+1. Identify HTTP helper code:
+   - `defaultHttpRequest` function (extracted during code reduction)
+   - Proxy request construction helpers
+   - Response parsing utilities
+   - Cache helpers
+2. Copy to `phenotype-go-httpkit/`:
+   - `request.go` — defaultHttpRequest, request builders
+   - `response.go` — response parsing, error extraction
+   - `cache.go` — cache helpers
+3. In cliproxyapi++, replace local helpers with httpkit imports
+4. Update `go.mod`
+
+**Validation**: `go build ./...` and `go test ./...` pass in both repos
+
+## Definition of Done
+
+- [ ] phenotype-go-authkit contains all shared auth types
+- [ ] phenotype-go-httpkit contains all shared HTTP helpers
+- [ ] cliproxyapi++ consumes both as Go module dependencies
+- [ ] No auth/HTTP duplicated code remains in cliproxyapi++ internals
+- [ ] All tests pass in all 3 repos
+
+## Risks
+
+- **internal/ visibility**: Go `internal/` packages can't be imported externally. The extraction must move types OUT of internal/ into the shared repo.
+- **Transitive deps**: Shared packages should minimize their own dependencies.
+
+## Reviewer Guidance
+
+- Verify no cliproxyapi++-specific logic leaked into shared packages
+- Check that shared package APIs are clean and documented
+- Ensure go.sum files are committed

--- a/agileplus-specs/phenotype-modular-arch/tasks/WP08-cliproxy-plugin-system.md
+++ b/agileplus-specs/phenotype-modular-arch/tasks/WP08-cliproxy-plugin-system.md
@@ -1,0 +1,129 @@
+---
+work_package_id: WP08
+title: 'cliproxyapi++: Plugin System + Hexagonal Ports'
+lane: planned
+dependencies: []
+subtasks: [T019, T020, T021, T022]
+history:
+- date: '2026-03-03'
+  event: created
+  by: spec-kitty.tasks
+- date: '2026-03-03'
+  event: revised
+  by: agent
+  note: 'Incorporate external-library-leverage research: tmaxmax/go-sse, coder/websocket for custom executor streaming'
+---
+
+# WP08: cliproxyapi++ — Plugin System + Hexagonal Ports
+
+**Implementation command**: `spec-kitty implement WP08 --base WP06`
+
+## Objective
+
+Implement the two-tier plugin architecture for cliproxyapi++ executors. Formalize executor and translator interfaces as hexagonal ports. Add translator matrix builder to reduce N×M duplication.
+
+## Context
+
+- executor-core extracted in WP06 provides BifrostAdapter (standard providers) and ThinCustomExecutor base (Kiro/Copilot/Cursor)
+- Bifrost handles streaming for standard providers; custom executors (Kiro, Copilot, Cursor) need their own streaming
+- Goal: allow third-party executors as WASM plugins without modifying core routing
+- Translator matrix (input format × output format) currently duplicated across executors
+- **Library research**: `kitty-specs/002-phenotype-modular-arch/research/external-library-leverage.md` — **tmaxmax/go-sse** (2-5K LOC saved) and **coder/websocket** (1-3K LOC saved) for streaming in custom executors and WASM plugins
+
+## Subtasks
+
+### T019: Tier 1 — Executor interface + init() registration
+
+**Steps**:
+1. Create `plugin/registry.go`:
+   ```go
+   var executorRegistry = make(map[string]ExecutorFactory)
+
+   type ExecutorFactory func(config map[string]any) (ExecutorInterface, error)
+
+   func RegisterExecutor(name string, factory ExecutorFactory) {
+       executorRegistry[name] = factory
+   }
+   ```
+2. Each built-in executor registers via `init()`:
+   ```go
+   func init() {
+       plugin.RegisterExecutor("claude", func(cfg map[string]any) (ExecutorInterface, error) {
+           return NewClaudeExecutor(cfg)
+       })
+   }
+   ```
+3. Update routing to discover executors from registry instead of hardcoded switch
+
+**Validation**: All 15 executors register via init() and are discoverable
+
+### T020: Tier 2 — Extism host for executor .wasm
+
+**Steps**:
+1. Add `github.com/extism/go-sdk` dependency
+2. Create `plugin/wasm_host.go`:
+   - Load `.wasm` executor plugins from configurable directory
+   - Validate plugin exports match ExecutorContract proto schema
+   - Wrap in WasmExecutor implementing ExecutorInterface
+3. Sandbox: memory limit (256MB), timeout (60s), no fs access
+4. Register WASM executors in same registry as Tier 1
+5. Create test .wasm plugin (minimal echo executor)
+
+**Validation**: WASM executor loads, registers, handles requests; failure doesn't crash host
+
+### T021: Translator matrix builder + streaming library integration
+
+**Library guidance**:
+- **tmaxmax/go-sse** — use for SSE streaming in custom executors (Kiro, Copilot, Cursor) and WASM plugin streaming bridges. Replaces all custom SSE parsers and reconnect logic. Provides typed event handling, automatic reconnection, and last-event-ID tracking. Estimated LOC savings: 2-5K. Note: provider-specific JSON envelope parsing is still per-provider.
+- **coder/websocket** — use for WebSocket streaming where providers use WS instead of SSE (e.g., some Cursor endpoints). Replaces custom WebSocket frame parsers. Estimated LOC savings: 1-3K.
+- Bifrost (from WP06) already handles streaming for the 9 standard providers; go-sse and coder/websocket are only needed for the custom executors and WASM plugin host.
+
+**Steps**:
+1. Add dependencies:
+   - `github.com/tmaxmax/go-sse`
+   - `github.com/coder/websocket`
+2. Analyze current translator duplication (input format × output format conversions)
+3. Create `translator/matrix.go`:
+   - Define `Translator` interface: `Translate(from Format, to Format, data []byte) ([]byte, error)`
+   - Build translator registry mapping (Format, Format) → Translator
+   - Codegen or builder pattern to reduce N×M to N+M implementations
+4. Create `translator/streaming.go`:
+   - `SSEStreamReader` wrapping go-sse client for SSE-based custom executors
+   - `WSStreamReader` wrapping coder/websocket for WebSocket-based custom executors
+   - Both implement a common `StreamReader` interface producing `StreamChunk`
+   - Wire into ThinCustomExecutor base (from WP06) as the default streaming layer
+5. Replace hardcoded format conversions in executors with matrix lookups
+6. Wire streaming readers into WASM plugin host (T020) for plugin streaming support
+
+**Validation**: All format conversions work through the matrix; no duplicated conversion code; custom executors use go-sse/websocket for streaming
+
+### T022: Formalize executor + translator as hexagonal ports
+
+**Steps**:
+1. Create `ports/` package:
+   - `executor_port.go` — ExecutorPort interface (same as ExecutorInterface but named as port)
+   - `translator_port.go` — TranslatorPort interface
+   - `routing_port.go` — RoutingPort for request dispatch
+2. Create `adapters/` for concrete implementations
+3. Ensure all external I/O goes through ports (HTTP calls, auth, storage)
+
+**Validation**: Clear separation between domain logic and external dependencies
+
+## Definition of Done
+
+- [ ] Plugin registry with init() registration for all built-in executors
+- [ ] Extism host loads and executes .wasm executor plugins
+- [ ] Translator matrix reduces format conversion duplication
+- [ ] Executor and translator formalized as hexagonal ports
+- [ ] All tests pass; no routing behavior changes
+
+## Risks
+
+- **Extism Go SDK maturity**: Test thoroughly; fall back to HashiCorp go-plugin if Extism is unstable.
+- **Translator matrix complexity**: Start simple (map-based registry) before adding codegen.
+
+## Reviewer Guidance
+
+- Verify WASM sandbox constraints are enforced
+- Check translator matrix covers all existing format pairs
+- Ensure hexagonal ports don't over-abstract simple operations

--- a/agileplus-specs/phenotype-modular-arch/tasks/WP09-thegent-package-migration.md
+++ b/agileplus-specs/phenotype-modular-arch/tasks/WP09-thegent-package-migration.md
@@ -1,0 +1,119 @@
+---
+work_package_id: "WP09"
+title: "thegent: Package Migration Completion"
+lane: "planned"
+dependencies: []
+subtasks: ["T024", "T025", "T026", "T027"]
+history:
+  - date: "2026-03-03"
+    event: "created"
+    by: "spec-kitty.tasks"
+  - date: "2026-03-03"
+    event: "revised"
+    by: "external-library-leverage research integration"
+---
+
+# WP09: thegent — Package Migration Completion
+
+**Implementation command**: `spec-kitty implement WP09`
+
+## Objective
+
+Complete thegent's partial migration from monolithic `src/thegent/` to `packages/thegent-*`. Extract config, infra, governance packages. Merge protocols+mcp.
+
+## Context
+
+- thegent is ~60% migrated; `packages/` already contains thegent-core, thegent-cli, thegent-agents, thegent-execution, thegent-sync, thegent-audit, thegent-planning, thegent-observability, thegent-skills
+- Remaining in `src/thegent/`: config*.py (~500 LOC), infra/ (~11K LOC), governance/ (~13K LOC)
+- thegent-protocols and thegent-mcp exist separately but overlap — merge into single thegent-mcp
+- See `kitty-specs/002-phenotype-modular-arch/research.md` Decision 4
+
+## Subtasks
+
+### T024: Extract thegent-config (pydantic-settings adoption)
+
+**Steps**:
+1. Identify config files: `src/thegent/config.py`, `src/thegent/config_schema.py`, related
+2. Create `packages/thegent-config/`:
+   - `pyproject.toml` with package metadata; add `pydantic-settings` as dependency
+   - `src/thegent_config/__init__.py` — re-exports
+   - Move config schemas, validation, loading logic
+3. **Replace custom config loaders with `pydantic-settings`**: Convert config classes to `BaseSettings` subclasses with env/file/secrets sources. This eliminates custom YAML/env loading logic (~2-4K LOC saved).
+4. Update `src/thegent/` imports to use `thegent-config`
+5. Add to workspace `pyproject.toml`
+
+**Implementation guidance (library research)**:
+- `pydantic/pydantic-settings` is a Phase A drop-in (very low complexity, no risk).
+- Use `SettingsConfigDict` for env prefix, nested model support, and `.env` file loading.
+- Preserve existing config key names via `Field(alias=...)` for backward compatibility.
+
+**Validation**: `uv sync && pytest packages/thegent-config/`
+
+### T025: Extract thegent-infra
+
+**Steps**:
+1. Identify infra code: `src/thegent/infra/` (~11K LOC)
+   - Fast YAML, subprocess runner, file ops, IPC bridge, cache
+2. Create `packages/thegent-infra/`:
+   - Preserve module structure from `infra/`
+   - Ensure zero thegent-specific imports (this is the reusable layer)
+3. Update all `src/thegent/` and `packages/*/` imports
+4. This package will later be published as `phenotype-py-infra` (WP10)
+
+**Validation**: `pytest packages/thegent-infra/` passes; no thegent-specific deps
+
+### T026: Extract thegent-governance (OPA + Guardrails AI adoption)
+
+**Steps**:
+1. Identify: `src/thegent/governance/` (~13K LOC) — policy engine, HITL, escalation
+2. Create `packages/thegent-governance/`
+3. Move governance code; update imports
+4. May depend on thegent-core for domain types
+5. **OPA adoption**: Replace the custom policy engine with `open-policy-agent/opa` (sidecar or embedded). Define policies in Rego. This replaces custom RBAC, compliance, and policy evaluation logic (~4-7K LOC saved).
+6. **Guardrails AI adoption**: Integrate `guardrails-ai/guardrails` for semantic validation (output validation, firewall). This replaces custom semantic firewall and output validation code (~4-6K LOC saved).
+
+**Implementation guidance (library research)**:
+- OPA is Phase C (medium complexity): requires Rego DSL for policy definitions and a sidecar process or embedded Go library. Map existing policy rules to Rego before migration.
+- Guardrails AI is Phase C (medium complexity): Flask-based daemon for validation. Evaluate whether to run as sidecar or in-process.
+- Combined, these two libraries save ~8-13K LOC out of the 13K governance module — the extraction and library adoption should be coordinated.
+- Retain HITL and escalation logic as custom code; OPA and Guardrails handle policy evaluation and semantic validation respectively.
+
+**Validation**: `pytest packages/thegent-governance/`
+
+### T027: Merge thegent-protocols + thegent-mcp (official MCP SDK adoption)
+
+**Steps**:
+1. Audit overlap between `packages/thegent-protocols/` and `packages/thegent-mcp/`
+2. Merge into single `packages/thegent-mcp/`:
+   - Combine protocol definitions with MCP implementation
+   - Remove thegent-protocols package
+3. **Replace custom MCP handler with `modelcontextprotocol/python-sdk`**: Swap hand-rolled MCP transport and protocol handling for the official SDK (~2-4K LOC saved). Use the SDK's transport, session, and tool-call primitives directly.
+4. Update all imports from thegent-protocols → thegent-mcp
+5. Update workspace pyproject.toml
+
+**Implementation guidance (library research)**:
+- `modelcontextprotocol/python-sdk` is Phase A (low-medium complexity, no major risk).
+- Note: v2 API changes expected Q1 2026 — pin to a stable release and track upstream.
+- The merge and SDK adoption can be done in one pass since both touch the same code.
+
+**Validation**: `pytest packages/thegent-mcp/` passes; no references to thegent-protocols remain
+
+## Definition of Done
+
+- [ ] thegent-config extracted and passing tests
+- [ ] thegent-infra extracted with zero thegent-specific deps
+- [ ] thegent-governance extracted and passing tests
+- [ ] thegent-protocols merged into thegent-mcp
+- [ ] All workspace tests pass (`pytest`)
+- [ ] `src/thegent/` is significantly smaller
+
+## Risks
+
+- **Import cycles**: Governance may depend on config which depends on core. Map dependency graph before extracting.
+- **Test fixtures**: Some tests may use fixtures from `src/thegent/` that need to move with their packages.
+
+## Reviewer Guidance
+
+- Verify thegent-infra has truly zero thegent-specific imports (grep for `thegent`)
+- Check dependency direction: infra should be at the bottom (no upward deps)
+- Ensure merged thegent-mcp covers all protocol+MCP functionality

--- a/agileplus-specs/phenotype-modular-arch/tasks/WP10-thegent-shared-publish-plugin.md
+++ b/agileplus-specs/phenotype-modular-arch/tasks/WP10-thegent-shared-publish-plugin.md
@@ -1,0 +1,135 @@
+---
+work_package_id: WP10
+title: 'thegent: Shared Publish + Plugin System + Re-export'
+lane: planned
+dependencies: []
+subtasks: [T028, T029, T030, T031, T033]
+history:
+- date: '2026-03-03'
+  event: created
+  by: spec-kitty.tasks
+- date: '2026-03-03'
+  event: revised
+  by: external-library-leverage research integration
+---
+
+# WP10: thegent — Shared Publish + Plugin System + Re-export Layer
+
+**Implementation command**: `spec-kitty implement WP10 --base WP09`
+
+## Objective
+
+Publish thegent-infra internals to `phenotype-py-infra` shared repo. Formalize the AdapterPort pattern. Implement Tier 1 (entry_points) and Tier 2 (Extism) plugin system. Make `src/thegent/` a thin re-export layer.
+
+## Context
+
+- thegent-infra extracted in WP09 (~11K LOC, zero thegent-specific deps)
+- phenotype-py-infra repo scaffolded in WP02
+- thegent has 15+ adapters with informal AdapterPort pattern — formalize for plugin registration
+- `src/thegent/` should become thin re-exports over packages
+
+## Subtasks
+
+### T028: Publish to phenotype-py-infra (+ shared LiteLLM proxy)
+
+**Steps**:
+1. Copy thegent-infra source to `phenotype-py-infra/src/phenotype_py_infra/`
+2. Set up pyproject.toml with proper metadata, version 0.1.0
+3. In thegent, replace local thegent-infra with `phenotype-py-infra` dependency
+4. In portage (future, WP13), will also consume this
+5. **Shared LiteLLM proxy**: Configure `BerriAI/litellm` in proxy mode as a shared gateway for both thegent and portage. This eliminates ~1.7K LOC of duplicate LiteLLM wrappers (1K thegent + 700 portage). Include proxy config and client helpers in phenotype-py-infra.
+
+**Implementation guidance (library research)**:
+- LiteLLM proxy is Phase A (very low complexity, config change only).
+- Run as a shared sidecar; both thegent and portage point to the same proxy endpoint.
+
+**Validation**: `uv pip install -e ./phenotype-py-infra && pytest`
+
+### T029: Formalize AdapterPort pattern (PydanticAI agent definitions)
+
+**Steps**:
+1. Define `AdapterPort` as a `typing.Protocol`, aligning with PydanticAI's agent model:
+   ```python
+   class AdapterPort(Protocol):
+       def name(self) -> str: ...
+       def capabilities(self) -> list[str]: ...
+       def execute(self, request: AdapterRequest) -> AdapterResponse: ...
+       def health(self) -> HealthStatus: ...
+   ```
+2. **Adopt `pydantic/pydantic-ai`**: Replace custom agent classes, tool registration, and OTel wiring with PydanticAI's `Agent` definitions, tool decorators, and built-in observability (~5-8K LOC saved). Use PydanticAI agents as the implementation behind AdapterPort where applicable.
+3. Audit all existing adapters in thegent-agents; ensure they conform to AdapterPort (backed by PydanticAI where appropriate)
+4. Add type checking enforcement (pyright/mypy strict mode on adapter modules)
+
+**Implementation guidance (library research)**:
+- `pydantic/pydantic-ai` is Phase B (medium complexity). Note: v0.x API — pin version and track upstream.
+- PydanticAI provides: agent class definitions, typed tool registration via decorators, structured output validation, and OpenTelemetry integration out of the box.
+- AdapterPort remains the contract; PydanticAI is the implementation backbone for agent-type adapters.
+
+**Validation**: All adapters pass type checking against AdapterPort
+
+### T030: Tier 1 — entry_points registration
+
+**Steps**:
+1. Add `entry_points` configuration in pyproject.toml for each adapter:
+   ```toml
+   [project.entry-points."thegent.adapters"]
+   codex = "thegent_agents.adapters.codex:CodexAdapter"
+   cursor = "thegent_agents.adapters.cursor:CursorAdapter"
+   ```
+2. Create adapter registry that discovers via `importlib.metadata.entry_points()`
+3. Wire registry into agent orchestration path
+
+**Validation**: Adapters discoverable via entry_points; no hardcoded adapter list
+
+### T031: Tier 2 — Extism host for user skills
+
+**Steps**:
+1. Add `extism` Python SDK dependency
+2. Create `thegent-skills/plugin_host.py`:
+   - Load .wasm skill plugins from `~/.thegent/plugins/`
+   - Validate plugin exports match AdapterPort contract
+   - Sandbox: memory limit, timeout, no fs access
+3. Register WASM skills alongside native entry_points
+4. Create test .wasm skill
+
+**Validation**: Test WASM skill loads and executes; failure doesn't crash host
+
+### T033: Make src/thegent/ a thin re-export layer
+
+**Steps**:
+1. Replace all business logic in `src/thegent/` with re-exports from packages:
+   ```python
+   # src/thegent/__init__.py
+   from thegent_core import *
+   from thegent_config import *
+   # etc.
+   ```
+2. Preserve backward compatibility — existing `from thegent import X` must still work
+3. Add deprecation warnings for direct `src/thegent/` imports if desired
+
+**Validation**: `from thegent import X` works for all public APIs; `src/thegent/` has minimal code
+
+## Library Adoption Notes (from external-library-leverage research)
+
+- **temporalio/sdk-python**: The hierarchical dispatcher + Redis locks + scheduler in thegent should be replaced with Temporal durable workflows (~6-10K LOC saved). This is Phase C (high complexity, requires Temporal server). Temporal adoption is out of scope for WP10 but should be planned as a follow-on; the plugin system and AdapterPort formalized here should be designed to work with Temporal-based orchestration.
+- **Textualize/textual**: Optional TUI replacement (~1-8K LOC saved). Phase B, v0.x asyncio-only. Not blocking for WP10 but worth evaluating for thegent-cli.
+
+## Definition of Done
+
+- [ ] phenotype-py-infra contains thegent-infra code and is consumable
+- [ ] AdapterPort formalized as typing.Protocol
+- [ ] entry_points registration replaces hardcoded adapter discovery
+- [ ] Extism host loads .wasm skill plugins
+- [ ] src/thegent/ is thin re-export layer
+- [ ] All tests pass
+
+## Risks
+
+- **entry_points discovery performance**: First call may be slow. Consider caching.
+- **Backward compatibility**: Re-export layer must not break existing imports. Test thoroughly.
+
+## Reviewer Guidance
+
+- Verify phenotype-py-infra has no thegent-specific types
+- Check AdapterPort is general enough for all adapter types
+- Ensure re-export layer covers all public APIs

--- a/agileplus-specs/phenotype-modular-arch/tasks/WP11-heliosapp-package-extraction.md
+++ b/agileplus-specs/phenotype-modular-arch/tasks/WP11-heliosapp-package-extraction.md
@@ -1,0 +1,122 @@
+---
+work_package_id: WP11
+title: 'heliosApp: Package Extraction + Publishing'
+lane: planned
+dependencies: []
+subtasks: [T034, T035, T036, T037, T038]
+history:
+- date: '2026-03-03'
+  event: created
+  by: spec-kitty.tasks
+---
+
+# WP11: heliosApp — Package Extraction + Publishing
+
+**Implementation command**: `spec-kitty implement WP11 --base WP02`
+
+## Objective
+
+Extract `@helios/audit-core`, `@helios/protocol-types`, and `@helios/service-contracts` from heliosApp. Publish to npm/GitHub Packages. Refactor runtime to consume extracted packages.
+
+## Context
+
+- heliosApp (TypeScript) has audit/event-sourcing (~3K LOC), protocol types (~1K LOC), service interfaces
+- These are reusable beyond heliosApp — audit-core especially (consumed by portage viewer, agentapi++)
+- Shared TS repos scaffolded in WP02
+
+## Subtasks
+
+### T034: Extract @helios/audit-core
+
+> **Library leverage**: Build `@helios/audit-core` ON TOP of **event-driven-io/emmett** rather than from scratch. Emmett provides append-only event store, projection engine, replay/snapshot, and read-model subscriptions out of the box (2-5K LOC saved vs custom implementation). The extracted package should re-export Emmett primitives with Helios-specific AuditEvent types and domain projections layered on top.
+
+**Steps**:
+1. Add `@event-driven-io/emmett` as a dependency of `helios-audit-core`
+2. Identify audit code in `apps/runtime/src/audit/`:
+   - AuditEvent types, Ledger, SQLiteStore, ReplayEngine, Snapshot
+3. Map existing abstractions to Emmett equivalents:
+   - `Ledger` → Emmett `EventStore` (append-only)
+   - `ReplayEngine` → Emmett projections + `readStream`
+   - `Snapshot` → Emmett inline snapshot support
+   - `SQLiteStore` → Emmett `getInMemoryEventStore()` for dev, pluggable store for prod
+4. Create `helios-audit-core/src/`:
+   - `event.ts` — AuditEvent, EventType (Helios-specific domain types)
+   - `store.ts` — Thin wrapper over Emmett EventStore with Helios configuration
+   - `projections.ts` — Domain-specific projections (audit summary, per-repo aggregation)
+   - Re-export Emmett primitives needed by consumers
+5. Ensure no heliosApp-internal imports (Electron, UI, etc.)
+6. Export all from `src/index.ts`
+
+**Validation**: `pnpm build` succeeds; types exported correctly; Emmett event store append/read round-trips
+
+### T035: Extract @helios/protocol-types
+
+> **Library leverage**: Evaluate **jsonnull/electron-trpc** to replace the custom Envelope/Command/Response IPC layer (1-3K LOC saved). electron-trpc provides type-safe IPC between Electron main ↔ renderer using tRPC routers, eliminating hand-rolled message serialization and dispatch. If adopted, protocol-types becomes a tRPC router definition package rather than raw message types.
+
+**Steps**:
+1. Identify protocol types in `apps/runtime/src/protocol/types.ts`:
+   - Envelope, Command, Event, Response types
+2. Evaluate electron-trpc adoption:
+   - If adopted: define tRPC routers + procedures that replace Envelope/Command/Response
+   - If deferred: copy raw types to `helios-protocol-types/src/`
+3. Ensure alignment with phenotype-proto generated TS types (WP01)
+
+**Validation**: `pnpm build` and `tsc --noEmit` pass
+
+### T036: Extract @helios/service-contracts
+
+> **Library leverage**: If electron-trpc is adopted in T035, service contracts can be expressed as tRPC router type signatures rather than standalone interface files. This reduces the surface area of this package to non-IPC contracts only.
+
+**Steps**:
+1. Identify service interfaces in runtime:
+   - Service boundaries for agent, session, routing, audit
+2. Create `helios-service-contracts/src/`:
+   - Interface definitions (not implementations)
+   - Shared error types
+   - If electron-trpc adopted: IPC contracts live in protocol-types as tRPC routers; this package covers non-IPC service boundaries only
+3. This enables hexagonal architecture in heliosApp runtime
+
+**Validation**: `pnpm build` passes; interfaces exported
+
+### T037: Publish packages
+
+**Steps**:
+1. Configure npm scope `@helios` (GitHub Packages or npm registry)
+2. Add `publishConfig` to each package.json
+3. Publish v0.1.0 of each package
+4. Verify packages installable: `pnpm add @helios/audit-core@0.1.0`
+
+**Validation**: Packages installable from registry
+
+### T038: Refactor runtime to consume packages
+
+**Steps**:
+1. In heliosApp, add dependencies on published packages
+2. Replace local imports with package imports:
+   ```typescript
+   // Before: import { AuditEvent } from '../audit/event'
+   // After:  import { AuditEvent } from '@helios/audit-core'
+   ```
+3. Remove extracted source files from heliosApp
+4. Run full test suite
+
+**Validation**: heliosApp builds and all tests pass with external packages
+
+## Definition of Done
+
+- [ ] 3 packages extracted and published
+- [ ] heliosApp consumes packages as dependencies
+- [ ] No duplicated code between heliosApp and packages
+- [ ] All heliosApp tests pass
+- [ ] Package CI workflows green
+
+## Risks
+
+- **Circular deps**: audit-core may reference protocol-types. Define clear dep direction: protocol-types → audit-core (audit-core depends on protocol-types, not vice versa).
+- **Electron-specific code**: Ensure no Electron APIs leak into shared packages.
+
+## Reviewer Guidance
+
+- Verify packages have no Electron/browser-specific imports
+- Check dependency direction between the 3 packages
+- Ensure published package versions are pinned in heliosApp

--- a/agileplus-specs/phenotype-modular-arch/tasks/WP12-audit-event-integration.md
+++ b/agileplus-specs/phenotype-modular-arch/tasks/WP12-audit-event-integration.md
@@ -1,0 +1,128 @@
+---
+work_package_id: WP12
+title: Audit Event Integration (All Repos)
+lane: planned
+dependencies: []
+subtasks: [T014, T023, T032, T041, T047]
+history:
+- date: '2026-03-03'
+  event: created
+  by: spec-kitty.tasks
+---
+
+# WP12: Audit Event Integration (All Repos)
+
+**Implementation command**: `spec-kitty implement WP12 --base WP01`
+
+## Objective
+
+Emit structured audit events from all 6 repos using the shared AuditEvent schema from phenotype-proto. Each repo emits events at its key state-changing operations.
+
+## Context
+
+- AuditEvent proto defined in WP01 (`proto/domain/v1/audit.proto`)
+- Each repo consumes generated types via buf codegen
+- Events follow CQRS pattern — write-side only (read-side aggregation in WP15)
+- See `kitty-specs/002-phenotype-modular-arch/spec.md` FR-5
+
+## Subtasks
+
+### T014: heliosCLI — session lifecycle audit events
+
+**Repo**: heliosCLI (Rust)
+
+**Steps**:
+1. Add `phenotype-proto` generated Rust types as dependency (via `phenotype-rs-protocol` or direct prost include)
+2. Emit events at key lifecycle points in codex-core:
+   - `SessionCreated` — when a new coding session starts
+   - `ToolExecuted` — when a tool is invoked
+   - `SessionCompleted` / `SessionFailed` — on session end
+3. Create `audit/` module:
+   - `emitter.rs` — `AuditEmitter` trait + stdout/file implementations
+   - `events.rs` — helper functions to construct AuditEvent with correct fields
+4. Wire emitter into session manager
+
+**Validation**: Running a coding session produces audit events in structured format
+
+### T023: cliproxyapi++ — routing audit events
+
+**Repo**: cliproxyapi++ (Go)
+
+**Steps**:
+1. Add phenotype-proto generated Go types
+2. Emit events at routing decisions:
+   - `RequestReceived` — incoming proxy request
+   - `ExecutorSelected` — routing decision made
+   - `ResponseForwarded` — response sent to client
+   - `ExecutorFailed` — executor error with fallback/retry info
+3. Create `internal/audit/` package:
+   - `emitter.go` — AuditEmitter interface + implementations
+   - `events.go` — event construction helpers
+4. Wire into request handler middleware
+
+**Validation**: Proxied requests produce audit trail
+
+### T032: thegent — agent execution audit events
+
+**Repo**: thegent (Python)
+
+**Steps**:
+1. Add phenotype-proto generated Python types (betterproto)
+2. Emit events at agent execution lifecycle:
+   - `AgentStarted` — agent begins execution
+   - `StepExecuted` — individual step completed
+   - `GovernanceDecision` — policy engine decision (approve/escalate/deny)
+   - `AgentCompleted` / `AgentFailed` — execution end
+3. Create `thegent-audit/emitter.py`:
+   - `AuditEmitter` protocol + implementations
+4. Wire into run execution core
+
+**Validation**: Agent execution produces structured audit events
+
+### T041: portage — trial execution audit events
+
+**Repo**: portage (Python)
+
+**Steps**:
+1. Add phenotype-proto generated Python types
+2. Emit events:
+   - `TrialStarted` — benchmark trial begins
+   - `TrialCheckpoint` — intermediate measurement
+   - `TrialCompleted` — trial finishes with results
+3. Wire into trial execution engine
+
+**Validation**: Running a benchmark trial produces audit events
+
+### T047: agentapi++ — routing audit events
+
+**Repo**: agentapi++ (Go)
+
+**Steps**:
+1. Add phenotype-proto generated Go types
+2. Emit events:
+   - `AgentRouted` — request routed to agent
+   - `SessionCreated` — new session established
+3. Wire into request handlers
+
+**Validation**: API requests produce audit events
+
+## Definition of Done
+
+- [ ] All 5 repos emit structured AuditEvent following the proto schema
+- [ ] Events include correlation_id for cross-repo tracing
+- [ ] Each repo's emitter is behind an interface (swappable backends)
+- [ ] Events are parseable by @helios/audit-core (WP15)
+- [ ] Existing tests pass in all repos
+
+## Risks
+
+- **Proto codegen in each language**: Ensure generated types work correctly in each ecosystem. Test imports early.
+- **Event volume**: Audit emitters should support async/batched emission to avoid performance impact.
+- **Correlation ID propagation**: Need convention for passing correlation IDs across service boundaries (HTTP headers, gRPC metadata).
+
+## Reviewer Guidance
+
+- Verify event types cover the key state changes per repo
+- Check correlation_id is propagated at service boundaries
+- Ensure emitter implementations are non-blocking (don't slow down hot paths)
+- Verify proto imports work correctly in each language

--- a/agileplus-specs/phenotype-modular-arch/tasks/WP13-portage-ports-plugins.md
+++ b/agileplus-specs/phenotype-modular-arch/tasks/WP13-portage-ports-plugins.md
@@ -1,0 +1,104 @@
+---
+work_package_id: WP13
+title: 'portage: Ports, Plugins, Shared Consumption'
+lane: planned
+dependencies: []
+subtasks: [T040, T042, T043, T044]
+history:
+- date: '2026-03-03'
+  event: created
+  by: spec-kitty.tasks
+- date: '2026-03-03'
+  event: revised
+  by: external-library-leverage research integration
+---
+
+# WP13: portage — Ports, Plugins, Shared Consumption
+
+**Implementation command**: `spec-kitty implement WP13 --base WP10`
+
+## Objective
+
+Formalize portage's extension points as `typing.Protocol` ports. Implement benchmark adapter plugin registry (Tier 1 via entry_points, Tier 2 via Extism). Consume `phenotype-py-infra` for shared utilities.
+
+## Context
+
+- portage has ~40 benchmark adapters with informal patterns
+- Shares infrastructure needs with thegent (file ops, subprocess, cache)
+- phenotype-py-infra published in WP10
+- See plan.md Lane 5
+
+## Subtasks
+
+### T040: Formalize ports via typing.Protocol (Inspect AI as framework)
+
+**Steps**:
+1. Define port protocols in `portage/ports/`, aligning with Inspect AI primitives:
+   ```python
+   class ExecutorPort(Protocol):
+       def run_trial(self, config: TrialConfig) -> TrialResult: ...
+
+   class ReporterPort(Protocol):
+       def report(self, results: list[TrialResult]) -> Report: ...
+
+   class LoaderPort(Protocol):
+       def load_benchmark(self, path: str) -> BenchmarkSpec: ...
+   ```
+2. **Inspect AI adoption**: `UKGovernmentBEIS/inspect_ai` provides the evaluation framework that replaces the custom BaseAgent, task harness, and ~40 benchmark adapters (~15-25K LOC saved). Port protocols should wrap Inspect AI primitives (Task, Solver, Scorer, Dataset). New benchmarks are authored as Inspect AI Task definitions rather than custom adapter classes.
+3. Retain custom environment drivers (Modal, Runloop, Daytona, E2B, GKE) — Inspect AI is Docker-first, so these remain custom.
+4. Ensure existing implementations conform to port protocols
+5. Add pyright strict mode on port modules
+
+**Implementation guidance (library research)**:
+- Inspect AI is Phase C (high complexity, transformative). This is the single highest-leverage adoption for portage.
+- The fundamental shift: instead of building 40 custom adapters, port benchmarks as Inspect AI Task definitions that use Inspect's solver/scorer/dataset primitives.
+- Inspect AI handles: model interaction, tool use, scoring, logging, and dataset management out of the box.
+
+**Validation**: Type checking passes on all port implementations
+
+### T042: Tier 1 — Inspect AI Task adapter registry
+
+**Steps**:
+1. Add entry_points for each adapter in pyproject.toml
+2. Create registry discovering adapters via `importlib.metadata`
+3. Replace hardcoded adapter list with registry discovery
+4. **Key shift**: The "benchmark adapter registry" becomes an "Inspect AI Task adapter registry". Each entry_point registers an Inspect AI Task definition (not a custom adapter class). The registry discovers and loads Task definitions that wrap Inspect primitives.
+
+**Implementation guidance (library research)**:
+- With Inspect AI adoption (T040), the adapter surface area shrinks dramatically — each adapter is a thin Task definition rather than a full custom class.
+- **Dramatiq or arq** can be added as a lightweight job queue for batch benchmark execution (~0.5-0.7K LOC saved vs custom queue logic). Phase A, low complexity.
+
+**Validation**: All adapters discoverable via entry_points as Inspect AI Task definitions
+
+### T043: Tier 2 — Extism host for user adapters
+
+**Steps**:
+1. Add extism Python SDK
+2. Create plugin host loading .wasm adapters from `~/.portage/plugins/`
+3. Validate against ExecutorPort contract
+4. Sandbox constraints: memory, timeout, no fs
+
+**Validation**: Test WASM adapter loads and executes
+
+### T044: Consume phenotype-py-infra (+ shared LiteLLM proxy)
+
+**Steps**:
+1. Add `phenotype-py-infra` dependency to portage
+2. Replace local utility code with shared imports (subprocess, file ops, cache)
+3. Remove duplicated utility code
+4. **Shared LiteLLM proxy**: Point portage at the shared `BerriAI/litellm` proxy configured in WP10/T028, eliminating portage's ~700 LOC of duplicate LiteLLM wrappers.
+
+**Validation**: `pytest` passes with shared dependency
+
+## Definition of Done
+
+- [ ] typing.Protocol ports formalized for executor, reporter, loader
+- [ ] Entry_points registry replaces hardcoded adapter discovery
+- [ ] Extism host prototype for .wasm adapters
+- [ ] phenotype-py-infra consumed, local duplicates removed
+- [ ] All tests pass
+
+## Reviewer Guidance
+
+- Verify port protocols are minimal (not over-specified)
+- Check adapter migration didn't break any benchmark workflows

--- a/agileplus-specs/phenotype-modular-arch/tasks/WP14-agentapi-domain-shared.md
+++ b/agileplus-specs/phenotype-modular-arch/tasks/WP14-agentapi-domain-shared.md
@@ -1,0 +1,66 @@
+---
+work_package_id: WP14
+title: 'agentapi++: Domain Extraction + Shared Consumption'
+lane: planned
+dependencies: []
+subtasks: [T045, T046]
+history:
+- date: '2026-03-03'
+  event: created
+  by: spec-kitty.tasks
+---
+
+# WP14: agentapi++ — Domain Extraction + Shared Consumption
+
+**Implementation command**: `spec-kitty implement WP14 --base WP07`
+
+## Objective
+
+Extract `internal/domain/` package with formal domain entities from agentapi++. Consume `phenotype-go-authkit` and `phenotype-go-httpkit` shared packages.
+
+## Context
+
+- agentapi++ is small (~3K LOC) — too small for full hexagonal, but needs domain layer
+- Auth and HTTP patterns shared with cliproxyapi++ (extracted in WP07)
+- See plan.md Lane 6
+
+## Subtasks
+
+### T045: Extract internal/domain/ package
+
+**Steps**:
+1. Create `internal/domain/`:
+   - `agent.go` — Agent entity with ID, name, type, capabilities
+   - `session.go` — Session entity with lifecycle state
+   - `routing.go` — RoutingRule, RoutingDecision
+   - `benchmark.go` — BenchmarkData (if applicable)
+2. Move entity definitions from handler code into domain types
+3. Handlers reference domain types instead of inline structs
+
+**Validation**: `go build ./...` passes; handlers use domain types
+
+### T046: Consume shared Go packages
+
+**Steps**:
+1. Add dependencies:
+   ```
+   go get github.com/KooshaPari/phenotype-go-authkit
+   go get github.com/KooshaPari/phenotype-go-httpkit
+   ```
+2. Replace local auth logic with authkit imports
+3. Replace local HTTP helpers with httpkit imports
+4. Remove duplicated local code
+
+**Validation**: `go build ./...` and `go test ./...` pass
+
+## Definition of Done
+
+- [ ] internal/domain/ package with Agent, Session, RoutingRule entities
+- [ ] authkit and httpkit consumed as dependencies
+- [ ] No duplicated auth/HTTP code
+- [ ] All tests pass
+
+## Reviewer Guidance
+
+- Verify domain types align with phenotype-proto definitions
+- Check that shared package versions are pinned

--- a/agileplus-specs/phenotype-modular-arch/tasks/WP15-heliosapp-audit-trail-view.md
+++ b/agileplus-specs/phenotype-modular-arch/tasks/WP15-heliosapp-audit-trail-view.md
@@ -1,0 +1,79 @@
+---
+work_package_id: WP15
+title: 'heliosApp: Aggregated Audit Trail View'
+lane: planned
+dependencies: [WP11]
+subtasks: [T039]
+history:
+- date: '2026-03-03'
+  event: created
+  by: spec-kitty.tasks
+---
+
+# WP15: heliosApp — Aggregated Audit Trail View
+
+**Implementation command**: `spec-kitty implement WP15 --base WP12`
+
+## Objective
+
+Implement an aggregated audit trail view in heliosApp that consumes structured audit events from all 6 repos, displaying end-to-end execution traces.
+
+## Context
+
+- @helios/audit-core extracted in WP11, now built on top of **Emmett** event store (see WP11 T034)
+- All repos emit AuditEvent per WP12
+- Events have correlation_id for cross-repo tracing
+- This is the read-side of the CQRS pattern
+- **With Emmett adoption**: the audit trail view should consume Emmett's projection and replay APIs directly rather than reimplementing custom read-model logic
+
+## Subtasks
+
+### T039: Aggregated audit trail view
+
+> **Emmett integration**: Use Emmett's projection engine and `readStream` / `readAll` APIs instead of custom ingestion and replay code. Emmett projections automatically maintain read models as events are appended, eliminating the need for manual SQLite read-side updates.
+
+**Steps**:
+1. Create audit trail ingestion:
+   - Consume events from all repos (file-based, API, or event bus — start with file-based for MVP)
+   - Append to Emmett event store via @helios/audit-core (which wraps Emmett)
+   - Define Emmett projections for: timeline read-model, per-repo aggregation, correlation trace
+2. Create UI component:
+   - Timeline view showing events chronologically (reads from Emmett projection)
+   - Filter by repo, event type, correlation_id
+   - Expand event details (payload, actor, timestamps)
+   - Trace view: follow a correlation_id across repos to see full execution path
+3. Implement replay:
+   - Use Emmett's `readStream` with time-range to replay event sequences
+   - Use Emmett inline snapshots for efficient state reconstruction at any point in time
+4. Wire into heliosApp navigation (new "Audit" tab/panel)
+
+**Files**:
+- `apps/desktop/src/components/audit/AuditTrailView.tsx` (~200 lines)
+- `apps/desktop/src/components/audit/EventTimeline.tsx` (~150 lines)
+- `apps/desktop/src/components/audit/TraceView.tsx` (~150 lines)
+- `apps/runtime/src/services/audit-ingestion.ts` (~100 lines)
+
+**Validation**:
+- Events from multiple repos display in timeline
+- Filtering works correctly
+- Correlation ID trace shows cross-repo flow
+- Replay reconstructs state accurately
+
+## Definition of Done
+
+- [ ] Audit events from all repos viewable in heliosApp
+- [ ] Filter by repo, type, correlation_id
+- [ ] Trace view follows execution across repos
+- [ ] Replay engine integrated
+- [ ] UI accessible from main navigation
+
+## Risks
+
+- **Event ingestion at scale**: Start with file-based; plan for event bus (NATS, Redis Streams) later.
+- **UI performance**: Large event volumes need virtualized lists and pagination.
+
+## Reviewer Guidance
+
+- Verify cross-repo trace correctly follows correlation_ids
+- Check replay accuracy against original event sequence
+- Ensure UI is responsive with large event volumes (test with 10K+ events)

--- a/agileplus-specs/phenotype-modular-arch/tasks/WP16-trace-code-intelligence.md
+++ b/agileplus-specs/phenotype-modular-arch/tasks/WP16-trace-code-intelligence.md
@@ -1,0 +1,117 @@
+---
+work_package_id: WP16
+title: 'trace: Code Intelligence Library Adoption'
+lane: planned
+dependencies: []
+subtasks: [T048, T049, T050]
+history:
+- date: '2026-03-03'
+  event: created
+  by: spec-kitty.tasks
+---
+
+# WP16: trace — Code Intelligence Library Adoption
+
+**Implementation command**: `spec-kitty implement WP16`
+
+## Objective
+
+Replace custom code intelligence infrastructure in the trace repo with battle-tested OSS libraries, reducing 7-23.5K LOC of custom parsers, embedding services, and client wrappers while gaining feature coverage (incremental parsing, SCIP cross-references, persistent embeddings).
+
+## Context
+
+- The trace repo (Go+Python+React) provides code-semantic + requirement traceability with graph storage
+- No OSS replacement exists for trace itself — its differentiation is the combination of code semantics, requirement traceability, and graph storage
+- However, the underlying infrastructure (parsers, embeddings, clients) can be replaced with specialized libraries
+- trace already uses NATS for messaging; JetStream adoption is a natural extension
+- See `research/external-library-leverage.md` for full analysis
+
+## Subtasks
+
+### T048: Replace custom code parsers with tree-sitter + scip-go
+
+**LOC saved**: 5-14K (2-6K from tree-sitter replacing custom parsers, 3-8K from scip-go replacing custom cross-reference indexing)
+
+**Steps**:
+1. Add `github.com/tree-sitter/go-tree-sitter` to Go module dependencies
+   - Note: CGo build requirement — ensure CI has C toolchain
+2. Replace custom language parsers with tree-sitter grammars:
+   - Identify all custom AST parsing code (likely in `internal/indexer/` or similar)
+   - Replace with tree-sitter `Parser` + language-specific grammars (Go, Python, TypeScript, Rust, etc.)
+   - Use tree-sitter's incremental parsing for file-change re-indexing
+3. Add `github.com/sourcegraph/scip-go` for deep Go cross-reference indexing:
+   - Replace custom Go symbol resolution with SCIP index generation
+   - SCIP provides definition, reference, and hover data in a standard format
+   - Note: Sourcegraph has commercial interests; pin version and evaluate license terms
+4. Update index storage to consume tree-sitter node types and SCIP occurrences
+5. Ensure backward compatibility with existing graph data (migration path for stored indexes)
+
+**Validation**:
+- tree-sitter parses all supported languages correctly
+- SCIP indexes match or exceed current cross-reference quality for Go
+- Incremental parsing works on file-change events
+- Existing graph queries still return correct results after migration
+
+### T049: Replace custom embedding service with chromem-go
+
+**LOC saved**: 1-3K
+
+**Steps**:
+1. Add `github.com/philippgille/chromem-go` to Go module dependencies
+2. Replace custom embedding storage/retrieval:
+   - Identify custom embedding service code (likely vector storage, similarity search)
+   - Replace with chromem-go's in-process embedding store
+   - chromem-go uses brute-force search — acceptable for per-repo scale; evaluate if cross-org scale needs a different solution later
+3. Configure persistent storage (chromem-go supports file-based persistence)
+4. Migrate existing embeddings or re-index (re-index is simpler if embedding model unchanged)
+
+**Validation**:
+- Embedding storage and retrieval works end-to-end
+- Similarity search returns equivalent results to current implementation
+- Persistence survives process restart
+
+### T050: Replace custom Neo4j client wrappers + optimize NATS JetStream
+
+**LOC saved**: 1-3.5K (0.5-1.5K from Neo4j driver, 0.5-2K from NATS JetStream)
+
+**Steps**:
+1. Replace custom Neo4j client wrappers with `github.com/neo4j/neo4j-go-driver/v5`:
+   - Identify custom Neo4j client code (connection pooling, query builders, result mappers)
+   - Replace with official driver's session management, result helpers, and built-in connection pooling
+   - Use driver's `ExecuteRead`/`ExecuteWrite` managed transaction APIs
+2. Optimize NATS usage with JetStream:
+   - trace already uses `github.com/nats-io/nats.go` for messaging
+   - Replace custom message routing/persistence with JetStream streams and consumers
+   - Use JetStream for durable event delivery (code change events, index update events)
+   - Eliminate custom retry/ack logic that JetStream provides natively
+
+**Validation**:
+- Neo4j queries execute correctly with official driver
+- Connection pooling and transaction management work under load
+- JetStream durable consumers receive all events without loss
+- No regression in message delivery latency
+
+## Definition of Done
+
+- [ ] tree-sitter replaces custom language parsers
+- [ ] scip-go provides Go cross-reference indexing
+- [ ] chromem-go replaces custom embedding storage
+- [ ] neo4j-go-driver v5 replaces custom Neo4j wrappers
+- [ ] NATS JetStream replaces custom message routing/persistence
+- [ ] All existing graph queries and searches return correct results
+- [ ] CI builds with CGo toolchain (for tree-sitter)
+
+## Risks
+
+- **CGo build complexity**: tree-sitter requires C compilation. Ensure CI images have gcc/clang. Consider static linking for deployment.
+- **chromem-go scale limits**: Brute-force search is O(n). Acceptable for per-repo embeddings (~10K-100K vectors); may need replacement (e.g., Qdrant) for cross-organization scale.
+- **scip-go Sourcegraph coupling**: Monitor for license changes or API instability. Pin to specific version, maintain ability to revert to custom indexing.
+- **JetStream operational overhead**: JetStream requires stream configuration and monitoring. Ensure proper stream retention policies to avoid unbounded storage growth.
+
+## Reviewer Guidance
+
+- Verify tree-sitter grammar coverage matches current language support
+- Check that SCIP index quality matches or exceeds custom Go cross-references
+- Ensure chromem-go persistence is properly configured (not in-memory only)
+- Verify Neo4j driver connection pooling settings are appropriate for workload
+- Check JetStream stream retention and consumer acknowledgment policies

--- a/agileplus-specs/phenotype-modular-arch/tasks/WP17-helioscli-fork-extraction.md
+++ b/agileplus-specs/phenotype-modular-arch/tasks/WP17-helioscli-fork-extraction.md
@@ -1,0 +1,106 @@
+---
+work_package_id: WP17
+title: 'heliosCLI: Fork-Specific Crate Extraction'
+lane: planned
+dependencies: [WP03]
+subtasks: [T051, T052]
+history:
+- date: '2026-03-03'
+  event: created
+  by: spec-kitty.tasks
+---
+
+# WP17: heliosCLI — Fork-Specific Crate Extraction
+
+**Implementation command**: `spec-kitty implement WP17 --base WP03`
+
+## Objective
+
+Extract ~20 `thegent-*` Rust crates from the heliosCLI codex fork into a standalone `phenotype-rs-agents` workspace. This separates Phenotype-specific agent orchestration code from the upstream codex fork, making future upstream rebases clean and predictable.
+
+## Context
+
+- heliosCLI is a fork of OpenAI Codex CLI with Phenotype-specific additions
+- ~20 `thegent-*` crates provide agent orchestration, routing, runtime, provider abstractions, and governance
+- These crates are NOT upstream codex code — they are Phenotype additions that should not live in the fork
+- Without extraction, every upstream rebase requires manually resolving conflicts in Phenotype-added files
+- WP03 (workspace structure) must be in place before extraction begins
+- Related: WP05 notes that `0xPlaygrounds/rig` can eventually replace `thegent-router`, `thegent-runtime`, and provider crates (2-4.5K LOC)
+
+## Subtasks
+
+### T051: Extract thegent-* crates to standalone workspace
+
+**Steps**:
+1. Identify all Phenotype-specific crates in heliosCLI:
+   - Scan `crates/thegent-*`, `helios-rs/crates/thegent-*`, and any other paths containing `thegent-` prefixed crates
+   - Catalog each crate: name, purpose, dependencies on codex crates, dependencies on other thegent crates
+2. Create `phenotype-rs-agents` repository/workspace:
+   - Initialize Cargo workspace
+   - Set up Bazel BUILD files mirroring heliosCLI patterns
+3. Move crates:
+   - Copy crate source to new workspace
+   - Update `Cargo.toml` for each crate (adjust paths, add git/path dependencies back to codex types if needed)
+   - Ensure internal thegent-* cross-dependencies resolve within the new workspace
+4. Update heliosCLI to consume extracted crates:
+   - Add `phenotype-rs-agents` as a Cargo workspace dependency (git or path)
+   - Replace local crate references with external dependency references
+   - Verify `cargo build --workspace` and `cargo test --workspace` pass in heliosCLI
+5. Verify standalone build:
+   - `cargo build --workspace` in `phenotype-rs-agents`
+   - `cargo test --workspace` in `phenotype-rs-agents`
+   - `cargo clippy --workspace -- -D warnings` in `phenotype-rs-agents`
+
+**Validation**:
+- heliosCLI builds and all tests pass with crates consumed externally
+- `phenotype-rs-agents` builds and tests independently
+- No `thegent-*` source directories remain in heliosCLI (only dependency references)
+
+### T052: Upstream sync strategy + automation
+
+**Steps**:
+1. Create upstream sync documentation:
+   - Document which files/directories are upstream codex (to be rebased)
+   - Document which files/directories are Phenotype additions (now extracted or minimal glue)
+   - Document remaining Phenotype modifications to upstream files (patches, config changes)
+   - Create a manifest file (e.g., `upstream-manifest.json`) listing every file with its provenance: `upstream`, `phenotype`, or `modified`
+2. Create sync automation script (`scripts/upstream-sync.sh`):
+   - Fetch latest upstream codex tags/branches
+   - Diff upstream changes against local state
+   - Flag conflicts between upstream changes and Phenotype modifications
+   - Generate a report: new upstream files, modified upstream files, conflict files
+3. Add CI job (`.github/workflows/upstream-sync-check.yml`):
+   - Run weekly (or on-demand) to check for new upstream releases
+   - Run the sync script and post results as a GitHub issue or PR comment
+   - Flag if any Phenotype-modified upstream files have changed upstream
+
+**Validation**:
+- Upstream manifest correctly classifies all files
+- Sync script detects upstream changes and flags conflicts
+- CI job runs and produces actionable reports
+- A simulated upstream rebase completes cleanly (no thegent-* conflicts)
+
+## Definition of Done
+
+- [ ] All thegent-* crates extracted to `phenotype-rs-agents` workspace
+- [ ] heliosCLI consumes extracted crates as external dependencies
+- [ ] Both workspaces build, test, and lint cleanly
+- [ ] Upstream manifest documents file provenance
+- [ ] Sync script detects upstream changes and flags conflicts
+- [ ] CI job automates weekly upstream sync checks
+- [ ] No thegent-* source code remains in heliosCLI repo
+
+## Risks
+
+- **Dependency cycles**: thegent-* crates may depend on codex core types. These become cross-workspace dependencies — ensure they are pinned to codex versions, not local paths.
+- **Bazel build graph**: Extracting crates changes the Bazel dependency graph. Ensure BUILD.bazel files are updated in both workspaces.
+- **Runtime linkage**: If any thegent-* crates use `inventory` or similar link-time registration, extraction may break registration. Test thoroughly.
+- **Git history**: Moving code loses per-file git history in the new repo. Use `git log --follow` or document the provenance commit in the new repo's initial commit message.
+
+## Reviewer Guidance
+
+- Verify no thegent-* source code remains in heliosCLI after extraction
+- Check that cross-workspace dependencies are version-pinned, not path-based (for CI reproducibility)
+- Verify the upstream manifest is complete — every file in heliosCLI should be classified
+- Test the sync script against a known upstream diff to confirm conflict detection works
+- Ensure Bazel targets are updated in both workspaces

--- a/agileplus-specs/phenotype-modular-arch/tasks/WP18-helioscli-god-module-decomposition.md
+++ b/agileplus-specs/phenotype-modular-arch/tasks/WP18-helioscli-god-module-decomposition.md
@@ -1,0 +1,126 @@
+---
+work_package_id: WP18
+title: 'heliosCLI: God Module Decomposition + Safety'
+lane: planned
+dependencies: [WP03]
+subtasks: [T053, T054, T055]
+history:
+- date: '2026-03-03'
+  event: created
+  by: spec-kitty.tasks
+---
+
+# WP18: heliosCLI — God Module Decomposition + Safety
+
+**Implementation command**: `spec-kitty implement WP18 --base WP03`
+
+## Objective
+
+Decompose the 6 largest and most complex Rust files in heliosCLI (all >5,000 LOC with the highest branch keyword density), eliminate production `unwrap()` crash surface, and clean up dead code and suppressions. This directly addresses the top quality and safety findings from the codebase quality analysis.
+
+## Context
+
+- heliosCLI has 422K Rust LOC across 65 crates and 956 .rs files
+- 6 files exceed 5,000 LOC and are simultaneously the highest-complexity modules by branch keyword density
+- 934 `unwrap()` calls in production (non-test) Rust code represent a significant crash risk surface
+- 54 `#[allow(dead_code)]` suppressions and 100 `// TODO` comments indicate accumulated technical debt
+- Connector crates (ollama, lmstudio, chatgpt, backend-client) duplicate near-identical interfaces
+- WP03 (workspace structure) must be in place before decomposition begins
+
+## Subtasks
+
+### T053: Split top 4 god modules
+
+**Steps**:
+1. Decompose `codex.rs` (9,571 LOC, 369 branches):
+   - `codex.rs` — entry point and orchestration only
+   - `session.rs` — session lifecycle and state management
+   - `model_config.rs` — model configuration and selection
+   - `tool_registry.rs` — tool registration and dispatch
+2. Decompose `chat_composer.rs` (9,499 LOC, 469 branches — highest complexity in codebase):
+   - `chat_composer.rs` — top-level composition orchestration
+   - `message_builder.rs` — message construction and formatting
+   - `context_window.rs` — context window management and truncation
+3. Decompose `codex_message_processor.rs` (8,460 LOC, 423 branches):
+   - Split by message type handlers — one module per message category
+   - Extract shared message processing utilities
+4. Decompose `chatwidget.rs` (8,146 LOC, 457 branches):
+   - Split by rendering concern — input handling, display rendering, layout, widget state
+5. Update all `mod.rs` and `use` declarations to re-export public API unchanged
+6. Update Bazel BUILD files for new source files
+
+**Validation**:
+- No file exceeds 3,000 LOC after split
+- `cargo build --workspace` succeeds
+- `cargo test --workspace` — all tests pass
+- `cargo clippy --workspace -- -D warnings` clean
+- Public API unchanged (no downstream breakage)
+
+### T054: Production unwrap() elimination
+
+**Steps**:
+1. Audit all 934 `unwrap()` calls in production (non-test) Rust code
+2. Prioritize by crash risk — files with highest concentration:
+   - `apply-patch/lib.rs` — 74 unwrap() calls
+   - `network-proxy/runtime.rs` — 38 unwrap() calls
+   - `turn_diff_tracker.rs` — 37 unwrap() calls
+   - `network-proxy/config.rs` — 33 unwrap() calls
+   - `network-proxy/policy.rs` — 29 unwrap() calls
+3. Replace each `unwrap()` with appropriate error handling:
+   - `.context("descriptive message")?` using anyhow for fallible operations
+   - `.expect("invariant: reason")` only where the unwrap is provably safe with a documented invariant
+   - Proper `match` or `if let` for cases requiring specific error paths
+4. Add `#![deny(clippy::unwrap_used)]` to crates that are fully cleaned
+
+**Validation**:
+- `grep -r 'unwrap()' --include='*.rs'` in non-test files shows <100 remaining
+- All remaining `unwrap()` calls have an adjacent `// SAFETY:` or `// INVARIANT:` comment justifying them
+- `cargo test --workspace` — all tests pass
+- No new panics introduced (run with `RUST_BACKTRACE=1` in CI)
+
+### T055: Dead code audit + cleanup
+
+**Steps**:
+1. Audit all 54 `#[allow(dead_code)]` suppressions:
+   - If the code is actually dead, delete it
+   - If the code is used but the compiler cannot see the usage (e.g., cfg-gated, test-only), document with an inline comment explaining why the suppression is needed
+   - Target: <10 remaining, all with justification comments
+2. Triage all 100 `// TODO` comments:
+   - Convert actionable items into tracked issues
+   - Remove stale or completed TODOs
+   - For TODOs that represent intentional future work, add an issue reference: `// TODO(#123): description`
+3. Connector crate deduplication:
+   - ollama, lmstudio, chatgpt, and backend-client crates implement near-identical model list/connect interfaces
+   - Extract a shared `ModelConnector` trait into a common crate (e.g., `codex-connector-core`)
+   - Define the trait with standard methods: `list_models()`, `connect()`, `health_check()`, `name()`
+   - Refactor each connector to implement the shared trait
+   - Remove duplicated interface definitions
+
+**Validation**:
+- `grep -r '#\[allow(dead_code)\]' --include='*.rs'` shows <10 remaining, each with inline justification
+- `grep -r '// TODO' --include='*.rs'` shows 0 untracked TODOs (all either removed or have issue references)
+- `ModelConnector` trait exists in a shared crate; `grep -r "class BaseAdapter\|impl.*Connector" --include='*.rs'` confirms all connectors use it
+- `cargo build --workspace` and `cargo test --workspace` pass
+
+## Definition of Done
+
+- [ ] Top 4 god modules decomposed — no file >3,000 LOC
+- [ ] Production unwrap() count reduced from 934 to <100, all remaining justified
+- [ ] `#[allow(dead_code)]` count reduced from 54 to <10, all remaining justified
+- [ ] 100 `// TODO` comments triaged — zero untracked
+- [ ] Shared `ModelConnector` trait extracted, 4 connector crates refactored
+- [ ] All tests pass, clippy clean, no public API changes
+
+## Risks
+
+- **Splitting god modules may break internal state assumptions**: Some modules rely on private fields being accessible within the same file. Splitting requires careful `pub(crate)` scoping.
+- **unwrap() elimination may change error behavior**: Some unwraps mask intentional panics (e.g., initialization assertions). Each must be individually assessed.
+- **Connector trait extraction may reveal subtle behavioral differences**: The "near-identical" interfaces may have provider-specific quirks that a uniform trait cannot capture. Allow trait default methods or associated types for provider-specific extensions.
+
+## Reviewer Guidance
+
+- Verify that decomposed modules maintain the same public API via re-exports
+- Check that unwrap replacements use descriptive context strings, not generic messages
+- Confirm dead_code suppressions that remain have meaningful justification comments
+- Verify the ModelConnector trait captures the full interface, not just a subset
+- Run the full test suite with `RUST_BACKTRACE=1` to catch any new panic paths

--- a/agileplus-specs/phenotype-modular-arch/tasks/WP19-thegent-migration-cleanup.md
+++ b/agileplus-specs/phenotype-modular-arch/tasks/WP19-thegent-migration-cleanup.md
@@ -1,0 +1,129 @@
+---
+work_package_id: WP19
+title: 'thegent: Migration Cleanup + God Function Decomposition'
+lane: planned
+dependencies: [WP09]
+subtasks: [T056, T057, T058]
+history:
+- date: '2026-03-03'
+  event: created
+  by: spec-kitty.tasks
+---
+
+# WP19: thegent — Migration Cleanup + God Function Decomposition
+
+**Implementation command**: `spec-kitty implement WP19 --base WP09`
+
+## Objective
+
+Complete the stalled thegent package migration by deleting 469 duplicate files, decompose the largest function in the entire ecosystem (run_impl_core at 1,022 lines), and reduce the 221-file circular dependency surface. This addresses the top three quality findings for thegent from the codebase quality analysis.
+
+## Context
+
+- thegent has ~160K Python LOC (unique, excluding duplicates)
+- Package migration is 32% complete: 469 of 1,467 src/ files have been migrated to packages/ but the src/ copies were never deleted
+- `run_impl_core` at 1,022 lines is the single largest function in the entire Phenotype ecosystem
+- 221 files (15% of the codebase) use `TYPE_CHECKING` blocks to work around circular imports — a massive dependency health indicator
+- `run_execution_core_helpers.py` exists in 3 locations with potential divergence
+- WP09 (thegent package migration) must be in place before this cleanup begins
+
+## Subtasks
+
+### T056: Delete 469 duplicate files from src/thegent/
+
+**Steps**:
+1. Generate the definitive list of byte-identical files between `src/thegent/` and `packages/thegent-*/`:
+   - Use `diff -rq src/thegent packages/` or equivalent checksum comparison
+   - Catalog each duplicate pair: src path, packages path, byte count
+2. Delete the `src/thegent/` copy for all 469 confirmed duplicates
+3. Update all import statements across the codebase to point to `packages/` locations:
+   - Search for `from thegent.` and `import thegent.` patterns
+   - Update to the corresponding `packages/thegent-*` import path
+4. Fix the tri-copy of `run_execution_core_helpers.py`:
+   - Identify which of the 3 copies is canonical (most recent, most complete)
+   - Delete the other 2 copies
+   - Update all imports to point to the canonical location
+5. Remove any now-empty directories under `src/thegent/`
+
+**Validation**:
+- `diff -rq src/thegent packages/` shows no remaining identical files
+- Estimated LOC reduction: ~100K (duplicate elimination)
+- All tests pass (`pytest` or equivalent test runner)
+- No import errors at runtime — `python -c "import thegent"` succeeds
+- `src/thegent/` directory either removed entirely or contains only non-migrated files with a tracking manifest
+
+### T057: Decompose run_impl_core (1,022 lines)
+
+**Steps**:
+1. Analyze `run_impl_core` to identify logical segments:
+   - Step execution logic
+   - Context and state management
+   - Result collection and aggregation
+   - Error handling and recovery
+2. Extract into focused modules:
+   - `run_impl_core()` — orchestration only, <100 lines, calls into extracted modules
+   - `step_executor.py` — individual step execution logic
+   - `context_manager.py` — context accumulation, state tracking, window management
+   - `result_aggregator.py` — result collection, formatting, output handling
+3. Also decompose `bg_impl_core` (513 lines) in the same file:
+   - Apply the same extraction pattern
+   - Share common utilities with `run_impl_core` decomposition where applicable
+4. Ensure all extracted functions have type annotations and docstrings
+
+**Validation**:
+- No function exceeds 200 lines in the decomposed modules
+- `run_impl_core()` orchestration body is <100 lines
+- All tests pass
+- Type checking passes (`mypy` or `pyright`)
+- No behavioral changes — identical output for identical inputs
+
+### T058: Break circular dependency surface (221 TYPE_CHECKING files)
+
+**Steps**:
+1. Map the circular dependency graph:
+   - Identify which modules import from each other via TYPE_CHECKING
+   - Cluster by dependency group: cli<->agents, execution<->orchestration, governance<->core
+   - Rank files by import count (most-imported files first)
+2. Extract shared types into `packages/thegent-core/types/`:
+   - Create type-only modules for shared data classes, protocols, and type aliases
+   - Move type definitions that cause circular imports into the shared types package
+   - Update TYPE_CHECKING imports to regular imports from the new shared location
+3. Phase approach — fix top 50 files by import count first:
+   - Prioritize files that are imported by the most other TYPE_CHECKING blocks
+   - Each fix should eliminate TYPE_CHECKING usage in multiple downstream files
+4. Document remaining legitimate TYPE_CHECKING uses:
+   - Forward references within the same package
+   - Genuinely optional type hints for rarely-used integrations
+
+**Validation**:
+- `grep -r 'TYPE_CHECKING' --include='*.py' | wc -l` shows <50 files (down from 221)
+- All remaining TYPE_CHECKING uses have an inline comment explaining why they are necessary
+- No new circular imports introduced — `import-linter` or equivalent passes
+- All tests pass
+- Type checking passes
+
+## Definition of Done
+
+- [ ] 469 duplicate files deleted from src/thegent/, ~100K LOC eliminated
+- [ ] Tri-copy of run_execution_core_helpers.py resolved to single canonical location
+- [ ] run_impl_core decomposed from 1,022 lines to <100 line orchestrator + extracted modules
+- [ ] bg_impl_core (513 lines) similarly decomposed
+- [ ] No function >200 lines in decomposed modules
+- [ ] TYPE_CHECKING usage reduced from 221 files to <50
+- [ ] Shared types extracted to packages/thegent-core/types/
+- [ ] All tests pass, type checking clean, no import errors
+
+## Risks
+
+- **Diverged duplicates**: Some of the 469 "duplicates" may have diverged since migration. Byte-identical check mitigates this, but verify with checksums, not just file names.
+- **Import chain breakage**: Deleting src/thegent/ copies may break transitive imports that other packages depend on. Run full import resolution before deleting.
+- **run_impl_core hidden state**: A 1,022-line function likely relies on local variable state accumulated across its body. Extraction requires careful identification of shared state and explicit parameter passing.
+- **TYPE_CHECKING removal may slow imports**: If circular deps exist because of heavy import-time computation, removing TYPE_CHECKING guards may increase startup time. Monitor import time before and after.
+
+## Reviewer Guidance
+
+- Verify the 469 duplicate deletion used byte-level comparison, not just filename matching
+- Check that run_impl_core decomposition preserves the exact execution order and error handling semantics
+- Confirm TYPE_CHECKING removals do not introduce import-time circular failures — run `python -c "import thegent"` as a smoke test
+- Verify shared types in thegent-core/types/ do not themselves create new dependency edges
+- Check that the remaining <50 TYPE_CHECKING files each have justification comments

--- a/agileplus-specs/phenotype-modular-arch/tasks/WP20-portage-trace-quality.md
+++ b/agileplus-specs/phenotype-modular-arch/tasks/WP20-portage-trace-quality.md
@@ -1,0 +1,153 @@
+---
+work_package_id: WP20
+title: 'portage + trace: Code Quality Remediation'
+lane: planned
+dependencies: []
+subtasks: [T059, T060, T061, T062]
+history:
+- date: '2026-03-03'
+  event: created
+  by: spec-kitty.tasks
+---
+
+# WP20: portage + trace — Code Quality Remediation
+
+**Implementation command**: `spec-kitty implement WP20`
+
+## Objective
+
+Remediate the top code quality issues in portage and trace: extract a shared BaseAdapter from 8 duplicate definitions in portage, decompose god functions in both repos, split trace's 9,274-line god module, remove deprecated dependencies, and clean up Python type debt. This WP has no dependencies and can proceed in parallel with other work packages.
+
+## Context
+
+- portage has 103K Python LOC with 8 independently defined BaseAdapter classes sharing identical method signatures
+- portage's `create_app` (1,164 lines) and `jobs.py::start` (856 lines) are god functions
+- trace has 678K LOC (Go+Python+TS) with `api/main.py` at 9,274 lines — the most severe god module in the entire ecosystem
+- trace uses gorilla/mux (archived/deprecated) alongside echo — redundant routers
+- trace has 390 Python type suppressions (`type: ignore` + `noqa`) indicating retrofitted typing
+- trace has 5 `.go.bak` dead backup files in handlers/
+
+## Subtasks
+
+### T059: portage — Extract shared BaseAdapter
+
+**Steps**:
+1. Audit all 8 independent BaseAdapter definitions across the 41 adapters:
+   - Document the method signatures each defines: `run`, `score`, `name`, and any additional methods
+   - Identify the `RequireNameMeta` metaclass duplicated across at least 4 adapters
+   - Catalog any per-adapter deviations from the common interface
+2. Create `src/harbor/adapters/base.py` with canonical definitions:
+   - `BaseAdapter` abstract class with standard methods: `run()`, `score()`, `name()`
+   - `RequireNameMeta` metaclass (single definition)
+   - Common adapter utilities: shared scoring patterns, result formatting helpers
+3. Refactor all 8 adapters to import from `src/harbor/adapters/base.py`:
+   - Remove local BaseAdapter class definitions
+   - Remove local RequireNameMeta definitions
+   - Update imports
+4. Extract additional shared adapter utilities where common patterns exist
+
+**Validation**:
+- `grep -r "class BaseAdapter" adapters/` returns 0 results (all use shared import)
+- `grep -r "RequireNameMeta" adapters/` shows only imports, no definitions
+- All 41 adapters import from the shared base
+- All tests pass
+
+### T060: portage — Split god functions
+
+**Steps**:
+1. Decompose `server.py::create_app` (1,164 lines):
+   - `server.py` — app factory and setup (<200 lines)
+   - `routes.py` — route registration and URL mapping
+   - `handlers.py` — request handler implementations
+   - `middleware.py` — middleware chain configuration
+2. Decompose `jobs.py::start` (856 lines):
+   - `jobs.py` — job orchestration and scheduling (<200 lines)
+   - `job_runner.py` — individual job execution logic
+   - `job_config.py` — job configuration parsing and validation
+3. Split `terminus_2.py` (1,838 lines):
+   - `terminus_parser.py` — input parsing and tokenization
+   - `terminus_renderer.py` — output rendering and formatting
+   - `terminus_state.py` — state machine and lifecycle management
+
+**Validation**:
+- No function exceeds 200 lines in the split files
+- `create_app` factory body is <200 lines
+- `jobs.py::start` orchestration body is <200 lines
+- All tests pass
+- No behavioral changes — identical API surface
+
+### T061: trace — Split api/main.py (9,274 lines) + remove deprecated deps
+
+**Steps**:
+1. Decompose `api/main.py` (9,274 lines — most severe god module in ecosystem):
+   - `main.py` — app setup and entry point only (<200 lines)
+   - `routers/` — route handlers (partially exists, complete the extraction)
+   - `middleware/` — middleware definitions and configuration
+   - `startup.py` — initialization, database connections, service registration
+2. Remove gorilla/mux (archived/deprecated):
+   - Identify all routes currently using gorilla/mux
+   - Migrate to echo (already in use for other routes)
+   - Remove gorilla/mux from `go.mod` and `go.sum`
+3. Consolidate pgxmock versions:
+   - Remove pgxmock v3 dependency
+   - Standardize all test files on pgxmock v4
+   - Update import paths in affected test files
+4. Delete 5 `.go.bak` dead backup files in `handlers/`:
+   - Verify they are not referenced anywhere
+   - Remove from repository
+
+**Validation**:
+- `api/main.py` is <500 LOC after split
+- `go mod tidy` shows no gorilla/mux in dependency tree
+- `grep -r "pgxmock/v3" --include='*.go'` returns 0 results
+- No `.go.bak` files remain in handlers/
+- `go build ./...` succeeds
+- All Go and Python tests pass
+
+### T062: trace — Clean Python type debt (390 suppressions)
+
+**Steps**:
+1. Catalog all 390 `type: ignore` and `noqa` suppressions in `src/`:
+   - Group by file (identify files with highest concentration)
+   - Categorize by suppression type (missing types, incompatible types, import errors, etc.)
+2. Fix the top 50 suppressions by file concentration:
+   - Add proper type annotations where suppressions hide missing types
+   - Fix incompatible type assignments with proper casting or interface changes
+   - Resolve import-related suppressions by fixing the underlying import structure
+3. For suppressions that remain, add specific error codes and justification:
+   - Change bare `# type: ignore` to `# type: ignore[specific-error] -- reason`
+   - Change bare `# noqa` to `# noqa: EXXX -- reason`
+
+**Validation**:
+- Total suppression count reduced from 390 to <100
+- All remaining suppressions have specific error codes and inline justification comments
+- No bare `# type: ignore` or `# noqa` without error codes
+- Type checking passes (`mypy` or `pyright`)
+- All tests pass
+
+## Definition of Done
+
+- [ ] Shared BaseAdapter extracted in portage — 0 local definitions remain
+- [ ] portage god functions decomposed — no function >200 lines
+- [ ] trace api/main.py split from 9,274 to <500 LOC
+- [ ] gorilla/mux removed, all routing on echo
+- [ ] pgxmock consolidated on v4
+- [ ] 5 .go.bak files deleted
+- [ ] Python type suppressions reduced from 390 to <100, all justified
+- [ ] All tests pass in both repos
+
+## Risks
+
+- **BaseAdapter extraction may reveal adapter-specific quirks**: Some adapters may have overloaded or extended the common interface in incompatible ways. Allow the shared trait to support optional extension methods.
+- **api/main.py split may break initialization order**: A 9,274-line file likely has implicit ordering dependencies. Map the initialization sequence before splitting.
+- **gorilla/mux removal may affect middleware chains**: gorilla/mux middleware and echo middleware have different signatures. Verify middleware compatibility before migration.
+- **Type suppression removal may surface real type errors**: Some suppressions may mask genuine type incompatibilities that require interface changes to fix. Budget time for actual type fixes, not just annotation additions.
+
+## Reviewer Guidance
+
+- Verify the shared BaseAdapter captures all methods used by the 8 original definitions, not just the common subset
+- Check that create_app split preserves the exact middleware ordering
+- Confirm api/main.py split maintains the startup initialization sequence
+- Verify gorilla/mux removal does not drop any routes — compare route count before and after
+- Check that type suppression removals include actual type fixes, not just suppression replacement
+- Verify .go.bak files are truly unreferenced before deletion

--- a/agileplus-specs/phenotype-modular-arch/tasks/WP21-cliproxy-god-module-auth-cleanup.md
+++ b/agileplus-specs/phenotype-modular-arch/tasks/WP21-cliproxy-god-module-auth-cleanup.md
@@ -1,0 +1,116 @@
+---
+work_package_id: "WP21"
+title: "cliproxyapi++: God Module Split + Auth Consolidation"
+lane: "planned"
+dependencies: ["WP06"]
+subtasks: ["T063", "T064", "T065"]
+history:
+  - date: "2026-03-03"
+    event: "created"
+    by: "spec-kitty.tasks"
+---
+
+# WP21: cliproxyapi++ — God Module Split + Auth Consolidation
+
+**Implementation command**: `spec-kitty implement WP21`
+
+## Objective
+
+Break apart the largest god modules in cliproxyapi++ and consolidate the duplicated auth directory. kiro_executor.go at 4,691 LOC is 3x the next largest executor, auth sprawls 21K LOC across 14 providers, and multiple functions exceed 200 lines. This WP reduces file sizes, eliminates dead code, and enforces complexity ceilings.
+
+## Context
+
+- cliproxyapi++ has 15 executor files totaling 15,403 LOC with kiro_executor.go as the worst offender
+- 21,441 LOC of auth code across 14 provider subdirectories, 6 distinct auth mechanisms
+- Functions exceeding 200 lines: `executeClaudeNonStream` (205L), `ExecuteStream` (198L), `Execute` (149L)
+- `internal/auth/` (~600L) appears dead — superseded by `pkg/llmproxy/auth/`
+- `config/config.go` (2,266L) and `sdk/cliproxy/service.go` (1,777L) are additional god modules
+- Depends on WP06 (executor core extraction) — splits happen after interface is defined
+- See `kitty-specs/002-phenotype-modular-arch/research/codebase-quality-analysis.md` for metrics
+
+## Subtasks
+
+### T063: Split kiro_executor.go (4,691 LOC)
+
+**Steps**:
+1. Analyze kiro_executor.go to identify natural seam boundaries: execution flow, session management, protocol handling, auth flows
+2. Split into four files:
+   - `kiro_executor.go` — main `Execute`/`Stream` entry points (<800 LOC)
+   - `kiro_session.go` — session creation, renewal, lifecycle management
+   - `kiro_protocol.go` — Kiro-specific protocol marshaling and response handling
+   - `kiro_auth.go` — AWS STS/SSO/OIDC flows (absorbs code from `auth/kiro/sso_oidc.go` (1,489L), `auth/kiro/oauth_web.go` (912L), and `auth/kiro/aws.go` (597L) after WP07 auth consolidation)
+3. Split antigravity_executor.go (1,783L) into:
+   - `antigravity_executor.go` — main executor logic
+   - `antigravity_auth.go` — provider-specific auth
+   - `antigravity_format.go` — format conversion between provider wire formats
+4. Ensure all split files are in the same package — no import changes required for callers
+5. Run full test suite after each file extraction
+
+**Validation**:
+- No executor file exceeds 1,000 LOC
+- `go build ./...` passes
+- `go test ./...` passes with no regressions
+
+### T064: Delete dead internal/auth/ directory (~600 LOC)
+
+**Steps**:
+1. Inventory `internal/auth/` — contains claude, copilot, gemini subdirectories
+2. Confirm these duplicate `pkg/llmproxy/auth/` by comparing function signatures and behavior
+3. Run `grep -r 'internal/auth' --include='*.go'` across the entire repo to confirm zero imports
+4. If zero imports: delete `internal/auth/` directory entirely
+5. If any imports found: update them to point to `pkg/llmproxy/auth/` equivalents, then delete
+
+**Validation**:
+- `grep -r 'internal/auth' --include='*.go'` returns 0 results
+- `go build ./...` passes
+- No test regressions
+
+### T065: Split remaining god functions and files
+
+**Steps**:
+1. Split `antigravity_executor.go::executeClaudeNonStream` (205 lines):
+   - Extract format conversion into `antigravity_format.go::convertClaudeResponse`
+   - Extract retry logic into a helper using retry-go (from WP06)
+2. Split `antigravity_executor.go::ExecuteStream` (198 lines):
+   - Extract SSE event parsing into `antigravity_stream.go::parseSSEEvents`
+   - Extract stream chunk assembly into `antigravity_stream.go::assembleStreamChunks`
+3. Split `claude_executor.go::ExecuteStream` (148 lines):
+   - Extract streaming response parser into `claude_stream.go::parseStreamResponse`
+4. Split `config/config.go` (2,266L) into:
+   - `config.go` — core config loading, merging, and access (<800L)
+   - `config_models.go` — model/provider type definitions and defaults
+   - `config_validation.go` — validation rules, constraint checking
+5. Split `sdk/cliproxy/service.go` (1,777L) into:
+   - `service.go` — server setup, lifecycle, dependency injection (<600L)
+   - `service_handlers.go` — HTTP handler registrations and route definitions
+   - `service_middleware.go` — middleware chain (auth, logging, rate limiting)
+6. Run tests after each split
+
+**Validation**:
+- No function exceeds 100 lines
+- No file exceeds 1,500 LOC
+- `go build ./...` passes
+- `go test ./...` passes with no regressions
+
+## Definition of Done
+
+- [ ] kiro_executor.go split into 4 files, each <1,000 LOC
+- [ ] antigravity_executor.go split into executor + auth + format files
+- [ ] `internal/auth/` deleted with zero import breakage
+- [ ] `config/config.go` split into 3 files
+- [ ] `sdk/cliproxy/service.go` split into 3 files
+- [ ] No function >100 lines, no file >1,500 LOC
+- [ ] `go build ./...` and `go test ./...` pass
+
+## Risks
+
+- **Merge conflicts with WP06/WP07**: This WP touches many of the same files as executor extraction and auth consolidation. Coordinate sequencing — WP06 lands first, then WP07, then WP21.
+- **Kiro auth absorption timing**: T063 absorbs kiro auth files that WP07 may restructure. If WP07 changes auth directory layout, T063 must adapt to the new locations.
+- **Hidden coupling in god functions**: Functions >200 lines often have non-obvious shared state. Extract carefully and verify with integration tests, not just unit tests.
+
+## Reviewer Guidance
+
+- Verify that each split file has a clear single responsibility — no "misc" or "utils" catch-all files
+- Check that no split introduced new public API surface — all splits should be package-internal reorganization
+- Confirm `internal/auth/` deletion is safe by reviewing the grep results for zero references
+- Ensure config split preserves the exact same config loading behavior — no field reordering or default changes

--- a/agileplus-specs/phenotype-modular-arch/tasks/WP22-heliosapp-test-coverage.md
+++ b/agileplus-specs/phenotype-modular-arch/tasks/WP22-heliosapp-test-coverage.md
@@ -1,0 +1,120 @@
+---
+work_package_id: "WP22"
+title: "heliosApp: Critical Test Coverage + agentapi++ Dedup"
+lane: "planned"
+dependencies: ["WP11"]
+subtasks: ["T066", "T067", "T068"]
+history:
+  - date: "2026-03-03"
+    event: "created"
+    by: "spec-kitty.tasks"
+---
+
+# WP22: heliosApp — Critical Test Coverage + agentapi++ Dedup
+
+**Implementation command**: `spec-kitty implement WP22`
+
+## Objective
+
+Close the test coverage gap in heliosApp where 11 of 17 runtime modules have zero tests, and eliminate the full inner-directory duplication in agentapi++. heliosApp has excellent code quality (0 `any`, 0 `console.log`) but the entire audit subsystem (2,577 LOC, 12 files) and protocol bus (805 LOC) are completely untested. agentapi++ contains ~50% duplicate LOC from an inner copy of itself.
+
+## Context
+
+- heliosApp: 78K TS, 8 god modules, 0 `any` casts, 0 `console.log` — code quality is high but test coverage is critically low
+- Audit subsystem: 2,577 LOC across 12 files with zero test coverage — this is the persistence and replay layer
+- Protocol bus: 805 LOC, the IPC backbone for inter-component messaging — untested
+- WP11 is building audit-core on Emmett — tests should target the Emmett-backed implementation
+- agentapi++: 16,804 LOC total but contains `agentapi-plusplus/agentapi-plusplus/` inner duplicate (~50% of LOC)
+- See `kitty-specs/002-phenotype-modular-arch/research/codebase-quality-analysis.md` for metrics
+
+## Subtasks
+
+### T066: Test audit subsystem (2,577 LOC, 12 files, 0 tests)
+
+**Steps**:
+1. Create test files for each audit module, prioritized by criticality:
+   - **P0 (core correctness)**: `ledger.test.ts` (351L source), `sqlite-store.test.ts` (293L), `replay.test.ts` (149L)
+   - **P1 (data flow)**: `sink.test.ts` (282L), `api.test.ts` (265L), `bus-subscriber.test.ts` (176L), `export.test.ts` (176L)
+   - **P2 (supporting)**: `ring-buffer.test.ts` (219L), `event.test.ts` (212L), `audit-sink.test.ts` (210L), `retention.test.ts` (152L), `snapshot.test.ts` (92L)
+2. For ledger tests: verify event append, ordering, idempotency, and recovery after crash
+3. For sqlite-store tests: verify persistence round-trip, schema migration, concurrent access
+4. For replay tests: verify event replay produces identical state, handles corrupted events gracefully
+5. Important: WP11 is building audit-core on Emmett — write tests against the Emmett-backed implementation where available, with adapters for the current implementation as fallback
+6. Use existing heliosApp test patterns and framework (vitest or equivalent)
+
+**Validation**:
+- 100% file coverage for `audit/` — every source file has a corresponding test file
+- All tests pass
+- Coverage >=80% for P0 files (ledger, sqlite-store, replay)
+
+### T067: Test protocol bus + critical runtime modules
+
+**Steps**:
+1. Create `protocol/bus.test.ts` for the IPC backbone (805L):
+   - Test message routing between registered handlers
+   - Test subscription and unsubscription lifecycle
+   - Test topic filtering and wildcard matching
+   - Test error propagation when handlers throw
+   - Test concurrent message delivery ordering guarantees
+2. Create test files for untested config modules (5 files):
+   - Test config validation rules (required fields, type coercion, defaults)
+   - Test config merging precedence (file < env < CLI args)
+   - Test error messages for invalid configurations
+3. Create test files for untested lanes modules (13 files):
+   - Test lane orchestration: creation, activation, deactivation, cleanup
+   - Test lane isolation — operations in one lane do not affect another
+4. Create test files for untested policy modules (5 files):
+   - Test policy evaluation against sample agent actions
+   - Test policy composition (allow + deny rules)
+5. Create test files for untested sessions modules (4 files):
+   - Test session creation, persistence, and restoration
+   - Test session expiry and cleanup
+
+**Validation**:
+- `protocol/` has >=1 test file with >=10 test cases
+- `config/` has >=1 test file
+- All tests pass
+
+### T068: agentapi++ — Remove inner directory duplication
+
+**Steps**:
+1. Identify the duplication: agentapi++ contains `agentapi-plusplus/agentapi-plusplus/` as a full inner copy
+2. Compare outer and inner directories to determine which is canonical:
+   - Check git history — which was committed first?
+   - Check imports — which do other repos reference?
+   - Check CI/build scripts — which path do they use?
+3. Likely outcome: the outer directory is canonical. Delete the inner `agentapi-plusplus/agentapi-plusplus/` directory
+4. Search for and update any references to the inner path:
+   - CI workflow files (`.github/workflows/`)
+   - Build scripts and Makefiles
+   - Import paths in Go files
+   - Documentation references
+5. Verify the repo still builds and tests pass after deletion
+
+**Validation**:
+- `find . -name 'agentapi-plusplus' -type d` returns only the repo root
+- `go build ./...` passes
+- `go test ./...` passes
+- No CI scripts reference the deleted inner path
+
+## Definition of Done
+
+- [ ] All 12 audit files have corresponding test files
+- [ ] Audit P0 files (ledger, sqlite-store, replay) have >=80% coverage
+- [ ] Protocol bus has >=10 test cases covering routing, subscription, and error handling
+- [ ] Config and policy modules each have >=1 test file
+- [ ] agentapi++ inner directory duplication removed (~8K LOC deleted)
+- [ ] All tests pass across heliosApp and agentapi++
+
+## Risks
+
+- **WP11 Emmett migration**: If WP11 significantly changes the audit subsystem API, tests written here may need rewriting. Mitigate by writing tests against the interface/contract, not implementation details.
+- **Protocol bus concurrency**: The bus likely uses async patterns that are hard to test deterministically. Use controlled schedulers or explicit flush/drain in tests.
+- **agentapi++ canonical determination**: If both inner and outer directories have diverged, a merge may be needed instead of a simple delete. Check file-level diffs before deleting.
+
+## Reviewer Guidance
+
+- Verify audit tests cover failure modes (corrupted data, full disk, concurrent writes) not just happy paths
+- Check that protocol bus tests verify ordering guarantees — this is the IPC backbone and ordering bugs cause cascading failures
+- For T068, confirm the reviewer checks `git log` on both directories to verify which is canonical before approving deletion
+- Ensure test files follow existing heliosApp test patterns (describe/it structure, fixture management, cleanup)

--- a/agileplus-specs/phenotype-modular-arch/tasks/WP23-hexagonal-architecture-enforcement.md
+++ b/agileplus-specs/phenotype-modular-arch/tasks/WP23-hexagonal-architecture-enforcement.md
@@ -1,0 +1,99 @@
+---
+work_package_id: WP23
+title: 'Hexagonal Architecture Enforcement (Cross-Repo)'
+lane: planned
+dependencies: [WP06, WP09]
+subtasks: [T069, T070, T071]
+history:
+- date: '2026-03-03'
+  event: created
+  by: spec-kitty.tasks
+---
+
+# WP23: Hexagonal Architecture Enforcement (Cross-Repo)
+
+**Implementation command**: `spec-kitty implement WP23 --base WP06,WP09`
+
+## Objective
+
+Introduce hexagonal port/adapter boundaries across all repos where domain logic currently makes direct infrastructure calls (HTTP, file I/O, sandbox syscalls, cloud SDKs, ORM queries). This enforces the dependency inversion principle at repo boundaries and enables testability via port mocking.
+
+## Context
+
+- Multiple repos violate hexagonal architecture by embedding infrastructure calls directly in domain logic
+- heliosCLI: `web_search.rs` makes direct HTTP calls; `codex-rs/state/` and `codex-rs/secrets/` perform file I/O in domain; no `SandboxPort` trait for sandbox policy (seatbelt/landlock/windows)
+- cliproxy++: executors construct `http.Client` inline; executors accept concrete `*config.Config` instead of interface; `internal/thinking/` duplicates provider switch logic instead of using a `ThinkingBehavior` port
+- thegent: 8+ files with direct `httpx` calls outside adapters (doctor/checks.py, tools/borrow.py, etc.); `clode_main.py` uses inline `os.execvpe()` instead of a `ProcessExecutionPort`
+- heliosApp: desktop `stores/` has direct IPC coupling; `integrations/` embedded in runtime instead of port extraction
+- portage: `gke.py` (1,023L) and `daytona.py` (1,081L) mix cloud SDK calls in domain; CLI `tasks.py`/`jobs.py` bypasses `use_cases/`
+- trace: handlers import `gorm.DB` directly; `temporal_repository.go` (1,095L) mixes query logic with business logic
+
+## Subtasks
+
+### T069: heliosCLI hexagonal ports
+
+**Steps**:
+1. Define `HttpPort` trait in `codex-rs/core/` — `web_search.rs` consumes it instead of direct reqwest calls
+2. Define `StatePort` and `SecretsPort` traits — `codex-rs/state/` and `codex-rs/secrets/` become adapters implementing these traits; domain code depends only on the trait
+3. Define `SandboxPort` trait abstracting seatbelt (macOS), landlock (Linux), and Windows sandbox policy behind a unified interface
+4. Update all call sites to accept `dyn Port` or generic `impl Port` parameters
+5. Add mock implementations for each port in test modules
+
+**Validation**:
+- `cargo build --workspace` succeeds
+- `cargo test --workspace` passes
+- No direct `reqwest::` usage in domain modules (only in adapter impls)
+- No direct `std::fs::` usage in domain modules for state/secrets
+- Each port has at least one mock implementation used in tests
+
+### T070: cliproxy++ hexagonal ports
+
+**Steps**:
+1. Define `HTTPClient` interface — executors accept it instead of constructing `http.Client` inline
+2. Define `ConfigProvider` interface — executors accept it instead of concrete `*config.Config`
+3. Extract `ThinkingBehavior` port from `internal/thinking/` — eliminate duplicated provider switch statements
+4. Update all executor constructors to accept interfaces
+5. Add mock implementations for testing
+
+**Validation**:
+- `go build ./...` succeeds
+- `go test ./...` passes
+- `grep -r 'http.Client{' internal/runtime/executor/` returns 0 matches
+- All executors accept interface parameters, not concrete types
+
+### T071: thegent + portage + trace hexagonal ports
+
+**Steps**:
+1. thegent: Route all direct `httpx` calls in doctor/checks.py, tools/borrow.py, and 6+ other files through the existing port system
+2. thegent: Extract `ProcessExecutionPort` — `clode_main.py` calls port instead of inline `os.execvpe()`
+3. portage: Define `CloudProviderPort` interface — `gke.py` and `daytona.py` become adapters behind the port
+4. portage: Ensure CLI `tasks.py`/`jobs.py` routes through `use_cases/` layer instead of bypassing it
+5. trace: Introduce repository layer — handlers no longer import `gorm.DB` directly
+6. trace: Split `temporal_repository.go` (1,095L) — separate query/persistence from business logic
+
+**Validation**:
+- All test suites pass in thegent, portage, and trace
+- `grep -r 'httpx\.' src/thegent/ --include='*.py'` only matches files under adapters/
+- `grep -r 'gorm.DB' internal/handler/` returns 0 matches in trace
+- `temporal_repository.go` split into files each <500 LOC
+
+## Definition of Done
+
+- [ ] All 6 repos have port traits/interfaces for infrastructure dependencies
+- [ ] No direct HTTP, file I/O, or cloud SDK calls in domain modules
+- [ ] Each port has mock implementations used in tests
+- [ ] All test suites pass across all affected repos
+- [ ] No public API changes to external consumers
+
+## Risks
+
+- **Cross-repo coordination complexity**: Changes span 6 repos and must not break inter-repo contracts. Sequence carefully per subtask.
+- **Performance overhead from dynamic dispatch**: Port traits using `dyn` dispatch add vtable indirection. Profile hot paths and use `impl Trait` (monomorphization) where performance-critical.
+- **Incomplete port coverage**: Some infrastructure calls may be missed in initial audit. Use grep/ripgrep sweeps post-implementation to verify.
+
+## Reviewer Guidance
+
+- Verify that port trait definitions live in domain/core modules, not in adapter modules
+- Check that adapter implementations are in dedicated adapter directories
+- Confirm no domain module has `use reqwest`, `use httpx`, `import gorm`, or direct cloud SDK imports
+- Verify mock implementations are non-trivial and actually used in tests

--- a/agileplus-specs/phenotype-modular-arch/tasks/WP24-kiss-simplification-pass.md
+++ b/agileplus-specs/phenotype-modular-arch/tasks/WP24-kiss-simplification-pass.md
@@ -1,0 +1,107 @@
+---
+work_package_id: WP24
+title: 'KISS Simplification Pass (Cross-Repo)'
+lane: planned
+dependencies: []
+subtasks: [T072, T073, T074]
+history:
+- date: '2026-03-03'
+  event: created
+  by: spec-kitty.tasks
+---
+
+# WP24: KISS Simplification Pass (Cross-Repo)
+
+**Implementation command**: `spec-kitty implement WP24`
+
+## Objective
+
+Address KISS (Keep It Simple, Stupid) violations across the ecosystem: god modules, committed artifacts that belong in .gitignore or .archive/, duplicated directory structures, namespace explosions, and unclear module boundaries.
+
+## Context
+
+- heliosCLI: `helios-rs/cli/src/main.rs` is a 1,485L god module combining CLI dispatch, desktop detection, WSL handling, MCP, cloud features, feature toggles, shell completions, and login; `perf-results/` has 40+ benchmark dirs committed to source; multi-model connectors (ollama/lmstudio/chatgpt/backend-client) each independently implement list_models/connect/close/call_tool
+- cliproxy++: dual executor directories (`internal/runtime/executor/` AND `pkg/llmproxy/executor/`) are identical copies; `sdk/cliproxy/service.go` is a 1,724L god class
+- thegent: 150+ flat entries in `src/thegent/` namespace; `cliproxy_*.py` (6 files) not consolidated into `cliproxy/` subdir; `govern/` vs `governance/` naming collision (1,465L vs 13,252L); `clode_model_routing.py` + `clode_glm_policy.py` should be `routing/` subpackage; `swarm/` (380L) vs `orchestration/` (13K) unclear boundary
+- heliosApp: desktop/renderer/runtime three-way split lacks ownership boundary documentation
+- trace: 4 NATS debug binaries should consolidate or move to tests/tooling; root-level lint artifacts committed; 43 Go files exceed 500 LOC
+- portage: `terminus_2.py` main class still overloaded after prior extraction
+
+## Subtasks
+
+### T072: heliosCLI KISS simplification
+
+**Steps**:
+1. Decompose `helios-rs/cli/src/main.rs` (1,485L) into submodules:
+   - `cli/dispatch.rs` — command dispatch and argument parsing
+   - `cli/desktop.rs` — desktop detection and WSL handling
+   - `cli/mcp.rs` — MCP server configuration
+   - `cli/cloud.rs` — cloud feature toggles
+   - `cli/completions.rs` — shell completion generation
+   - `cli/auth.rs` — login and authentication flow
+   - `main.rs` — thin entry point composing the above
+2. Move `perf-results/` to `.archive/perf-results/` or add to `.gitignore` — benchmark artifacts should not be in source tree
+3. Deduplicate multi-model connector interfaces (overlaps with T055 ModelConnector trait — coordinate or defer if T055 handles this)
+
+**Validation**:
+- `main.rs` is <200 LOC
+- Each submodule is <400 LOC
+- `perf-results/` is no longer tracked in git (either archived or gitignored)
+- `cargo build --workspace` and `cargo test --workspace` pass
+
+### T073: cliproxy++ and thegent KISS simplification
+
+**Steps**:
+1. cliproxy++: Delete one of the dual executor directories (`internal/runtime/executor/` or `pkg/llmproxy/executor/`) — keep the canonical one, update all imports
+2. cliproxy++: Split `sdk/cliproxy/service.go` (1,724L) into focused service files by responsibility
+3. thegent: Consolidate `cliproxy_*.py` (6 files) into existing `cliproxy/` subdirectory
+4. thegent: Resolve `govern/` vs `governance/` naming collision — merge into single `governance/` package
+5. thegent: Move `clode_model_routing.py` + `clode_glm_policy.py` into `routing/` subpackage
+6. thegent: Document `swarm/` vs `orchestration/` boundary or merge if boundary is not meaningful
+7. thegent: Organize top-level `src/thegent/` — group 150+ flat entries into logical subdirectories
+
+**Validation**:
+- Only one executor directory exists in cliproxy++
+- `service.go` split into files each <500 LOC
+- `src/thegent/` top-level has <30 direct entries (rest in subdirectories)
+- No `govern/` directory (merged into `governance/`)
+- All test suites pass
+
+### T074: trace + portage + heliosApp KISS simplification
+
+**Steps**:
+1. trace: Consolidate 4 NATS debug binaries into a single `cmd/nats-debug/` tool or move to `tests/tooling/`
+2. trace: Remove root-level lint artifacts from source control (add to .gitignore)
+3. trace: Identify and split the worst offenders among 43 Go files >500 LOC (target top 10)
+4. portage: Further decompose `terminus_2.py` main class — extract session management, command dispatch, and output processing into separate modules
+5. heliosApp: Document desktop/renderer/runtime ownership boundaries in a `docs/architecture/` file listing which modules belong to which layer and the allowed dependency directions
+
+**Validation**:
+- trace: single NATS debug entry point or moved to tests/
+- trace: no lint artifacts in root
+- trace: top 10 largest files each reduced below 500 LOC
+- portage: `terminus_2.py` main class <300 LOC
+- heliosApp: boundary documentation exists and matches actual import graph
+- All test suites pass
+
+## Definition of Done
+
+- [ ] No god module >500 LOC across heliosCLI CLI, cliproxy++ service, thegent top-level
+- [ ] No committed benchmark/lint artifacts in source trees
+- [ ] No duplicate directory structures (cliproxy++ executor dirs)
+- [ ] thegent namespace organized into logical subdirectories
+- [ ] All naming collisions resolved
+- [ ] All test suites pass across all affected repos
+
+## Risks
+
+- **Namespace reorganization breaks imports**: Particularly thegent with 150+ entries. Use automated refactoring tools (rope, jedi) and run full test suites after each move.
+- **Deleting duplicate executor dir may have subtle differences**: Diff the two directories thoroughly before deleting one. If differences exist, reconcile first.
+- **perf-results may be referenced by CI or docs**: Check for references before archiving.
+
+## Reviewer Guidance
+
+- Verify that decomposed modules have clear single responsibilities
+- Check that deleted duplicates are truly identical (or differences reconciled)
+- Confirm namespace reorganization preserves all public imports via re-exports
+- Verify .gitignore additions are correct and do not exclude needed files

--- a/agileplus-specs/phenotype-modular-arch/tasks/WP25-shared-package-extraction-phase2.md
+++ b/agileplus-specs/phenotype-modular-arch/tasks/WP25-shared-package-extraction-phase2.md
@@ -1,0 +1,98 @@
+---
+work_package_id: WP25
+title: 'Shared Package Extraction Phase 2 (Polyrepo)'
+lane: planned
+dependencies: [WP02, WP09, WP11]
+subtasks: [T075, T076, T077]
+history:
+- date: '2026-03-03'
+  event: created
+  by: spec-kitty.tasks
+---
+
+# WP25: Shared Package Extraction Phase 2 (Polyrepo)
+
+**Implementation command**: `spec-kitty implement WP25 --base WP02,WP09,WP11`
+
+## Objective
+
+Extract 15 additional shared package candidates identified in prior audit but not covered by WP02-WP14. These are reusable modules currently embedded in individual repos that have cross-repo consumers or standalone utility value.
+
+## Context
+
+- WP02 scaffolded initial shared repos; WP07/WP09/WP11 extracted first-wave packages
+- This WP covers second-wave extractions identified during the cross-repo quality audit
+- Candidates span Go, Python, and TypeScript across 7 repos
+- Each candidate has either multiple consumers or standalone utility justifying extraction
+
+## Subtasks
+
+### T075: Go shared package extractions
+
+**Steps**:
+1. `agentapi++/lib/screentracker/` (523L `pty_conversation.go`) -> publish as `phenotype/screentracker-go`
+2. `agentapi++/lib/msgfmt/` (322L) + `lib/termexec/` -> extract as standalone Go libs `phenotype/msgfmt-go` and `phenotype/termexec-go`
+3. `cliproxy/sdk/auth/` (2,800L) -> extract as `phenotype/llm-auth-go` (multi-provider OAuth conductor)
+4. `trace/codeindex/` -> publish as `phenotype/codeindex-go` (standalone code indexing library)
+5. For each: create repo with go.mod, CI, README, and update source repo to consume as dependency
+
+**Validation**:
+- Each extracted package builds independently (`go build ./...`)
+- Each extracted package passes its own test suite
+- Source repos updated to import from shared packages
+- Source repo tests still pass after migration
+- No copied code remains in source repos (clean extraction)
+
+### T076: Python shared package extractions
+
+**Steps**:
+1. `thegent/protocols/jsonrpc_agent_server.py` (1,378L) -> publish as `phenotype/jsonrpc-agent-server` (pyproject.toml, pip-publishable)
+2. `thegent/orchestration/` (13,068L) -> extract as `phenotype/agent-orchestration` (Redis locks, resource-aware scheduling — no thegent-specific logic)
+3. `thegent/audit/` + `audit_v2/` -> shared `phenotype/audit-trail` utility
+4. `portage/terminus_2/` (~2,500L) -> extract as `phenotype/terminus2-harness` (reusable tmux agent executor)
+5. `portage/viewer/server.py` (1,237L) -> extract as `phenotype/eval-viewer` (standalone FastAPI results viewer)
+6. `portage/registry/` -> extract as `phenotype/harbor-registry-client`
+7. For each: create repo with pyproject.toml, CI, tests, and update source repo to consume
+
+**Validation**:
+- Each extracted package installs and passes tests independently
+- Source repos updated to import from shared packages
+- No duplicated code remains in source repos
+- `pytest` passes in all affected repos
+
+### T077: TypeScript shared package extractions
+
+**Steps**:
+1. `heliosCLI/shell-tool-mcp/` (~300 LOC TS) -> publish as `@phenotype/shell-tool-mcp` npm package
+2. heliosApp `ProviderRegistry` -> extract as `@phenotype/provider-registry`
+3. heliosApp `mcp-bridge.ts` + `acp-client.ts` + `a2a-router.ts` -> extract as `@phenotype/agent-protocol-bridge`
+4. `trace/embeddings/` -> shared service package (portage, thegent, trace consumers)
+5. `trace/graph/` -> shared Neo4j service package (portage+thegent potential consumers)
+6. For each: create package with package.json, tsconfig, CI, tests, and update source repos
+
+**Validation**:
+- Each extracted package builds and passes tests independently
+- Source repos updated to import from shared packages
+- `pnpm build` and `pnpm test` pass in all affected repos
+- npm packages have proper exports and type definitions
+
+## Definition of Done
+
+- [ ] 15 shared packages extracted and published (5 Go, 6 Python, 4 TS)
+- [ ] All source repos migrated to consume shared packages
+- [ ] No duplicated code remains in source repos for extracted modules
+- [ ] Each shared package has CI, tests, and README
+- [ ] All repo test suites pass after migration
+
+## Risks
+
+- **Hidden dependencies on repo internals**: Extracted modules may import private symbols from their source repo. Audit imports before extraction and make necessary symbols public or refactor.
+- **Version coordination across consumers**: Multiple repos consuming the same shared package need coordinated version bumps. Use semantic versioning from the start.
+- **thegent orchestration extraction is large (13K LOC)**: May require iterative extraction — start with the core scheduling logic and expand.
+
+## Reviewer Guidance
+
+- Verify each extraction is clean — no remaining copies in source repos
+- Check that shared packages have no imports from their source repo (true independence)
+- Confirm CI is set up for each new shared package repo
+- Verify consumers pin specific versions, not floating refs

--- a/agileplus-specs/phenotype-modular-arch/tasks/WP26-polyglot-alignment-cross-language-protocol.md
+++ b/agileplus-specs/phenotype-modular-arch/tasks/WP26-polyglot-alignment-cross-language-protocol.md
@@ -1,0 +1,94 @@
+---
+work_package_id: WP26
+title: 'Polyglot Alignment + Cross-Language Protocol'
+lane: planned
+dependencies: [WP01, WP07, WP09]
+subtasks: [T078, T079, T080]
+history:
+- date: '2026-03-03'
+  event: created
+  by: spec-kitty.tasks
+---
+
+# WP26: Polyglot Alignment + Cross-Language Protocol
+
+**Implementation command**: `spec-kitty implement WP26 --base WP01,WP07,WP09`
+
+## Objective
+
+Align cross-language implementations that duplicate the same logic in different languages, publish missing language SDK bindings, and define cross-language consumption interfaces for governance and routing.
+
+## Context
+
+- PTY tracking is implemented twice: `agentapi++/lib/screentracker/` (Go) and `portage/terminus_2/` (Python/tmux) — no shared protocol format
+- Python cliproxy SDK is not published; thegent uses `cliproxy_adapter.py` (1,253L) reimplementing Go SDK logic in Python
+- thegent `governance/` (13,252L) has no cross-language consumption interface — WP09 adopted OPA but did not define how non-Python consumers invoke policy checks
+- AgentBifrost routing logic exists in both `agentapi++/internal/routing/agent_bifrost.go` and `thegent/cliproxy_adapter.py` — should have canonical implementation in one language with thin client in the other
+
+## Subtasks
+
+### T078: PTY protocol alignment
+
+**Steps**:
+1. Define a shared PTY session protocol format (protobuf or JSON schema) covering: session start/end, keystroke events, screen state snapshots, command detection
+2. Update `agentapi++/lib/screentracker/` (Go) to emit/consume the shared format
+3. Update `portage/terminus_2/` (Python) to emit/consume the shared format
+4. Add integration tests verifying both implementations produce compatible output for the same PTY session
+5. Document the protocol in `phenotype-proto` or a dedicated spec file
+
+**Validation**:
+- Shared PTY protocol schema exists and is versioned
+- Both Go and Python implementations pass cross-language compatibility tests
+- Protocol format is documented with examples
+
+### T079: Python cliproxy SDK + governance PolicyPort
+
+**Steps**:
+1. Publish `phenotype-py-cliproxy` Python SDK that consumes the same auth contracts as the Go SDK
+2. Migrate thegent `cliproxy_adapter.py` (1,253L) to use the published SDK instead of reimplementing Go SDK logic
+3. Define `PolicyPort` interface in thegent `governance/` that is consumable cross-language:
+   - Option A: OPA Rego policies served via OPA REST API (language-agnostic)
+   - Option B: gRPC service wrapping governance logic (generated clients in Go, Rust, TS)
+4. Document the chosen cross-language governance consumption pattern
+
+**Validation**:
+- `phenotype-py-cliproxy` published and installable via pip
+- thegent `cliproxy_adapter.py` reduced to <200 LOC (thin SDK consumer)
+- At least one non-Python consumer can invoke policy checks via the defined interface
+- All thegent tests pass after migration
+
+### T080: Routing alignment
+
+**Steps**:
+1. Identify canonical routing implementation between `agentapi++/internal/routing/agent_bifrost.go` and `thegent/cliproxy_adapter.py`
+2. Designate one as the canonical source of truth (likely Go, given Bifrost is Go-native)
+3. Reduce the non-canonical implementation to a thin client calling the canonical one (via gRPC, REST, or SDK)
+4. Ensure routing decisions are consistent across both entry points
+5. Add cross-language routing integration tests
+
+**Validation**:
+- Only one codebase contains routing decision logic
+- The other codebase is a thin client (<300 LOC)
+- Cross-language routing tests pass
+- No routing decision duplication between Go and Python
+
+## Definition of Done
+
+- [ ] Shared PTY protocol format defined and implemented in both languages
+- [ ] `phenotype-py-cliproxy` published and consumed by thegent
+- [ ] Cross-language PolicyPort interface defined and at least one non-Python consumer exists
+- [ ] Canonical routing implementation designated; non-canonical reduced to thin client
+- [ ] All test suites pass across affected repos
+
+## Risks
+
+- **Protocol format design is a long-lived decision**: PTY protocol format will be consumed by multiple repos for years. Invest in forward-compatible schema design (protobuf with reserved fields).
+- **OPA REST API adds latency to policy checks**: If governance checks are on the hot path, the REST overhead may be unacceptable. Profile and consider embedded OPA (Go) or compiled Rego for latency-sensitive paths.
+- **Routing canonical designation may be contentious**: Both implementations may have features the other lacks. Do a thorough feature matrix comparison before designating canonical.
+
+## Reviewer Guidance
+
+- Verify the PTY protocol schema is forward-compatible (reserved fields, versioning)
+- Check that the Python cliproxy SDK has feature parity with the Go SDK
+- Confirm the PolicyPort interface is truly language-agnostic (no Python-specific constructs in the contract)
+- Verify routing thin client faithfully delegates all decisions to canonical implementation

--- a/agileplus-specs/phenotype-modular-arch/tasks/WP27-fork-hardening-upstream-sync.md
+++ b/agileplus-specs/phenotype-modular-arch/tasks/WP27-fork-hardening-upstream-sync.md
@@ -1,0 +1,87 @@
+---
+work_package_id: WP27
+title: 'Fork Hardening + Upstream Sync Tooling (heliosCLI)'
+lane: planned
+dependencies: [WP03, WP17]
+subtasks: [T081, T082]
+history:
+- date: '2026-03-03'
+  event: created
+  by: spec-kitty.tasks
+---
+
+# WP27: Fork Hardening + Upstream Sync Tooling (heliosCLI)
+
+**Implementation command**: `spec-kitty implement WP27 --base WP03,WP17`
+
+## Objective
+
+Harden heliosCLI's fork maintenance by adding CI-enforced alias map validation, automated upstream drift tracking, and a formal ADR documenting the Tauri 2.0 evaluation for heliosApp.
+
+## Context
+
+- heliosCLI is a fork with `helios-rs/Cargo.toml` using alias maps like `codex_protocol = { package = "helios-protocol", ... }` — upstream crate renames silently break these
+- WP17 created an upstream sync strategy but it is docs-only (`UPSTREAM_DIFF_SPEC.md`); no automated code-level drift detection exists
+- Prior session evaluated Tauri 2.0 as an Electron replacement for heliosApp (600KB vs 150MB binary, better perf) but no formal ADR was recorded
+
+## Subtasks
+
+### T081: Alias map CI + upstream diff tooling
+
+**Steps**:
+1. Create `scripts/check-alias-map.sh` that:
+   - Parses all `Cargo.toml` files for `package = "..."` alias declarations
+   - Verifies each aliased crate name exists in the upstream Codex repo's Cargo workspace
+   - Fails CI if any alias references a crate name that does not exist upstream
+2. Create `scripts/upstream-diff.sh` that:
+   - Clones or fetches upstream codex HEAD (configurable remote)
+   - Diffs heliosCLI source tree against upstream, filtering out known Phenotype-only paths
+   - Outputs drift metrics: files changed, lines added/removed, new upstream files not in fork, fork files not in upstream
+   - Generates a summary report suitable for PR comments
+3. Add both scripts to CI workflow (run on PRs targeting main)
+4. Add upstream remote configuration to repo (`.upstream-sync.yml` or similar)
+
+**Validation**:
+- `scripts/check-alias-map.sh` runs successfully on current codebase
+- `scripts/upstream-diff.sh` produces a readable drift report
+- Both scripts are invoked in CI and produce visible output on PRs
+- Intentionally breaking an alias (renaming a crate) causes CI failure
+
+### T082: Tauri 2.0 ADR
+
+**Steps**:
+1. Create `ADR-XXX-tauri-2-evaluation.md` in the appropriate ADR location documenting:
+   - Context: heliosApp currently uses Electron (150MB binary, high memory usage)
+   - Decision: Evaluate Tauri 2.0 as long-term replacement
+   - Pros: 600KB binary, lower memory, Rust backend, better security sandbox
+   - Cons: Migration complexity, WebView compatibility variations, ecosystem maturity
+   - Migration complexity assessment: affected modules, estimated effort, breaking changes
+   - Timeline: recommended phases for incremental migration
+   - Status: Proposed (pending team confirmation)
+2. Reference the prior session's research findings in the ADR
+
+**Validation**:
+- ADR exists with complete context, decision, alternatives, and consequences sections
+- Migration complexity assessment includes specific heliosApp modules affected
+- Timeline includes phased migration approach with concrete milestones
+
+## Definition of Done
+
+- [ ] `scripts/check-alias-map.sh` validates all Cargo.toml alias maps against upstream
+- [ ] `scripts/upstream-diff.sh` produces drift metrics report
+- [ ] Both scripts integrated into CI pipeline
+- [ ] Tauri 2.0 ADR created with full evaluation and migration assessment
+- [ ] All existing tests pass
+
+## Risks
+
+- **Upstream remote may not be publicly accessible**: Ensure the diff script handles authentication or uses a cached/mirrored upstream.
+- **Alias map check may have false positives**: Some aliases may reference Phenotype-only crates that intentionally do not exist upstream. Add an allowlist mechanism.
+- **Tauri 2.0 ADR may become stale**: Include a review date in the ADR to prompt re-evaluation.
+
+## Reviewer Guidance
+
+- Verify alias map check script handles edge cases (workspace inheritance, path dependencies)
+- Check upstream diff script filters out Phenotype-only directories correctly
+- Confirm ADR follows the project's ADR format and numbering convention
+- Verify CI integration does not add excessive build time (upstream fetch should be cached)

--- a/agileplus-specs/phenotype-modular-arch/tasks/WP28-stub-completion-service-boundaries.md
+++ b/agileplus-specs/phenotype-modular-arch/tasks/WP28-stub-completion-service-boundaries.md
@@ -1,0 +1,116 @@
+---
+work_package_id: WP28
+title: 'Architectural Stub Completion + Service Boundaries'
+lane: planned
+dependencies: [WP09, WP11, WP14, WP16]
+subtasks: [T083, T084, T085]
+history:
+- date: '2026-03-03'
+  event: created
+  by: spec-kitty.tasks
+---
+
+# WP28: Architectural Stub Completion + Service Boundaries
+
+**Implementation command**: `spec-kitty implement WP28 --base WP09,WP11,WP14,WP16`
+
+## Objective
+
+Complete architectural stubs that represent intended product direction, formalize unclear service boundaries, and migrate remaining consumers to shared infrastructure (LiteLLM proxy).
+
+## Context
+
+- `agentapi++/internal/phenotype/` exists as an empty `init.go` stub — intended as the formal isolation boundary for Phenotype-specific extensions but never completed
+- trace `backend/internal/plugin/` anticipated a plugin registry but was never implemented
+- heliosApp `sessions/` and `workspace/` services are embedded in the same runtime as provider routing — should be separate services
+- thegent `governance/` (13K LOC) sits directly in the call path with no port abstraction — needs `PolicyEngine` port for hot-swapping backends (OPA, Guardrails AI, custom)
+- portage `environments/` has 8 environment plugins with clean `BaseEnvironment` ABC — ready to formalize as entry_points plugin system and extract
+- WP10 set up LiteLLM shared proxy for thegent, but portage `lite_llm.py` (727L) was not migrated (not addressed in WP13)
+
+## Subtasks
+
+### T083: agentapi++ phenotype boundary + trace plugin system
+
+**Steps**:
+1. Complete `agentapi++/internal/phenotype/` as the formal isolation boundary:
+   - Define `PhenotypeExtension` interface listing all Phenotype-specific hooks (routing overrides, audit emission, auth integration)
+   - Implement the interface with concrete Phenotype extensions
+   - Ensure all Phenotype-specific code in agentapi++ routes through this boundary
+2. Implement trace `backend/internal/plugin/` plugin registry:
+   - Define `PluginSource` interface for runtime data source addition
+   - Support plugin types: Neo4j, Postgres, Redis, NATS
+   - Implement plugin discovery and lifecycle management (init, health check, shutdown)
+   - Migrate existing hardcoded data sources to use the plugin interface
+
+**Validation**:
+- `agentapi++/internal/phenotype/` has non-empty implementation with clear interface
+- All Phenotype-specific code routes through the phenotype boundary (no Phenotype logic in generic agentapi code)
+- trace plugin registry supports adding data sources at runtime
+- `go build ./...` and `go test ./...` pass for both repos
+
+### T084: heliosApp service separation
+
+**Steps**:
+1. Separate `sessions/` service from provider routing runtime:
+   - Define session service interface (create, resume, list, delete)
+   - Extract session state management into standalone service module
+   - Communicate with provider routing via protocol bus (IPC/events)
+2. Separate `workspace/` service similarly:
+   - Define workspace service interface
+   - Extract workspace state and file management
+   - Communicate via protocol bus
+3. Document the new service boundaries and allowed communication patterns
+4. Update Electron main process to bootstrap services independently
+
+**Validation**:
+- Sessions and workspace modules have no direct imports from provider routing
+- Services communicate only via protocol bus events
+- Service boundary documentation exists
+- heliosApp builds and all tests pass
+
+### T085: thegent PolicyPort + portage LiteLLM migration
+
+**Steps**:
+1. Refactor thegent `governance/` (13K LOC) to sit behind a `PolicyEngine` port interface:
+   - Define `PolicyEngine` protocol with methods: `evaluate(policy_context) -> PolicyDecision`
+   - Current governance logic becomes the default `OPABackedPolicyEngine` implementation
+   - Interface enables hot-swapping to Guardrails AI, custom backends, or mock implementations
+2. Migrate portage `lite_llm.py` (727L) to use the shared LiteLLM proxy established in WP10:
+   - Replace direct LiteLLM library usage with shared proxy client calls
+   - Remove portage-local LiteLLM configuration
+   - Ensure all model routing goes through the shared proxy
+3. Formalize portage `environments/` as `entry_points` plugin package:
+   - Add `pyproject.toml` entry_points configuration for 8 environment plugins
+   - Extract as `phenotype/harbor-environments` package
+   - Source repo consumes via pip dependency
+
+**Validation**:
+- thegent governance accessible via `PolicyEngine` interface
+- At least one alternative PolicyEngine implementation exists (mock or Guardrails AI stub)
+- portage no longer has local LiteLLM configuration; all calls route through shared proxy
+- portage environments discoverable via entry_points
+- All test suites pass in thegent and portage
+
+## Definition of Done
+
+- [ ] agentapi++ phenotype boundary completed with concrete implementation
+- [ ] trace plugin registry implemented with PluginSource interface
+- [ ] heliosApp sessions/ and workspace/ separated from provider routing
+- [ ] thegent governance behind PolicyEngine port interface
+- [ ] portage LiteLLM migrated to shared proxy
+- [ ] portage environments formalized as entry_points plugin and extracted
+- [ ] All test suites pass across all affected repos
+
+## Risks
+
+- **heliosApp service separation may introduce race conditions**: Services communicating via protocol bus instead of direct calls need careful event ordering. Add integration tests for concurrent operations.
+- **PolicyEngine abstraction may lose governance nuance**: 13K LOC of governance logic may have subtle behaviors that a generic interface cannot capture. Allow the interface to be rich enough (policy context objects, decision metadata).
+- **portage LiteLLM migration depends on shared proxy availability**: Ensure WP10 shared proxy is deployed and accessible before migration.
+
+## Reviewer Guidance
+
+- Verify agentapi++ phenotype boundary is a true isolation layer (grep for Phenotype-specific imports outside the boundary)
+- Check trace plugin interface supports all current data source types
+- Confirm heliosApp service separation does not break existing IPC contracts
+- Verify PolicyEngine interface is rich enough to express current governance decisions without loss
+- Check portage LiteLLM migration does not change model routing behavior

--- a/agileplus-specs/phenotype-modular-arch/tasks/tasks.md
+++ b/agileplus-specs/phenotype-modular-arch/tasks/tasks.md
@@ -1,0 +1,408 @@
+# Work Packages: Phenotype Ecosystem Modularization & Plugin Architecture
+
+**Feature**: 002-phenotype-modular-arch
+**Generated**: 2026-03-03
+**Total Subtasks**: 85 | **Work Packages**: 28
+**Revised**: 2026-03-03 (library leverage research + codebase quality analysis + prior session gap recovery)
+
+---
+
+## Subtask Registry
+
+| ID | Description | Lane | Parallel | WP |
+|----|-------------|------|----------|----|
+| T001 | Create `phenotype-proto` repo with buf config | L0 | — | WP01 |
+| T002 | Define `domain/v1/` protos (session, agent, routing, audit) | L0 | [P] | WP01 |
+| T003 | Define `plugin/v1/` protos (executor, tool, adapter) | L0 | [P] | WP01 |
+| T004 | Configure `buf generate` for Rust, Go, Python, TypeScript | L0 | — | WP01 |
+| T005 | CI: buf lint + buf breaking on phenotype-proto | L0 | — | WP01 |
+| T006 | Create empty shared Go repos (authkit, executor-core, httpkit) | L0 | [P] | WP02 |
+| T007 | Create empty shared repos (rs-protocol, py-infra, audit-core, protocol-types) | L0 | [P] | WP02 |
+| T008 | Merge codex-rs + helios-rs into single Cargo workspace | L1 | — | WP03 |
+| T009 | Gate variant code behind feature flags | L1 | — | WP03 |
+| T010 | Remove helios-rs directory, update CI | L1 | — | WP03 |
+| T011 | Extract protocol crate to `phenotype-rs-protocol` | L1 | — | WP04 |
+| T012 | Implement Tier 1 plugin: `ToolPlugin` trait + `inventory` | L1 | — | WP05 |
+| T013 | Prototype Tier 2 plugin: Extism host for user tools | L1 | — | WP05 |
+| T014 | Emit audit events from codex-core session lifecycle | L1 | — | WP12 |
+| T015 | Bifrost integration + ExecutorInterface port + resilience primitives | L2 | — | WP06 |
+| T016 | Migrate standard executors to Bifrost; keep Kiro/Copilot/Cursor custom | L2 | — | WP06 |
+| T017 | Extract auth logic to `phenotype-go-authkit` (x/oauth2 + Goth) | L2 | — | WP07 |
+| T018 | Extract HTTP helpers to `phenotype-go-httpkit` | L2 | — | WP07 |
+| T019 | Implement Tier 1 plugin: Executor interface + init() | L2 | — | WP08 |
+| T020 | Prototype Tier 2 plugin: Extism host for executor .wasm | L2 | — | WP08 |
+| T021 | Translator matrix builder codegen | L2 | — | WP08 |
+| T022 | Formalize executor + translator as hexagonal ports | L2 | — | WP08 |
+| T023 | Emit audit events from proxy routing | L2 | — | WP12 |
+| T024 | Extract `thegent-config` (adopt pydantic-settings) | L3 | [P] | WP09 |
+| T025 | Extract `thegent-infra` from src/thegent/infra/ | L3 | [P] | WP09 |
+| T026 | Extract `thegent-governance` (adopt OPA + Guardrails AI) | L3 | [P] | WP09 |
+| T027 | Merge thegent-protocols + thegent-mcp (adopt MCP Python SDK) | L3 | [P] | WP09 |
+| T028 | Publish thegent-infra internals to `phenotype-py-infra` | L3 | — | WP10 |
+| T029 | Formalize AdapterPort pattern (adopt PydanticAI) | L3 | — | WP10 |
+| T030 | Implement Tier 1 plugin: entry_points registration | L3 | — | WP10 |
+| T031 | Prototype Tier 2 plugin: Extism host for user skills | L3 | — | WP10 |
+| T032 | Emit audit events from agent execution lifecycle | L3 | — | WP12 |
+| T033 | Make src/thegent/ a thin re-export layer | L3 | — | WP10 |
+| T034 | Extract `@helios/audit-core` (build on Emmett) | L4 | [P] | WP11 |
+| T035 | Extract `@helios/protocol-types` from protocol/types.ts | L4 | [P] | WP11 |
+| T036 | Extract service interfaces to `@helios/service-contracts` | L4 | [P] | WP11 |
+| T037 | Publish TS packages to npm/GitHub Packages | L4 | — | WP11 |
+| T038 | Refactor runtime to consume extracted packages | L4 | — | WP11 |
+| T039 | Implement aggregated audit trail view | L4 | — | WP15 |
+| T040 | Formalize ports wrapping Inspect AI primitives | L5 | — | WP13 |
+| T041 | Emit trial events: TrialStarted, TrialCheckpoint, TrialCompleted | L5 | — | WP12 |
+| T042 | Inspect AI Task adapter registry (Tier 1) | L5 | — | WP13 |
+| T043 | Prototype Tier 2 plugin: Extism host for adapters | L5 | — | WP13 |
+| T044 | Consume `phenotype-py-infra` for shared utilities | L5 | — | WP13 |
+| T045 | Extract internal/domain/ package: Agent, Session, RoutingRule | L6 | — | WP14 |
+| T046 | Consume phenotype-go-authkit + httpkit | L6 | — | WP14 |
+| T047 | Emit routing audit events: AgentRouted, SessionCreated | L6 | — | WP12 |
+| T048 | Replace custom code parsers with tree-sitter + scip-go | L2 | [P] | WP16 |
+| T049 | Replace custom embedding service with chromem-go | L2 | [P] | WP16 |
+| T050 | Replace custom Neo4j wrappers + optimize NATS JetStream | L2 | [P] | WP16 |
+| T051 | Extract thegent-* Rust crates to phenotype-rs-agents | L1 | — | WP17 |
+| T052 | Create upstream sync strategy + CI automation | L1 | — | WP17 |
+| T053 | Split top 4 god modules (codex.rs 9.6K, chat_composer 9.5K, etc.) | L1 | [P] | WP18 |
+| T054 | Eliminate 934 production `unwrap()` calls | L1 | [P] | WP18 |
+| T055 | Dead code audit (54 allow(dead_code), 100 TODOs) + connector dedup | L1 | [P] | WP18 |
+| T056 | Delete 469 duplicate files from src/thegent/ (~100K LOC) | L3 | — | WP19 |
+| T057 | Decompose run_impl_core (1,022L function) | L3 | — | WP19 |
+| T058 | Break 221-file circular dep surface (TYPE_CHECKING) | L3 | — | WP19 |
+| T059 | portage: Extract shared BaseAdapter (8 independent definitions) | L5 | [P] | WP20 |
+| T060 | portage: Split god functions (create_app 1,164L, jobs::start 856L) | L5 | [P] | WP20 |
+| T061 | trace: Split api/main.py (9,274L) + remove deprecated deps | L2 | [P] | WP20 |
+| T062 | trace: Clean 390 Python type suppressions | L2 | [P] | WP20 |
+| T063 | cliproxy: Split kiro_executor.go (4,691L) + antigravity (1,783L) | L2 | — | WP21 |
+| T064 | cliproxy: Delete dead internal/auth/ (~600 LOC) | L2 | — | WP21 |
+| T065 | cliproxy: Split remaining god functions (>200L) + config/service files | L2 | — | WP21 |
+| T066 | heliosApp: Test audit subsystem (2,577L, 0 tests) | L4 | [P] | WP22 |
+| T067 | heliosApp: Test protocol bus (805L) + critical runtime modules | L4 | [P] | WP22 |
+| T068 | agentapi++: Remove inner directory duplication (~8K LOC) | L6 | — | WP22 |
+| T069 | heliosCLI: Define HttpPort, StatePort, SecretsPort, SandboxPort traits | L2 | [P] | WP23 |
+| T070 | cliproxy++: HTTPClient, ConfigProvider, ThinkingBehavior port interfaces | L2 | [P] | WP23 |
+| T071 | thegent+portage+trace: httpx routing, ProcessExecutionPort, CloudProviderPort, repository layer | L2 | [P] | WP23 |
+| T072 | heliosCLI: Decompose main.rs (1,485L), archive perf-results, connector dedup | L1 | [P] | WP24 |
+| T073 | cliproxy++: Delete dup executor dir, split service.go; thegent namespace reorg | L3 | [P] | WP24 |
+| T074 | trace: NATS debug consolidation, lint artifacts; portage: terminus_2 decomp; heliosApp: boundary docs | L4 | [P] | WP24 |
+| T075 | Go shared extractions: screentracker, msgfmt, termexec, llm-auth, codeindex | L2 | [P] | WP25 |
+| T076 | Python shared extractions: jsonrpc-agent-server, agent-orchestration, audit-trail, terminus2, eval-viewer, harbor-registry | L3 | [P] | WP25 |
+| T077 | TS shared extractions: shell-tool-mcp, provider-registry, agent-protocol-bridge, embeddings, graph | L4 | [P] | WP25 |
+| T078 | Define shared PTY protocol format, align Go+Python implementations | L2 | — | WP26 |
+| T079 | Publish phenotype-py-cliproxy SDK + define cross-language PolicyPort | L3 | — | WP26 |
+| T080 | Designate canonical routing implementation, reduce non-canonical to thin client | L2 | — | WP26 |
+| T081 | Alias map CI check + upstream-diff.sh drift tracking script | L1 | [P] | WP27 |
+| T082 | Create Tauri 2.0 evaluation ADR with migration assessment | L1 | — | WP27 |
+| T083 | agentapi++ phenotype boundary completion + trace plugin registry | L6 | [P] | WP28 |
+| T084 | heliosApp sessions/ + workspace/ service separation | L4 | — | WP28 |
+| T085 | thegent PolicyEngine port + portage LiteLLM shared proxy migration + environments extraction | L3 | [P] | WP28 |
+
+---
+
+## Work Package Summary
+
+### Phase 1: Foundation
+
+#### WP01 — Protobuf Contract System (phenotype-proto)
+- **Priority**: P0 (critical path — blocks audit events in all repos)
+- **Subtasks**: T001, T002, T003, T004, T005 (5 tasks)
+- **Dependencies**: None
+- **Estimated prompt**: ~350 lines
+- **Implementation**: `spec-kitty implement WP01`
+
+Create phenotype-proto repo, define domain and plugin protos, configure buf codegen for 4 languages, add CI.
+
+#### WP02 — Shared Package Scaffolding
+- **Priority**: P0 (blocks shared package extraction)
+- **Subtasks**: T006, T007 (2 tasks)
+- **Dependencies**: None
+- **Estimated prompt**: ~200 lines
+- **Implementation**: `spec-kitty implement WP02`
+
+Create 7 empty shared package repos with proper structure, README, CI, and package manager config.
+
+### Phase 2: Per-Repo Internal Restructuring (all parallel)
+
+#### WP03 — heliosCLI: codex/helios Workspace Merge
+- **Priority**: P0 (highest impact — eliminates ~50 redundant crates)
+- **Subtasks**: T008, T009, T010 (3 tasks)
+- **Dependencies**: None
+- **Estimated prompt**: ~400 lines
+- **Implementation**: `spec-kitty implement WP03`
+
+Merge codex-rs + helios-rs into single Cargo workspace with feature flags. Remove helios-rs.
+
+#### WP04 — heliosCLI: Protocol Extraction to Shared Repo
+- **Priority**: P1
+- **Subtasks**: T011 (1 task — but complex, ~300 lines of guidance)
+- **Dependencies**: WP02, WP03
+- **Estimated prompt**: ~250 lines
+- **Implementation**: `spec-kitty implement WP04 --base WP03`
+
+Extract protocol crate types to phenotype-rs-protocol shared repo.
+
+#### WP05 — heliosCLI: Plugin System (Tier 1 + Tier 2)
+- **Priority**: P2
+- **Subtasks**: T012, T013 (2 tasks)
+- **Dependencies**: WP03
+- **Estimated prompt**: ~350 lines
+- **Implementation**: `spec-kitty implement WP05 --base WP03`
+
+Implement ToolPlugin trait with inventory registration (Tier 1), prototype Extism host (Tier 2).
+
+#### WP06 — cliproxyapi++: Executor Core Extraction
+- **Priority**: P1
+- **Subtasks**: T015, T016 (2 tasks)
+- **Dependencies**: None
+- **Estimated prompt**: ~400 lines
+- **Implementation**: `spec-kitty implement WP06`
+
+Embed Bifrost for 9+ standard providers (25-40K LOC saved), keep thin custom executors for Kiro/Copilot/Cursor. Add retry-go, gobreaker, go-retryablehttp.
+
+#### WP07 — cliproxyapi++: Shared Package Extraction (authkit + httpkit)
+- **Priority**: P1
+- **Subtasks**: T017, T018 (2 tasks)
+- **Dependencies**: WP02
+- **Estimated prompt**: ~300 lines
+- **Implementation**: `spec-kitty implement WP07 --base WP02`
+
+Extract auth to phenotype-go-authkit (backed by x/oauth2 + Goth, 6-14K LOC saved), HTTP helpers to phenotype-go-httpkit.
+
+#### WP08 — cliproxyapi++: Plugin System + Hexagonal Ports
+- **Priority**: P2
+- **Subtasks**: T019, T020, T021, T022 (4 tasks)
+- **Dependencies**: WP06
+- **Estimated prompt**: ~450 lines
+- **Implementation**: `spec-kitty implement WP08 --base WP06`
+
+Tier 1 + Tier 2 executor plugins, translator matrix builder, hexagonal port formalization.
+
+#### WP09 — thegent: Package Migration Completion
+- **Priority**: P1
+- **Subtasks**: T024, T025, T026, T027 (4 tasks)
+- **Dependencies**: None
+- **Estimated prompt**: ~400 lines
+- **Implementation**: `spec-kitty implement WP09`
+
+Extract config (pydantic-settings), infra, governance (OPA + Guardrails AI). Merge protocols+mcp (official MCP Python SDK).
+
+#### WP10 — thegent: Shared Publish + Plugin System + Re-export Layer
+- **Priority**: P2
+- **Subtasks**: T028, T029, T030, T031, T033 (5 tasks)
+- **Dependencies**: WP02, WP09
+- **Estimated prompt**: ~450 lines
+- **Implementation**: `spec-kitty implement WP10 --base WP09`
+
+Publish to phenotype-py-infra + shared LiteLLM proxy, formalize AdapterPort via PydanticAI (5-8K LOC saved), plugin registration, Extism prototype, thin re-export layer.
+
+#### WP11 — heliosApp: Package Extraction + Publishing
+- **Priority**: P1
+- **Subtasks**: T034, T035, T036, T037, T038 (5 tasks)
+- **Dependencies**: WP02
+- **Estimated prompt**: ~400 lines
+- **Implementation**: `spec-kitty implement WP11 --base WP02`
+
+Extract audit-core (built on Emmett, 2-5K LOC saved), protocol-types (+ electron-trpc evaluation, 1-3K LOC), service-contracts. Publish. Refactor runtime.
+
+### Phase 3: Cross-Repo Audit Events
+
+#### WP12 — Audit Event Integration (All Repos)
+- **Priority**: P1 (requires proto codegen from WP01)
+- **Subtasks**: T014, T023, T032, T041, T047 (5 tasks)
+- **Dependencies**: WP01
+- **Estimated prompt**: ~500 lines
+- **Implementation**: `spec-kitty implement WP12 --base WP01`
+
+Emit structured audit events from heliosCLI, cliproxyapi++, thegent, portage, agentapi++.
+
+### Phase 4: Remaining Plugin Systems + Shared Consumption
+
+#### WP13 — portage: Ports, Plugins, Shared Consumption
+- **Priority**: P2
+- **Subtasks**: T040, T042, T043, T044 (4 tasks)
+- **Dependencies**: WP10 (for phenotype-py-infra)
+- **Estimated prompt**: ~350 lines
+- **Implementation**: `spec-kitty implement WP13 --base WP10`
+
+Adopt Inspect AI as framework (15-25K LOC saved). Formalize ports wrapping Inspect primitives, Task adapter registry, Extism prototype, consume phenotype-py-infra + shared LiteLLM proxy.
+
+#### WP14 — agentapi++: Domain Extraction + Shared Consumption
+- **Priority**: P2
+- **Subtasks**: T045, T046 (2 tasks)
+- **Dependencies**: WP07
+- **Estimated prompt**: ~250 lines
+- **Implementation**: `spec-kitty implement WP14 --base WP07`
+
+Extract internal/domain/ package, consume authkit + httpkit.
+
+### Phase 5: Integration
+
+#### WP15 — heliosApp: Aggregated Audit Trail View
+- **Priority**: P3
+- **Subtasks**: T039 (1 task — UI + data integration)
+- **Dependencies**: WP11, WP12
+- **Estimated prompt**: ~250 lines
+- **Implementation**: `spec-kitty implement WP15 --base WP12`
+
+Implement aggregated audit trail view consuming Emmett-backed events from all repos.
+
+### Phase 2 Additions (parallel with existing Phase 2)
+
+#### WP16 — trace: Code Intelligence Library Adoption
+- **Priority**: P1
+- **Subtasks**: T048, T049, T050 (3 tasks)
+- **Dependencies**: None
+- **Estimated prompt**: ~400 lines
+- **Implementation**: `spec-kitty implement WP16`
+
+Adopt tree-sitter + scip-go (5-14K LOC saved), chromem-go (1-3K LOC), neo4j-go-driver v5 (0.5-1.5K LOC). Trace repo was missing from original WPs.
+
+#### WP17 — heliosCLI: Fork-Specific Crate Extraction
+- **Priority**: P1 (blocks next upstream rebase)
+- **Subtasks**: T051, T052 (2 tasks)
+- **Dependencies**: WP03
+- **Estimated prompt**: ~350 lines
+- **Implementation**: `spec-kitty implement WP17 --base WP03`
+
+Extract ~20 thegent-* Rust crates to standalone phenotype-rs-agents workspace. Create upstream sync strategy + CI automation.
+
+### Quality-Driven WPs (from codebase analysis)
+
+#### WP18 — heliosCLI: God Module Decomposition + Safety
+- **Priority**: P1 (safety-critical: 934 unwrap() crash risks)
+- **Subtasks**: T053, T054, T055 (3 tasks)
+- **Dependencies**: WP03
+- **Estimated prompt**: ~450 lines
+- **Implementation**: `spec-kitty implement WP18 --base WP03`
+
+Split 4 god modules (codex.rs 9.6K, chat_composer 9.5K, codex_message_processor 8.5K, chatwidget 8.1K). Eliminate 934 production unwrap(). Audit 54 dead_code suppressions + 100 TODOs.
+
+#### WP19 — thegent: Migration Cleanup + God Function Decomposition
+- **Priority**: P0 (immediate ~100K LOC reduction from dup deletion)
+- **Subtasks**: T056, T057, T058 (3 tasks)
+- **Dependencies**: WP09
+- **Estimated prompt**: ~400 lines
+- **Implementation**: `spec-kitty implement WP19 --base WP09`
+
+Delete 469 duplicate files (~100K LOC). Decompose run_impl_core (1,022L function). Break 221-file circular dep surface.
+
+#### WP20 — portage + trace: Code Quality Remediation
+- **Priority**: P1
+- **Subtasks**: T059, T060, T061, T062 (4 tasks)
+- **Dependencies**: None
+- **Estimated prompt**: ~500 lines
+- **Implementation**: `spec-kitty implement WP20`
+
+portage: Extract shared BaseAdapter (8 dups), split god functions. trace: Split api/main.py (9,274L), remove deprecated deps, clean 390 type suppressions.
+
+#### WP21 — cliproxyapi++: God Module Split + Auth Consolidation
+- **Priority**: P1
+- **Subtasks**: T063, T064, T065 (3 tasks)
+- **Dependencies**: WP06
+- **Estimated prompt**: ~400 lines
+- **Implementation**: `spec-kitty implement WP21 --base WP06`
+
+Split kiro_executor.go (4,691L), delete dead internal/auth/ (~600L), split remaining god functions (>200L).
+
+#### WP22 — heliosApp: Critical Test Coverage + agentapi++ Dedup
+- **Priority**: P2
+- **Subtasks**: T066, T067, T068 (3 tasks)
+- **Dependencies**: WP11
+- **Estimated prompt**: ~400 lines
+- **Implementation**: `spec-kitty implement WP22 --base WP11`
+
+Test audit subsystem (2,577L, 0 tests), test protocol bus (805L), remove agentapi++ inner directory duplication (~8K LOC).
+
+### Phase 2-3 Additions (Prior Session Gap Recovery)
+
+#### WP23 — Hexagonal Architecture Enforcement (Cross-Repo)
+- **Priority**: P1
+- **Subtasks**: T069, T070, T071 (3 tasks)
+- **Dependencies**: WP06, WP09
+- **Estimated prompt**: ~500 lines
+- **Implementation**: `spec-kitty implement WP23 --base WP06,WP09`
+
+Introduce hexagonal port/adapter boundaries across all repos: HttpPort, StatePort, SecretsPort, SandboxPort (heliosCLI); HTTPClient, ConfigProvider, ThinkingBehavior (cliproxy++); httpx routing, ProcessExecutionPort, CloudProviderPort, repository layer (thegent, portage, trace).
+
+#### WP24 — KISS Simplification Pass (Cross-Repo)
+- **Priority**: P1
+- **Subtasks**: T072, T073, T074 (3 tasks)
+- **Dependencies**: None
+- **Estimated prompt**: ~500 lines
+- **Implementation**: `spec-kitty implement WP24`
+
+Decompose god modules (main.rs 1,485L, service.go 1,724L), archive committed artifacts (perf-results, lint), delete duplicate directories (cliproxy executor dirs), reorganize thegent namespace (150+ flat entries), resolve naming collisions (govern/governance), document heliosApp boundaries.
+
+#### WP25 — Shared Package Extraction Phase 2 (Polyrepo)
+- **Priority**: P2
+- **Subtasks**: T075, T076, T077 (3 tasks)
+- **Dependencies**: WP02, WP09, WP11
+- **Estimated prompt**: ~500 lines
+- **Implementation**: `spec-kitty implement WP25 --base WP02,WP09,WP11`
+
+Extract 15 additional shared packages: Go (screentracker, msgfmt, termexec, llm-auth, codeindex), Python (jsonrpc-agent-server, agent-orchestration, audit-trail, terminus2-harness, eval-viewer, harbor-registry), TS (shell-tool-mcp, provider-registry, agent-protocol-bridge, embeddings/graph services).
+
+#### WP26 — Polyglot Alignment + Cross-Language Protocol
+- **Priority**: P2
+- **Subtasks**: T078, T079, T080 (3 tasks)
+- **Dependencies**: WP01, WP07, WP09
+- **Estimated prompt**: ~400 lines
+- **Implementation**: `spec-kitty implement WP26 --base WP01,WP07,WP09`
+
+Align cross-language duplications: shared PTY protocol (Go/Python), publish phenotype-py-cliproxy SDK, define cross-language PolicyPort for governance, designate canonical routing implementation.
+
+#### WP27 — Fork Hardening + Upstream Sync Tooling (heliosCLI)
+- **Priority**: P1
+- **Subtasks**: T081, T082 (2 tasks)
+- **Dependencies**: WP03, WP17
+- **Estimated prompt**: ~300 lines
+- **Implementation**: `spec-kitty implement WP27 --base WP03,WP17`
+
+Add CI-enforced alias map validation, automated upstream diff tracking (code-level drift metrics), and Tauri 2.0 evaluation ADR with migration assessment.
+
+#### WP28 — Architectural Stub Completion + Service Boundaries
+- **Priority**: P2
+- **Subtasks**: T083, T084, T085 (3 tasks)
+- **Dependencies**: WP09, WP11, WP14, WP16
+- **Estimated prompt**: ~500 lines
+- **Implementation**: `spec-kitty implement WP28 --base WP09,WP11,WP14,WP16`
+
+Complete agentapi++ phenotype boundary stub, implement trace plugin registry, separate heliosApp sessions/workspace services, refactor thegent governance behind PolicyEngine port, migrate portage LiteLLM to shared proxy, extract portage environments as entry_points plugin.
+
+---
+
+## Dependency DAG
+
+```
+WP01 ──────────────────────────────▶ WP12 ──▶ WP15
+WP01 ──▶ WP26
+WP02 ──▶ WP04, WP07, WP10, WP11 ──────────▶ WP15
+WP02 ──▶ WP25
+WP03 ──▶ WP04, WP05, WP17, WP18
+WP03 ──▶ WP27
+WP06 ──▶ WP08, WP21, WP23
+WP07 ──▶ WP14, WP26
+WP09 ──▶ WP10 ──▶ WP13
+WP09 ──▶ WP19, WP23, WP25, WP26, WP28
+WP11 ──▶ WP22, WP25, WP28
+WP14 ──▶ WP28
+WP16 ──▶ WP28
+WP17 ──▶ WP27
+WP16, WP20, WP24 (no deps)
+```
+
+## Parallelization Opportunities
+
+**Batch A** (no deps, fully parallel): WP01, WP02, WP03, WP06, WP09, WP16, WP20, WP24
+**Batch B** (after Batch A): WP04, WP05, WP07, WP08, WP10, WP11, WP12, WP17, WP18, WP19, WP21, WP23, WP25, WP26, WP27
+**Batch C** (after Batch B): WP13, WP14, WP15, WP22, WP28
+
+**Maximum parallelism**: 8 agents in Batch A, 15 in Batch B, 5 in Batch C.
+
+## MVP Scope
+
+**WP19 + WP03 + WP20** are the highest-impact starting points:
+- WP19: Delete 469 thegent duplicate files (~100K LOC immediate reduction)
+- WP03: Eliminate ~50 redundant Rust crate definitions
+- WP20: Split the 2 worst god modules in ecosystem (api/main.py 9,274L, create_app 1,164L)
+- WP01: Unblocks audit event integration across all repos


### PR DESCRIPTION
Rebased version of #495 (closed due to merge conflicts). Migrates kitty-specs to AgilePlus spec format.