### PR TITLE
fix(workspace): unblock codex-rs cargo resolution

### DIFF
--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -229,6 +229,8 @@ rustls = { version = "0.23", default-features = false, features = [
     "ring",
     "std",
 ] }
+rustls-native-certs = "0.8"
+rustls-pki-types = "1.10"
 schemars = "0.8.22"
 seccompiler = "0.5.0"
 semver = "1.0"

--- a/codex-rs/core/Cargo.toml
+++ b/codex-rs/core/Cargo.toml
@@ -72,10 +72,7 @@ eventsource-stream = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
 iana-time-zone = { workspace = true }
-<<<<<<< HEAD
-=======
 image = { workspace = true, features = ["jpeg", "png", "webp"] }
->>>>>>> upstream_main
 indexmap = { workspace = true }
 libc = { workspace = true }
 notify = { workspace = true }


### PR DESCRIPTION
## **User description**
## Summary

Resolves two blockers from the Helios cascade audit that prevent codex-rs workspace from loading:

1. **Merge conflict marker** in `codex-rs/core/Cargo.toml` (literal `<<<<<<< HEAD ... >>>>>>> upstream_main` around the `image` dep). Resolved by taking the `upstream_main` side — matches actual usage in `core/src/context_manager/history*.rs`.
2. **Undeclared workspace deps** referenced by `codex-rs/codex-client/Cargo.toml`: added `rustls-native-certs = "0.8"` and `rustls-pki-types = "1.10"` to `codex-rs/Cargo.toml [workspace.dependencies]`.

## Out of scope (follow-up needed)

Pristine `origin/main` has additional undeclared workspace deps that surface only after these two are fixed (askama, several internal `codex-*` crates not yet in `members`, fd-lock, flate2, quick-xml, tar, v8). Those are independent of the cascade audit and need their own consolidation PR.

## Test plan

- [x] Merge conflict marker removed; TOML parses
- [x] `rustls-native-certs` / `rustls-pki-types` declared at workspace root
- [ ] Full `cargo metadata` clean (blocked by additional pre-existing undeclared deps — out of scope)

Stacked PR follow-up: CVE sweep (PR #233 pattern: aws-lc-rs, quinn-proto, rustls-webpki) once workspace fully resolves.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to Cargo workspace manifests to resolve dependency metadata and remove an accidental merge-conflict marker; no runtime logic is modified.
> 
> **Overview**
> Fixes workspace manifest issues that prevented `codex-rs` from resolving/building.
> 
> This removes stray git merge-conflict markers in `core/Cargo.toml` and restores the intended `image` dependency entry (with `jpeg`/`png`/`webp` features). It also adds missing workspace dependency declarations for `rustls-native-certs` and `rustls-pki-types` in the root `Cargo.toml` so crates referencing them can resolve via `workspace = true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15819bff5d195420eb5cc2fc5bac56c575c5cd50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Unblock `codod-rs` workspace loading by fixing manifest errors

### What Changed
- Removed a stray merge-conflict marker from the core manifest so the workspace file parses cleanly again
- Added missing workspace dependency entries for `rustls-native-certs` and `rustls-pki-types`, allowing the client crate to resolve its declared dependencies

### Impact
`✅ Workspace manifests load without parse errors`
`✅ Fewer dependency resolution failures`
`✅ Faster local builds and metadata checks`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=Sh3DmYGiFvyhaGLpdDKkbAmLOiYSfic46UdDnoORZEk&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
