### PR TITLE
fix(deps): bump 10 HIGH CVEs in codex-rs (aws-lc-sys, quinn-proto, rustls-webpki)

### DIFF
--- a/codex-rs/.cargo/audit.toml
+++ b/codex-rs/.cargo/audit.toml
@@ -3,4 +3,11 @@ ignore = [
     "RUSTSEC-2024-0388", # derivative 2.2.0 via starlark; upstream crate is unmaintained
     "RUSTSEC-2025-0057", # fxhash 0.2.1 via starlark_map; upstream crate is unmaintained
     "RUSTSEC-2024-0436", # paste 1.0.15 via starlark/ratatui; upstream crate is unmaintained
+    # RUSTSEC-2023-0071: Marvin attack on rsa crate (RSA decryption timing
+    # side-channel). No upstream fix has been released — the rsa maintainers
+    # have not yet shipped a patched version. The crate enters our graph
+    # transitively through sqlx's native-tls / mysql backends, which are
+    # not exercised in production code paths. Re-evaluate when rsa publishes
+    # a fix; track upstream at https://rustsec.org/advisories/RUSTSEC-2023-0071
+    "RUSTSEC-2023-0071",
 ]

--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -758,9 +758,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c34dda4df7017c8db52132f0f8a2e0f8161649d15723ed63fc00c82d0f2081a"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -6981,9 +6981,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -7881,9 +7881,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## **User description**
## Summary

Cascades the **heliosCLI PR #233 CVE pattern** into the codex-rs subtree. Stacked on top of #525 (workspace unblock).

Closes **10 of 11** HIGH advisories surfaced by `cargo audit`:

| Crate | From | To | Closes |
|-------|------|-----|--------|
| aws-lc-sys | 0.37.0 | 0.40.0 | RUSTSEC-2026-0044/0045/0046/0047/0048 |
| quinn-proto | 0.11.13 | 0.11.14 | RUSTSEC-2026-0037 |
| rustls-webpki | 0.103.9 | 0.103.13 | RUSTSEC-2026-0049/0098/0099/0104 |

Lock-file updates only; no workspace declaration changes.

## The 11th advisory: RUSTSEC-2023-0071 (rsa Marvin attack)

No upstream fix has been released. The rsa maintainers have not shipped a patched version. The crate enters our graph transitively through sqlx's native-tls / mysql backends that are not exercised in production code paths. Suppressed in `codex-rs/.cargo/audit.toml` with an explanatory comment and re-evaluation pointer.

## Verification

```
$ cargo audit --json | jq '.vulnerabilities.list | length'
0
```

Zero vulnerabilities, 5 informational warnings (pre-existing unmaintained/unsound — not the rsa CVE).

## Test plan

- [x] `cargo audit` reports 0 vulnerabilities (down from 11)
- [x] rsa CVE suppression has explicit justification + tracking pointer
- [x] Stacked on #525 workspace unblock

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Lockfile-only crypto/TLS dependency bumps can change native build/link behavior and runtime TLS/QUIC behavior, so regressions are possible despite no app code changes. The added `cargo-audit` ignore for `RUSTSEC-2023-0071` reduces signal until it’s revisited when upstream ships a fix.
> 
> **Overview**
> Updates `codex-rs` dependency resolutions to remediate multiple **HIGH** RustSec advisories by bumping `aws-lc-sys` `0.37.0→0.40.0`, `quinn-proto` `0.11.13→0.11.14`, and `rustls-webpki` `0.103.9→0.103.13` (via `Cargo.lock` changes only).
> 
> Adds a documented suppression in `codex-rs/.cargo/audit.toml` for `RUSTSEC-2023-0071` (rsa Marvin attack) with justification and a pointer to re-evaluate once an upstream fix is released.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62fa61eefab01bd58fe3a76fb9fe1d13a9da0c03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Ignore the unpatched RSA advisory in the security audit, with a note pointing to the upstream tracking issue.

### What Changed
- The audit list now skips the RSA Marvin attack advisory because no fixed release is available yet
- The entry includes a clear reason and a link for re-checking when an upstream fix lands

### Impact
`✅ Fewer false alarm security scan results`
`✅ Clearer audit reports`
`✅ Easier follow-up on the remaining RSA advisory`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=beKL8pTlnsj_IPY0KaR43ys1SvSD94DTJ3wVtP9Gbbs&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
