### PR TITLE
fix(ci): resolve merge conflict in deny.toml

### DIFF
--- a/.github/workflows/rusty-v8-release.yml
+++ b/.github/workflows/rusty-v8-release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       - name: Resolve exact v8 crate version
         id: v8_version
@@ -83,7 +83,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       - name: Build Bazel V8 release pair
         env:

--- a/.github/workflows/v8-canary.yml
+++ b/.github/workflows/v8-canary.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       - name: Resolve exact v8 crate version
         id: v8_version
@@ -80,7 +80,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       - name: Build Bazel V8 release pair
         env:

--- a/codex-rs/deny.toml
+++ b/codex-rs/deny.toml
@@ -73,7 +73,6 @@ ignore = [
     { id = "RUSTSEC-2024-0388", reason = "derivative is unmaintained; pulled in via starlark v0.13.0 used by execpolicy/cli/core; no fixed release yet" },
     { id = "RUSTSEC-2025-0057", reason = "fxhash is unmaintained; pulled in via starlark_map/starlark v0.13.0 used by execpolicy/cli/core; no fixed release yet" },
     { id = "RUSTSEC-2024-0436", reason = "paste is unmaintained; pulled in via ratatui/rmcp/starlark used by tui/execpolicy; no fixed release yet" },
-<<<<<<< HEAD
     # TODO(joshka, nornagon): remove this exception when once we update the ratatui fork to a version that uses lru 0.13+.
         # TODO: remove when aws-lc is updated to a patched version
     { id = "RUSTSEC-2026-0044", reason = "aws-lc-sys: X.509 Name Constraints Bypass via Wildcard/Unicode CN; no fixed version available yet" },
@@ -84,8 +83,6 @@ ignore = [
     { id = "RUSTSEC-2026-0042", reason = "aws-lc-fips-sys: CRL Distribution Point Scope Check Logic Error; no fixed version available yet" },
     { id = "RUSTSEC-2026-0043", reason = "aws-lc-fips-sys: Timing Side-Channel in AES-CCM Tag Verification; no fixed version available yet" },
     { id = "RUSTSEC-2026-0002", reason = "lru 0.12.5 is pulled in via ratatui fork; cannot upgrade until the fork is updated" },
-=======
->>>>>>> upstream_main
     # TODO(fcoury): remove this exception when syntect drops yaml-rust and bincode, or updates to versions that have fixed the vulnerabilities.
     { id = "RUSTSEC-2024-0320", reason = "yaml-rust is unmaintained; pulled in via syntect v5.3.0 used by codex-tui for syntax highlighting; no fixed release yet" },
     { id = "RUSTSEC-2025-0141", reason = "bincode is unmaintained; pulled in via syntect v5.3.0 used by codex-tui for syntax highlighting; no fixed release yet" },


### PR DESCRIPTION
Resolves merge conflict in codex-rs/deny.toml by keeping all RUSTSEC advisory ignores.

Fixes CI failures:
- cargo-deny: unexpected character found (was failing on conflict markers)
- metadata: would have failed on same issue
- sdks: would have failed on same issue