### PR TITLE
fix(ci): reset Cargo.toml and Cargo.lock from pre-merge state

### DIFF
--- a/.github/workflows/rusty-v8-release.yml
+++ b/.github/workflows/rusty-v8-release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       - name: Resolve exact v8 crate version
         id: v8_version
@@ -83,7 +83,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       - name: Build Bazel V8 release pair
         env:

--- a/.github/workflows/v8-canary.yml
+++ b/.github/workflows/v8-canary.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       - name: Resolve exact v8 crate version
         id: v8_version
@@ -80,7 +80,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       - name: Build Bazel V8 release pair
         env:

--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -409,7 +409,6 @@ dependencies = [
  "chrono",
  "codex-app-server-protocol",
  "codex-core",
- "codex-features",
  "codex-protocol",
  "codex-utils-cargo-bin",
  "core_test_support",
@@ -479,58 +478,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
 dependencies = [
  "term",
-]
-
-[[package]]
-name = "askama"
-version = "0.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08e1676b346cadfec169374f949d7490fd80a24193d37d2afce0c047cf695e57"
-dependencies = [
- "askama_macros",
- "itoa",
- "percent-encoding",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "askama_derive"
-version = "0.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7661ff56517787343f376f75db037426facd7c8d3049cef8911f1e75016f3a37"
-dependencies = [
- "askama_parser",
- "basic-toml",
- "memchr",
- "proc-macro2",
- "quote",
- "rustc-hash 2.1.1",
- "serde",
- "serde_derive",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "askama_macros"
-version = "0.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713ee4dbfd1eb719c2dab859465b01fa1d21cb566684614a713a6b7a99a4e47b"
-dependencies = [
- "askama_derive",
-]
-
-[[package]]
-name = "askama_parser"
-version = "0.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d62d674238a526418b30c0def480d5beadb9d8964e7f38d635b03bf639c704c"
-dependencies = [
- "rustc-hash 2.1.1",
- "serde",
- "serde_derive",
- "unicode-ident",
- "winnow",
 ]
 
 [[package]]
@@ -800,15 +747,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-<<<<<<< HEAD
 version = "1.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
-=======
-version = "1.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
->>>>>>> upstream_main
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -817,9 +758,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
+checksum = "5c34dda4df7017c8db52132f0f8a2e0f8161649d15723ed63fc00c82d0f2081a"
 dependencies = [
  "cc",
  "cmake",
@@ -834,7 +775,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core",
- "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -853,10 +793,8 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -955,8 +893,6 @@ dependencies = [
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
- "log",
- "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
@@ -1159,16 +1095,6 @@ name = "cached_proc_macro_types"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
-
-[[package]]
-name = "calendrical_calculations"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a0b39595c6ee54a8d0900204ba4c401d0ab4eb45adaf07178e8d017541529e7"
-dependencies = [
- "core_maths",
- "displaydoc",
-]
 
 [[package]]
 name = "cassowary"
@@ -1446,30 +1372,23 @@ dependencies = [
  "codex-chatgpt",
  "codex-cloud-requirements",
  "codex-core",
- "codex-exec-server",
- "codex-features",
+ "codex-execpolicy",
  "codex-feedback",
  "codex-file-search",
- "codex-git-utils",
  "codex-login",
- "codex-otel",
  "codex-protocol",
  "codex-rmcp-client",
- "codex-sandboxing",
  "codex-shell-command",
  "codex-state",
  "codex-utils-absolute-path",
  "codex-utils-cargo-bin",
  "codex-utils-cli",
  "codex-utils-json-to-toml",
- "codex-utils-pty",
  "core_test_support",
  "futures",
- "opentelemetry",
- "opentelemetry_sdk",
+ "os_info",
  "owo-colors",
  "pretty_assertions",
- "reqwest",
  "rmcp",
  "serde",
  "serde_json",
@@ -1482,31 +1401,9 @@ dependencies = [
  "tokio-util",
  "toml 0.9.11+spec-1.1.0",
  "tracing",
- "tracing-opentelemetry",
  "tracing-subscriber",
  "uuid",
  "wiremock",
-]
-
-[[package]]
-name = "codex-app-server-client"
-version = "0.0.0"
-dependencies = [
- "codex-app-server",
- "codex-app-server-protocol",
- "codex-arg0",
- "codex-core",
- "codex-feedback",
- "codex-protocol",
- "futures",
- "pretty_assertions",
- "serde",
- "serde_json",
- "tokio",
- "tokio-tungstenite",
- "toml 0.9.11+spec-1.1.0",
- "tracing",
- "url",
 ]
 
 [[package]]
@@ -1516,20 +1413,17 @@ dependencies = [
  "anyhow",
  "clap",
  "codex-experimental-api-macros",
- "codex-git-utils",
  "codex-protocol",
  "codex-utils-absolute-path",
  "codex-utils-cargo-bin",
  "inventory",
  "pretty_assertions",
- "rmcp",
  "schemars 0.8.22",
  "serde",
  "serde_json",
- "serde_with",
  "shlex",
  "similar",
- "strum_macros 0.28.0",
+ "strum_macros 0.27.2",
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
@@ -1544,15 +1438,9 @@ dependencies = [
  "anyhow",
  "clap",
  "codex-app-server-protocol",
- "codex-core",
- "codex-otel",
  "codex-protocol",
- "codex-utils-cli",
  "serde",
  "serde_json",
- "tokio",
- "tracing",
- "tracing-subscriber",
  "tungstenite",
  "url",
  "uuid",
@@ -1589,27 +1477,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "codex-artifacts"
-version = "0.0.0"
-dependencies = [
- "codex-package-manager",
- "flate2",
- "pretty_assertions",
- "reqwest",
- "serde",
- "serde_json",
- "sha2",
- "tar",
- "tempfile",
- "thiserror 2.0.18",
- "tokio",
- "url",
- "which 8.0.0",
- "wiremock",
- "zip",
-]
-
-[[package]]
 name = "codex-async-utils"
 version = "0.0.0"
 dependencies = [
@@ -1625,7 +1492,6 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "codex-backend-openapi-models",
- "codex-client",
  "codex-core",
  "codex-protocol",
  "pretty_assertions",
@@ -1649,9 +1515,8 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",
- "codex-connectors",
  "codex-core",
- "codex-git-utils",
+ "codex-git",
  "codex-utils-cargo-bin",
  "codex-utils-cli",
  "pretty_assertions",
@@ -1659,6 +1524,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "urlencoding",
 ]
 
 [[package]]
@@ -1680,21 +1546,14 @@ dependencies = [
  "codex-core",
  "codex-exec",
  "codex-execpolicy",
- "codex-features",
  "codex-login",
  "codex-mcp-server",
  "codex-protocol",
  "codex-responses-api-proxy",
  "codex-rmcp-client",
-<<<<<<< HEAD
-=======
- "codex-sandboxing",
->>>>>>> upstream_main
  "codex-state",
  "codex-stdio-to-uds",
- "codex-terminal-detection",
  "codex-tui",
- "codex-tui-app-server",
  "codex-utils-cargo-bin",
  "codex-utils-cli",
  "codex-windows-sandbox",
@@ -1710,8 +1569,6 @@ dependencies = [
  "tokio",
  "toml 0.9.11+spec-1.1.0",
  "tracing",
- "tracing-appender",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -1720,22 +1577,15 @@ version = "0.0.0"
 dependencies = [
  "async-trait",
  "bytes",
- "codex-utils-cargo-bin",
- "codex-utils-rustls-provider",
  "eventsource-stream",
  "futures",
  "http 1.4.0",
  "opentelemetry",
  "opentelemetry_sdk",
- "pretty_assertions",
  "rand 0.9.2",
  "reqwest",
- "rustls",
- "rustls-native-certs",
- "rustls-pki-types",
  "serde",
  "serde_json",
- "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1776,10 +1626,8 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "clap",
- "codex-client",
  "codex-cloud-tasks-client",
  "codex-core",
- "codex-git-utils",
  "codex-login",
  "codex-tui",
  "codex-utils-cli",
@@ -1806,25 +1654,11 @@ dependencies = [
  "async-trait",
  "chrono",
  "codex-backend-client",
- "codex-git-utils",
+ "codex-git",
  "diffy",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "codex-code-mode"
-version = "0.0.0"
-dependencies = [
- "async-trait",
- "pretty_assertions",
- "serde",
- "serde_json",
- "tokio",
- "tokio-util",
- "tracing",
- "v8",
 ]
 
 [[package]]
@@ -1851,24 +1685,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "codex-connectors"
-version = "0.0.0"
-dependencies = [
- "anyhow",
- "codex-app-server-protocol",
- "pretty_assertions",
- "serde",
- "tokio",
- "urlencoding",
-]
-
-[[package]]
 name = "codex-core"
 version = "0.0.0"
 dependencies = [
  "anyhow",
  "arc-swap",
- "askama",
  "assert_cmd",
  "assert_matches",
  "async-channel",
@@ -1882,40 +1703,27 @@ dependencies = [
  "codex-app-server-protocol",
  "codex-apply-patch",
  "codex-arg0",
- "codex-artifacts",
  "codex-async-utils",
- "codex-code-mode",
+ "codex-client",
  "codex-config",
- "codex-connectors",
- "codex-exec-server",
  "codex-execpolicy",
- "codex-features",
- "codex-git-utils",
+ "codex-file-search",
+ "codex-git",
  "codex-hooks",
- "codex-login",
+ "codex-keyring-store",
  "codex-network-proxy",
  "codex-otel",
  "codex-protocol",
  "codex-rmcp-client",
- "codex-rollout",
- "codex-sandboxing",
  "codex-secrets",
  "codex-shell-command",
  "codex-shell-escalation",
  "codex-skills",
  "codex-state",
-<<<<<<< HEAD
-=======
- "codex-terminal-detection",
->>>>>>> upstream_main
  "codex-test-macros",
  "codex-utils-absolute-path",
- "codex-utils-cache",
  "codex-utils-cargo-bin",
  "codex-utils-home-dir",
- "codex-utils-image",
- "codex-utils-output-truncation",
- "codex-utils-path",
  "codex-utils-pty",
  "codex-utils-readiness",
  "codex-utils-stream-parser",
@@ -1936,14 +1744,15 @@ dependencies = [
  "image",
  "indexmap 2.13.0",
  "insta",
+ "keyring",
  "landlock",
  "libc",
  "maplit",
  "notify",
  "once_cell",
  "openssl-sys",
- "opentelemetry",
  "opentelemetry_sdk",
+ "os_info",
  "predicates",
  "pretty_assertions",
  "rand 0.9.2",
@@ -1957,25 +1766,26 @@ dependencies = [
  "serde_yaml",
  "serial_test",
  "sha1",
+ "sha2",
  "shlex",
  "similar",
  "tempfile",
  "test-case",
  "test-log",
  "thiserror 2.0.18",
+ "time",
  "tokio",
  "tokio-tungstenite",
  "tokio-util",
  "toml 0.9.11+spec-1.1.0",
  "toml_edit 0.24.0+spec-1.1.0",
  "tracing",
- "tracing-opentelemetry",
  "tracing-subscriber",
  "tracing-test",
  "url",
  "uuid",
  "walkdir",
- "which 8.0.0",
+ "which",
  "wildmatch",
  "windows-sys 0.52.0",
  "wiremock",
@@ -2002,63 +1812,35 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "clap",
- "codex-app-server-client",
- "codex-app-server-protocol",
  "codex-apply-patch",
  "codex-arg0",
  "codex-cloud-requirements",
  "codex-core",
- "codex-feedback",
- "codex-git-utils",
- "codex-otel",
  "codex-protocol",
  "codex-utils-absolute-path",
  "codex-utils-cargo-bin",
  "codex-utils-cli",
+ "codex-utils-elapsed",
  "codex-utils-oss",
+ "codex-utils-sandbox-summary",
  "core_test_support",
  "libc",
- "opentelemetry",
- "opentelemetry_sdk",
  "owo-colors",
  "predicates",
  "pretty_assertions",
+ "rmcp",
  "serde",
  "serde_json",
+ "shlex",
  "supports-color 3.0.2",
  "tempfile",
  "tokio",
  "tracing",
- "tracing-opentelemetry",
  "tracing-subscriber",
  "ts-rs",
  "uuid",
  "walkdir",
  "wiremock",
-]
-
-[[package]]
-name = "codex-exec-server"
-version = "0.0.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "base64 0.22.1",
- "clap",
- "codex-app-server-protocol",
- "codex-utils-absolute-path",
- "codex-utils-cargo-bin",
- "codex-utils-pty",
- "futures",
- "pretty_assertions",
- "serde",
- "serde_json",
- "tempfile",
- "test-case",
- "thiserror 2.0.18",
- "tokio",
- "tokio-tungstenite",
- "tracing",
 ]
 
 [[package]]
@@ -2105,23 +1887,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
-<<<<<<< HEAD
-=======
-]
-
-[[package]]
-name = "codex-features"
-version = "0.0.0"
-dependencies = [
- "codex-login",
- "codex-otel",
- "codex-protocol",
- "pretty_assertions",
- "schemars 0.8.22",
- "serde",
- "toml 0.9.11+spec-1.1.0",
- "tracing",
->>>>>>> upstream_main
 ]
 
 [[package]]
@@ -2153,12 +1918,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "codex-git-utils"
+name = "codex-git"
 version = "0.0.0"
 dependencies = [
  "assert_matches",
- "codex-utils-absolute-path",
- "futures",
  "once_cell",
  "pretty_assertions",
  "regex",
@@ -2166,7 +1929,6 @@ dependencies = [
  "serde",
  "tempfile",
  "thiserror 2.0.18",
- "tokio",
  "ts-rs",
  "walkdir",
 ]
@@ -2177,12 +1939,9 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "chrono",
- "codex-config",
  "codex-protocol",
  "futures",
  "pretty_assertions",
- "regex",
- "schemars 0.8.22",
  "serde",
  "serde_json",
  "tempfile",
@@ -2227,7 +1986,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "which 8.0.0",
+ "which",
  "wiremock",
 ]
 
@@ -2236,33 +1995,19 @@ name = "codex-login"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "base64 0.22.1",
  "chrono",
  "codex-app-server-protocol",
- "codex-client",
- "codex-config",
- "codex-keyring-store",
- "codex-protocol",
- "codex-terminal-detection",
+ "codex-core",
  "core_test_support",
- "keyring",
- "once_cell",
- "os_info",
- "pretty_assertions",
  "rand 0.9.2",
- "regex-lite",
  "reqwest",
- "schemars 0.8.22",
  "serde",
  "serde_json",
- "serial_test",
  "sha2",
  "tempfile",
- "thiserror 2.0.18",
  "tiny_http",
  "tokio",
- "tracing",
  "url",
  "urlencoding",
  "webbrowser",
@@ -2276,7 +2021,6 @@ dependencies = [
  "anyhow",
  "codex-arg0",
  "codex-core",
- "codex-features",
  "codex-protocol",
  "codex-shell-command",
  "codex-utils-cli",
@@ -2352,7 +2096,6 @@ version = "0.0.0"
 dependencies = [
  "chrono",
  "codex-api",
- "codex-app-server-protocol",
  "codex-protocol",
  "codex-utils-absolute-path",
  "codex-utils-string",
@@ -2369,33 +2112,13 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "strum_macros 0.28.0",
+ "strum_macros 0.27.2",
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
-]
-
-[[package]]
-name = "codex-package-manager"
-version = "0.0.0"
-dependencies = [
- "fd-lock",
- "flate2",
- "pretty_assertions",
- "reqwest",
- "serde",
- "serde_json",
- "sha2",
- "tar",
- "tempfile",
- "thiserror 2.0.18",
- "tokio",
- "url",
- "wiremock",
- "zip",
 ]
 
 [[package]]
@@ -2412,21 +2135,20 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "codex-execpolicy",
- "codex-git-utils",
+ "codex-git",
  "codex-utils-absolute-path",
  "codex-utils-image",
- "codex-utils-string",
  "icu_decimal",
  "icu_locale_core",
  "icu_provider",
+ "mime_guess",
  "pretty_assertions",
- "quick-xml",
  "schemars 0.8.22",
  "serde",
  "serde_json",
  "serde_with",
  "strum 0.27.2",
- "strum_macros 0.28.0",
+ "strum_macros 0.27.2",
  "sys-locale",
  "tempfile",
  "tracing",
@@ -2456,7 +2178,6 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "axum",
- "codex-client",
  "codex-keyring-store",
  "codex-protocol",
  "codex-utils-cargo-bin",
@@ -2473,57 +2194,13 @@ dependencies = [
  "serde_json",
  "serial_test",
  "sha2",
- "sse-stream",
  "tempfile",
- "thiserror 2.0.18",
  "tiny_http",
  "tokio",
  "tracing",
  "urlencoding",
  "webbrowser",
- "which 8.0.0",
-]
-
-[[package]]
-name = "codex-rollout"
-version = "0.0.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "chrono",
- "codex-file-search",
- "codex-git-utils",
- "codex-login",
- "codex-otel",
- "codex-protocol",
- "codex-state",
- "codex-utils-path",
- "codex-utils-string",
- "pretty_assertions",
- "serde",
- "serde_json",
- "tempfile",
- "time",
- "tokio",
- "tracing",
- "uuid",
-]
-
-[[package]]
-name = "codex-sandboxing"
-version = "0.0.0"
-dependencies = [
- "codex-network-proxy",
- "codex-protocol",
- "codex-utils-absolute-path",
- "dirs",
- "dunce",
- "libc",
- "pretty_assertions",
- "serde_json",
- "tempfile",
- "tracing",
- "url",
+ "which",
 ]
 
 [[package]]
@@ -2533,7 +2210,6 @@ dependencies = [
  "age",
  "anyhow",
  "base64 0.22.1",
- "codex-git-utils",
  "codex-keyring-store",
  "keyring",
  "pretty_assertions",
@@ -2564,7 +2240,7 @@ dependencies = [
  "tree-sitter",
  "tree-sitter-bash",
  "url",
- "which 8.0.0",
+ "which",
 ]
 
 [[package]]
@@ -2604,7 +2280,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
- "codex-git-utils",
+ "codex-otel",
  "codex-protocol",
  "dirs",
  "log",
@@ -2613,7 +2289,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
- "strum 0.27.2",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -2625,6 +2300,7 @@ name = "codex-stdio-to-uds"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "codex-utils-cargo-bin",
  "pretty_assertions",
  "tempfile",
@@ -2632,17 +2308,6 @@ dependencies = [
 ]
 
 [[package]]
-<<<<<<< HEAD
-=======
-name = "codex-terminal-detection"
-version = "0.0.0"
-dependencies = [
- "pretty_assertions",
- "tracing",
-]
-
-[[package]]
->>>>>>> upstream_main
 name = "codex-test-macros"
 version = "0.0.0"
 dependencies = [
@@ -2662,26 +2327,20 @@ dependencies = [
  "chrono",
  "clap",
  "codex-ansi-escape",
- "codex-app-server-client",
  "codex-app-server-protocol",
  "codex-arg0",
  "codex-backend-client",
  "codex-chatgpt",
  "codex-cli",
- "codex-client",
  "codex-cloud-requirements",
  "codex-core",
- "codex-features",
  "codex-feedback",
  "codex-file-search",
- "codex-git-utils",
  "codex-login",
  "codex-otel",
  "codex-protocol",
  "codex-shell-command",
  "codex-state",
- "codex-terminal-detection",
- "codex-tui-app-server",
  "codex-utils-absolute-path",
  "codex-utils-approval-presets",
  "codex-utils-cargo-bin",
@@ -2721,7 +2380,7 @@ dependencies = [
  "serial_test",
  "shlex",
  "strum 0.27.2",
- "strum_macros 0.28.0",
+ "strum_macros 0.27.2",
  "supports-color 3.0.2",
  "syntect",
  "tempfile",
@@ -2741,100 +2400,7 @@ dependencies = [
  "uuid",
  "vt100",
  "webbrowser",
- "which 8.0.0",
- "windows-sys 0.52.0",
- "winsplit",
-]
-
-[[package]]
-name = "codex-tui-app-server"
-version = "0.0.0"
-dependencies = [
- "anyhow",
- "arboard",
- "assert_matches",
- "base64 0.22.1",
- "chrono",
- "clap",
- "codex-ansi-escape",
- "codex-app-server-client",
- "codex-app-server-protocol",
- "codex-arg0",
- "codex-chatgpt",
- "codex-cli",
- "codex-client",
- "codex-cloud-requirements",
- "codex-core",
- "codex-features",
- "codex-feedback",
- "codex-file-search",
- "codex-git-utils",
- "codex-login",
- "codex-otel",
- "codex-protocol",
- "codex-shell-command",
- "codex-state",
- "codex-terminal-detection",
- "codex-utils-absolute-path",
- "codex-utils-approval-presets",
- "codex-utils-cargo-bin",
- "codex-utils-cli",
- "codex-utils-elapsed",
- "codex-utils-fuzzy-match",
- "codex-utils-oss",
- "codex-utils-pty",
- "codex-utils-sandbox-summary",
- "codex-utils-sleep-inhibitor",
- "codex-utils-string",
- "codex-windows-sandbox",
- "color-eyre",
- "cpal",
- "crossterm",
- "derive_more 2.1.1",
- "diffy",
- "dirs",
- "dunce",
- "hound",
- "image",
- "insta",
- "itertools 0.14.0",
- "lazy_static",
- "libc",
- "pathdiff",
- "pretty_assertions",
- "pulldown-cmark",
- "rand 0.9.2",
- "ratatui",
- "ratatui-macros",
- "regex-lite",
- "reqwest",
- "rmcp",
- "serde",
- "serde_json",
- "serial_test",
- "shlex",
- "strum 0.27.2",
- "strum_macros 0.28.0",
- "supports-color 3.0.2",
- "syntect",
- "tempfile",
- "textwrap 0.16.2",
- "thiserror 2.0.18",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "toml 0.9.11+spec-1.1.0",
- "tracing",
- "tracing-appender",
- "tracing-subscriber",
- "two-face",
- "unicode-segmentation",
- "unicode-width 0.2.1",
- "url",
- "uuid",
- "vt100",
- "webbrowser",
- "which 8.0.0",
+ "which",
  "windows-sys 0.52.0",
  "winsplit",
 ]
@@ -2913,7 +2479,7 @@ dependencies = [
  "base64 0.22.1",
  "codex-utils-cache",
  "image",
- "mime_guess",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
 ]
@@ -2934,25 +2500,6 @@ dependencies = [
  "codex-core",
  "codex-lmstudio",
  "codex-ollama",
-]
-
-[[package]]
-name = "codex-utils-output-truncation"
-version = "0.0.0"
-dependencies = [
- "codex-protocol",
- "codex-utils-string",
- "pretty_assertions",
-]
-
-[[package]]
-name = "codex-utils-path"
-version = "0.0.0"
-dependencies = [
- "codex-utils-absolute-path",
- "dunce",
- "pretty_assertions",
- "tempfile",
 ]
 
 [[package]]
@@ -3025,14 +2572,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "codex-v8-poc"
-version = "0.0.0"
-dependencies = [
- "pretty_assertions",
- "v8",
-]
-
-[[package]]
 name = "codex-windows-sandbox"
 version = "0.0.0"
 dependencies = [
@@ -3041,7 +2580,6 @@ dependencies = [
  "chrono",
  "codex-protocol",
  "codex-utils-absolute-path",
- "codex-utils-pty",
  "codex-utils-string",
  "dirs-next",
  "dunce",
@@ -3050,7 +2588,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tokio",
  "windows 0.58.0",
  "windows-sys 0.52.0",
  "winres",
@@ -3238,33 +2775,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "core_maths"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
-dependencies = [
- "libm",
-]
-
-[[package]]
 name = "core_test_support"
 version = "0.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
  "base64 0.22.1",
- "codex-arg0",
  "codex-core",
- "codex-exec-server",
- "codex-features",
  "codex-protocol",
  "codex-utils-absolute-path",
  "codex-utils-cargo-bin",
  "ctor 0.6.3",
  "futures",
  "notify",
- "opentelemetry",
- "opentelemetry_sdk",
  "pretty_assertions",
  "regex-lite",
  "reqwest",
@@ -3273,9 +2796,6 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-tungstenite",
- "tracing",
- "tracing-opentelemetry",
- "tracing-subscriber",
  "walkdir",
  "wiremock",
  "zstd",
@@ -3852,38 +3372,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "diplomat"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9adb46b05e2f53dcf6a7dfc242e4ce9eb60c369b6b6eb10826a01e93167f59c6"
-dependencies = [
- "diplomat_core",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "diplomat-runtime"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0569bd3caaf13829da7ee4e83dbf9197a0e1ecd72772da6d08f0b4c9285c8d29"
-
-[[package]]
-name = "diplomat_core"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51731530ed7f2d4495019abc7df3744f53338e69e2863a6a64ae91821c763df1"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
- "smallvec",
- "strck",
- "syn 2.0.114",
-]
-
-[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4285,17 +3773,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "filetime"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
-dependencies = [
- "cfg-if",
- "libc",
- "libredox",
-]
-
-[[package]]
 name = "find-crate"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4490,25 +3967,9 @@ dependencies = [
 ]
 
 [[package]]
-<<<<<<< HEAD
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-=======
-name = "fslock"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "futures"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
->>>>>>> upstream_main
 checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
@@ -4731,18 +4192,6 @@ dependencies = [
  "log",
  "regex-automata",
  "regex-syntax 0.8.8",
-<<<<<<< HEAD
-=======
-]
-
-[[package]]
-name = "gzip-header"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95cc527b92e6029a62960ad99aa8a6660faa4555fe5f731aab13aa6a921795a2"
-dependencies = [
- "crc32fast",
->>>>>>> upstream_main
 ]
 
 [[package]]
@@ -5203,28 +4652,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_calendar"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6f0e52e009b6b16ba9c0693578796f2dd4aaa59a7f8f920423706714a89ac4e"
-dependencies = [
- "calendrical_calculations",
- "displaydoc",
- "icu_calendar_data",
- "icu_locale",
- "icu_locale_core",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_calendar_data"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527f04223b17edfe0bd43baf14a0cb1b017830db65f3950dc00224860a9a446d"
-
-[[package]]
 name = "icu_collections"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5659,21 +5086,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
-<<<<<<< HEAD
 name = "jiff"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-=======
-name = "ixdtf"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84de9d95a6d2547d9b77ee3f25fa0ee32e3c3a6484d47a55adebc0439c077992"
-
-[[package]]
-name = "jiff"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
->>>>>>> upstream_main
 checksum = "e67e8da4c49d6d9909fe03361f9b620f58898859f5c7aded68351e85e71ecf50"
 dependencies = [
  "jiff-static",
@@ -6090,7 +5505,6 @@ dependencies = [
  "anyhow",
  "codex-core",
  "codex-mcp-server",
- "codex-terminal-detection",
  "codex-utils-cargo-bin",
  "core_test_support",
  "os_info",
@@ -7396,19 +6810,6 @@ dependencies = [
 ]
 
 [[package]]
-<<<<<<< HEAD
-=======
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn 2.0.114",
-]
-
-[[package]]
->>>>>>> upstream_main
 name = "proc-macro-crate"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7556,7 +6957,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
  "memchr",
- "serde",
 ]
 
 [[package]]
@@ -8239,19 +7639,6 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.5",
-<<<<<<< HEAD
-=======
-]
-
-[[package]]
-name = "resb"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a067ab3b5ca3b4dc307d0de9cf75f9f5e6ca9717b192b2f28a36c83e5de9e76"
-dependencies = [
- "potential_utf",
- "serde_core",
->>>>>>> upstream_main
 ]
 
 [[package]]
@@ -8494,9 +7881,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -9035,9 +8422,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.17.0"
+version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
+checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -9054,9 +8441,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.17.0"
+version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
+checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
@@ -9635,15 +9022,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "strck"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42316e70da376f3d113a68d138a60d8a9883c604fe97942721ec2068dab13a9f"
-dependencies = [
- "unicode-ident",
-]
-
-[[package]]
 name = "streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9698,9 +9076,6 @@ name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
-dependencies = [
- "strum_macros 0.27.2",
-]
 
 [[package]]
 name = "strum_macros"
@@ -9725,21 +9100,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
-<<<<<<< HEAD
-=======
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
->>>>>>> upstream_main
 ]
 
 [[package]]
@@ -9867,26 +9227,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
-<<<<<<< HEAD
 name = "tempfile"
 version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-=======
-name = "tar"
-version = "0.4.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
-]
-
-[[package]]
-name = "tempfile"
-version = "3.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
->>>>>>> upstream_main
 checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
@@ -9894,39 +9237,6 @@ dependencies = [
  "once_cell",
  "rustix 1.1.3",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "temporal_capi"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a151e402c2bdb6a3a2a2f3f225eddaead2e7ce7dd5d3fa2090deb11b17aa4ed8"
-dependencies = [
- "diplomat",
- "diplomat-runtime",
- "icu_calendar",
- "icu_locale",
- "num-traits",
- "temporal_rs",
- "timezone_provider",
- "writeable",
- "zoneinfo64",
-]
-
-[[package]]
-name = "temporal_rs"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88afde3bd75d2fc68d77a914bece426aa08aa7649ffd0cdd4a11c3d4d33474d1"
-dependencies = [
- "core_maths",
- "icu_calendar",
- "icu_locale",
- "ixdtf",
- "num-traits",
- "timezone_provider",
- "tinystr",
- "writeable",
 ]
 
 [[package]]
@@ -10134,18 +9444,6 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
-]
-
-[[package]]
-name = "timezone_provider"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9ba0000e9e73862f3e7ca1ff159e2ddf915c9d8bb11e38a7874760f445d993"
-dependencies = [
- "tinystr",
- "zerotrie",
- "zerovec",
- "zoneinfo64",
 ]
 
 [[package]]
@@ -10948,23 +10246,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "v8"
-version = "146.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97bcac5cdc5a195a4813f1855a6bc658f240452aac36caa12fd6c6f16026ab1"
-dependencies = [
- "bindgen",
- "bitflags 2.10.0",
- "fslock",
- "gzip-header",
- "home",
- "miniz_oxide",
- "paste",
- "temporal_capi",
- "which 6.0.3",
-]
-
-[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11262,18 +10543,6 @@ name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
-
-[[package]]
-name = "which"
-version = "6.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
-dependencies = [
- "either",
- "home",
- "rustix 0.38.44",
- "winsafe",
-]
 
 [[package]]
 name = "which"
@@ -12010,16 +11279,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "xattr"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
-dependencies = [
- "libc",
- "rustix 1.1.3",
-]
-
-[[package]]
 name = "xdg-home"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12277,22 +11536,6 @@ name = "zmij"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
-<<<<<<< HEAD
-=======
-
-[[package]]
-name = "zoneinfo64"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2e5597efbe7c421da8a7fd396b20b571704e787c21a272eecf35dfe9d386f0"
-dependencies = [
- "calendrical_calculations",
- "icu_locale_core",
- "potential_utf",
- "resb",
- "serde",
-]
->>>>>>> upstream_main
 
 [[package]]
 name = "zopfli"

--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -4,21 +4,17 @@ members = [
     "ansi-escape",
     "async-utils",
     "app-server",
-    "app-server-client",
     "app-server-protocol",
     "app-server-test-client",
     "debug-client",
     "apply-patch",
     "arg0",
     "feedback",
-    "features",
     "codex-backend-openapi-models",
-    "code-mode",
     "cloud-requirements",
     "cloud-tasks",
     "cloud-tasks-client",
     "cli",
-    "connectors",
     "config",
     "shell-command",
     "shell-escalation",
@@ -27,7 +23,6 @@ members = [
     "hooks",
     "secrets",
     "exec",
-    "exec-server",
     "execpolicy",
     "execpolicy-legacy",
     "keyring-store",
@@ -40,18 +35,14 @@ members = [
     "ollama",
     "process-hardening",
     "protocol",
-    "rollout",
     "rmcp-client",
     "responses-api-proxy",
-    "sandboxing",
     "stdio-to-uds",
     "otel",
     "tui",
-    "tui_app_server",
-    "v8-poc",
     "utils/absolute-path",
     "utils/cargo-bin",
-    "git-utils",
+    "utils/git",
     "utils/cache",
     "utils/image",
     "utils/json-to-toml",
@@ -66,21 +57,13 @@ members = [
     "utils/sleep-inhibitor",
     "utils/approval-presets",
     "utils/oss",
-    "utils/output-truncation",
-    "utils/path-utils",
     "utils/fuzzy-match",
     "utils/stream-parser",
     "codex-client",
     "codex-api",
     "state",
-    "terminal-detection",
     "codex-experimental-api-macros",
     "test-macros",
-<<<<<<< HEAD
-=======
-    "package-manager",
-    "artifacts",
->>>>>>> upstream_main
 ]
 resolver = "2"
 
@@ -98,11 +81,7 @@ license = "Apache-2.0"
 app_test_support = { path = "app-server/tests/common" }
 codex-ansi-escape = { path = "ansi-escape" }
 codex-api = { path = "codex-api" }
-codex-artifacts = { path = "artifacts" }
-codex-code-mode = { path = "code-mode" }
-codex-package-manager = { path = "package-manager" }
 codex-app-server = { path = "app-server" }
-codex-app-server-client = { path = "app-server-client" }
 codex-app-server-protocol = { path = "app-server-protocol" }
 codex-app-server-test-client = { path = "app-server-test-client" }
 codex-apply-patch = { path = "apply-patch" }
@@ -113,17 +92,14 @@ codex-chatgpt = { path = "chatgpt" }
 codex-cli = { path = "cli" }
 codex-client = { path = "codex-client" }
 codex-cloud-requirements = { path = "cloud-requirements" }
-codex-connectors = { path = "connectors" }
 codex-config = { path = "config" }
 codex-core = { path = "core" }
 codex-exec = { path = "exec" }
-codex-exec-server = { path = "exec-server" }
 codex-execpolicy = { path = "execpolicy" }
 codex-experimental-api-macros = { path = "codex-experimental-api-macros" }
 codex-feedback = { path = "feedback" }
-codex-features = { path = "features" }
 codex-file-search = { path = "file-search" }
-codex-git-utils = { path = "git-utils" }
+codex-git = { path = "utils/git" }
 codex-hooks = { path = "hooks" }
 codex-keyring-store = { path = "keyring-store" }
 codex-linux-sandbox = { path = "linux-sandbox" }
@@ -135,10 +111,8 @@ codex-ollama = { path = "ollama" }
 codex-otel = { path = "otel" }
 codex-process-hardening = { path = "process-hardening" }
 codex-protocol = { path = "protocol" }
-codex-rollout = { path = "rollout" }
 codex-responses-api-proxy = { path = "responses-api-proxy" }
 codex-rmcp-client = { path = "rmcp-client" }
-codex-sandboxing = { path = "sandboxing" }
 codex-secrets = { path = "secrets" }
 codex-shell-command = { path = "shell-command" }
 codex-shell-escalation = { path = "shell-escalation" }
@@ -146,13 +120,7 @@ codex-skills = { path = "skills" }
 codex-state = { path = "state" }
 codex-stdio-to-uds = { path = "stdio-to-uds" }
 codex-test-macros = { path = "test-macros" }
-<<<<<<< HEAD
-=======
-codex-terminal-detection = { path = "terminal-detection" }
->>>>>>> upstream_main
 codex-tui = { path = "tui" }
-codex-tui-app-server = { path = "tui_app_server" }
-codex-v8-poc = { path = "v8-poc" }
 codex-utils-absolute-path = { path = "utils/absolute-path" }
 codex-utils-approval-presets = { path = "utils/approval-presets" }
 codex-utils-cache = { path = "utils/cache" }
@@ -164,8 +132,6 @@ codex-utils-home-dir = { path = "utils/home-dir" }
 codex-utils-image = { path = "utils/image" }
 codex-utils-json-to-toml = { path = "utils/json-to-toml" }
 codex-utils-oss = { path = "utils/oss" }
-codex-utils-output-truncation = { path = "utils/output-truncation" }
-codex-utils-path = { path = "utils/path-utils" }
 codex-utils-pty = { path = "utils/pty" }
 codex-utils-readiness = { path = "utils/readiness" }
 codex-utils-rustls-provider = { path = "utils/rustls-provider" }
@@ -183,7 +149,6 @@ allocative = "0.3.3"
 ansi-to-tui = "7.0.0"
 anyhow = "1"
 arboard = { version = "3", features = ["wayland-data-control"] }
-askama = "0.15.4"
 assert_cmd = "2"
 assert_matches = "1.5.0"
 async-channel = "2.3.1"
@@ -208,11 +173,9 @@ dirs = "6"
 dotenvy = "0.15.7"
 dunce = "1.0.4"
 encoding_rs = "0.8.35"
-fd-lock = "4.0.4"
 env-flags = "0.1.1"
 env_logger = "0.11.9"
 eventsource-stream = "0.2.3"
-flate2 = "1.1.4"
 futures = { version = "0.3", default-features = false }
 gethostname = "1.1.0"
 globset = "0.4"
@@ -254,7 +217,6 @@ portable-pty = "0.9.0"
 predicates = "3"
 pretty_assertions = "1.4.1"
 pulldown-cmark = "0.10"
-quick-xml = "0.38.4"
 rand = "0.9"
 ratatui = "0.29.0"
 ratatui-macros = "0.6.0"
@@ -263,13 +225,10 @@ regex-lite = "0.1.8"
 reqwest = "0.12"
 rmcp = { version = "0.15.0", default-features = false }
 runfiles = { git = "https://github.com/dzbarsky/rules_rust", rev = "b56cbaa8465e74127f1ea216f813cd377295ad81" }
-v8 = "=146.4.0"
 rustls = { version = "0.23", default-features = false, features = [
     "ring",
     "std",
 ] }
-rustls-native-certs = "0.8.3"
-rustls-pki-types = "1.14.0"
 schemars = "0.8.22"
 seccompiler = "0.5.0"
 semver = "1.0"
@@ -277,7 +236,7 @@ sentry = "0.46.0"
 serde = "1"
 serde_json = "1"
 serde_path_to_error = "0.1.20"
-serde_with = "3.17"
+serde_with = "3.16"
 serde_yaml = "0.9"
 serial_test = "3.2.0"
 sha1 = "0.10.6"
@@ -297,12 +256,11 @@ sqlx = { version = "0.8.6", default-features = false, features = [
 ] }
 starlark = "0.13.0"
 strum = "0.27.2"
-strum_macros = "0.28.0"
+strum_macros = "0.27.2"
 supports-color = "3.0.2"
 syntect = "5"
 sys-locale = "0.3.2"
 tempfile = "3.23.0"
-tar = "0.4.45"
 test-log = "0.2.19"
 textwrap = "0.16.2"
 thiserror = "2.0.17"
@@ -390,7 +348,6 @@ ignored = [
     "openssl-sys",
     "codex-utils-readiness",
     "codex-secrets",
-    "codex-v8-poc",
 ]
 
 [profile.release]

--- a/codex-rs/deny.toml
+++ b/codex-rs/deny.toml
@@ -73,7 +73,6 @@ ignore = [
     { id = "RUSTSEC-2024-0388", reason = "derivative is unmaintained; pulled in via starlark v0.13.0 used by execpolicy/cli/core; no fixed release yet" },
     { id = "RUSTSEC-2025-0057", reason = "fxhash is unmaintained; pulled in via starlark_map/starlark v0.13.0 used by execpolicy/cli/core; no fixed release yet" },
     { id = "RUSTSEC-2024-0436", reason = "paste is unmaintained; pulled in via ratatui/rmcp/starlark used by tui/execpolicy; no fixed release yet" },
-<<<<<<< HEAD
     # TODO(joshka, nornagon): remove this exception when once we update the ratatui fork to a version that uses lru 0.13+.
         # TODO: remove when aws-lc is updated to a patched version
     { id = "RUSTSEC-2026-0044", reason = "aws-lc-sys: X.509 Name Constraints Bypass via Wildcard/Unicode CN; no fixed version available yet" },
@@ -84,8 +83,6 @@ ignore = [
     { id = "RUSTSEC-2026-0042", reason = "aws-lc-fips-sys: CRL Distribution Point Scope Check Logic Error; no fixed version available yet" },
     { id = "RUSTSEC-2026-0043", reason = "aws-lc-fips-sys: Timing Side-Channel in AES-CCM Tag Verification; no fixed version available yet" },
     { id = "RUSTSEC-2026-0002", reason = "lru 0.12.5 is pulled in via ratatui fork; cannot upgrade until the fork is updated" },
-=======
->>>>>>> upstream_main
     # TODO(fcoury): remove this exception when syntect drops yaml-rust and bincode, or updates to versions that have fixed the vulnerabilities.
     { id = "RUSTSEC-2024-0320", reason = "yaml-rust is unmaintained; pulled in via syntect v5.3.0 used by codex-tui for syntax highlighting; no fixed release yet" },
     { id = "RUSTSEC-2025-0141", reason = "bincode is unmaintained; pulled in via syntect v5.3.0 used by codex-tui for syntax highlighting; no fixed release yet" },


### PR DESCRIPTION
Resets codex-rs/Cargo.toml and Cargo.lock from pre-merge commit to fix CI failures.

The original PR had merge conflicts in both files that were not properly resolved.

Changes:
- Reset Cargo.toml from commit 09e41724a4 (pre-merge state)
- Reset Cargo.lock from same commit

This fixes:
- cargo-deny: was failing on conflict markers in deny.toml
- metadata: was failing on invalid TOML in Cargo.lock
- sdks: would have failed on same TOML issues