### PR TITLE
fix(workspace): declare 19 missing workspace dependencies

### DIFF
--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -42,7 +42,6 @@ members = [
     "tui",
     "utils/absolute-path",
     "utils/cargo-bin",
-    "utils/git",
     "utils/cache",
     "utils/image",
     "utils/json-to-toml",
@@ -82,24 +81,30 @@ app_test_support = { path = "app-server/tests/common" }
 codex-ansi-escape = { path = "ansi-escape" }
 codex-api = { path = "codex-api" }
 codex-app-server = { path = "app-server" }
+codex-app-server-client = { path = "app-server-client" }
 codex-app-server-protocol = { path = "app-server-protocol" }
 codex-app-server-test-client = { path = "app-server-test-client" }
 codex-apply-patch = { path = "apply-patch" }
 codex-arg0 = { path = "arg0" }
+codex-artifacts = { path = "artifacts" }
 codex-async-utils = { path = "async-utils" }
 codex-backend-client = { path = "backend-client" }
 codex-chatgpt = { path = "chatgpt" }
 codex-cli = { path = "cli" }
 codex-client = { path = "codex-client" }
 codex-cloud-requirements = { path = "cloud-requirements" }
+codex-code-mode = { path = "code-mode" }
 codex-config = { path = "config" }
+codex-connectors = { path = "connectors" }
 codex-core = { path = "core" }
 codex-exec = { path = "exec" }
+codex-exec-server = { path = "exec-server" }
 codex-execpolicy = { path = "execpolicy" }
 codex-experimental-api-macros = { path = "codex-experimental-api-macros" }
+codex-features = { path = "features" }
 codex-feedback = { path = "feedback" }
 codex-file-search = { path = "file-search" }
-codex-git = { path = "utils/git" }
+codex-git-utils = { path = "git-utils" }
 codex-hooks = { path = "hooks" }
 codex-keyring-store = { path = "keyring-store" }
 codex-linux-sandbox = { path = "linux-sandbox" }
@@ -109,18 +114,23 @@ codex-mcp-server = { path = "mcp-server" }
 codex-network-proxy = { path = "network-proxy" }
 codex-ollama = { path = "ollama" }
 codex-otel = { path = "otel" }
+codex-package-manager = { path = "package-manager" }
 codex-process-hardening = { path = "process-hardening" }
 codex-protocol = { path = "protocol" }
 codex-responses-api-proxy = { path = "responses-api-proxy" }
 codex-rmcp-client = { path = "rmcp-client" }
+codex-rollout = { path = "rollout" }
+codex-sandboxing = { path = "sandboxing" }
 codex-secrets = { path = "secrets" }
 codex-shell-command = { path = "shell-command" }
 codex-shell-escalation = { path = "shell-escalation" }
 codex-skills = { path = "skills" }
 codex-state = { path = "state" }
 codex-stdio-to-uds = { path = "stdio-to-uds" }
+codex-terminal-detection = { path = "terminal-detection" }
 codex-test-macros = { path = "test-macros" }
 codex-tui = { path = "tui" }
+codex-tui-app-server = { path = "tui_app_server" }
 codex-utils-absolute-path = { path = "utils/absolute-path" }
 codex-utils-approval-presets = { path = "utils/approval-presets" }
 codex-utils-cache = { path = "utils/cache" }
@@ -132,6 +142,8 @@ codex-utils-home-dir = { path = "utils/home-dir" }
 codex-utils-image = { path = "utils/image" }
 codex-utils-json-to-toml = { path = "utils/json-to-toml" }
 codex-utils-oss = { path = "utils/oss" }
+codex-utils-output-truncation = { path = "utils/output-truncation" }
+codex-utils-path = { path = "utils/path-utils" }
 codex-utils-pty = { path = "utils/pty" }
 codex-utils-readiness = { path = "utils/readiness" }
 codex-utils-rustls-provider = { path = "utils/rustls-provider" }
@@ -154,6 +166,7 @@ assert_matches = "1.5.0"
 async-channel = "2.3.1"
 async-stream = "0.3.6"
 async-trait = "0.1.89"
+askama = "0.14.0"
 axum = { version = "0.8", default-features = false }
 base64 = "0.22.1"
 bm25 = "2.3.2"
@@ -176,6 +189,8 @@ encoding_rs = "0.8.35"
 env-flags = "0.1.1"
 env_logger = "0.11.9"
 eventsource-stream = "0.2.3"
+fd-lock = "4.0.4"
+flate2 = "1.0.35"
 futures = { version = "0.3", default-features = false }
 gethostname = "1.1.0"
 globset = "0.4"
@@ -217,6 +232,7 @@ portable-pty = "0.9.0"
 predicates = "3"
 pretty_assertions = "1.4.1"
 pulldown-cmark = "0.10"
+quick-xml = "0.38.3"
 rand = "0.9"
 ratatui = "0.29.0"
 ratatui-macros = "0.6.0"
@@ -262,6 +278,7 @@ strum_macros = "0.27.2"
 supports-color = "3.0.2"
 syntect = "5"
 sys-locale = "0.3.2"
+tar = "0.4.43"
 tempfile = "3.23.0"
 test-log = "0.2.19"
 textwrap = "0.16.2"
@@ -293,6 +310,7 @@ unicode-width = "0.2"
 url = "2"
 urlencoding = "2.1"
 uuid = "1"
+v8 = "130"
 vt100 = "0.16.2"
 walkdir = "2.5.0"
 webbrowser = "1.0"

--- a/codex-rs/cli/Cargo.toml
+++ b/codex-rs/cli/Cargo.toml
@@ -36,10 +36,7 @@ codex-mcp-server = { workspace = true }
 codex-protocol = { workspace = true }
 codex-responses-api-proxy = { workspace = true }
 codex-rmcp-client = { workspace = true }
-<<<<<<< HEAD
-=======
 codex-sandboxing = { workspace = true }
->>>>>>> upstream_main
 codex-state = { workspace = true }
 codex-stdio-to-uds = { workspace = true }
 codex-terminal-detection = { workspace = true }


### PR DESCRIPTION
## **User description**
## Summary

`cargo metadata --manifest-path codex-rs/Cargo.toml --no-deps` failed because workspace members inherit deps that were never declared in `[workspace.dependencies]`. This blocks tooling, IDEs, and CI that rely on metadata loading. Adds the 19 missing entries (14 internal path deps, 6 external version deps) plus two pre-existing blockers exposed once the deps loaded.

## Changes

**Internal `path` deps** (local workspace crates):
- `codex-app-server-client`, `codex-artifacts`, `codex-code-mode`, `codex-connectors`, `codex-exec-server`, `codex-features`, `codex-git-utils`, `codex-package-manager`, `codex-rollout`, `codex-sandboxing`, `codex-terminal-detection`, `codex-tui-app-server`, `codex-utils-output-truncation`, `codex-utils-path`

**External `version` deps** (latest stable per "bleeding-edge first"):
- `askama = "0.14.0"`
- `fd-lock = "4.0.4"`
- `flate2 = "1.0.35"`
- `quick-xml = "0.38.3"`
- `tar = "0.4.43"`
- `v8 = "130"`

**Pre-existing blockers fixed** (CI Completeness Policy):
- Removed orphan workspace member `utils/git` — directory does not exist on disk, no consumer references `codex-git`.
- Resolved unmerged conflict marker in `codex-rs/cli/Cargo.toml` (`<<<<<<< HEAD ... >>>>>>> upstream_main`) by keeping the `codex-sandboxing = { workspace = true }` line.

## Verification

```
$ cargo metadata --manifest-path codex-rs/Cargo.toml --no-deps
# (success — metadata loads, all members resolve)
```

Did not run `cargo build` (disk-tight on this host); metadata-only verification per task scope.

## Test plan
- [x] `cargo metadata --manifest-path codex-rs/Cargo.toml --no-deps` exits 0
- [ ] `cargo build --workspace` (defer to CI / merger; disk constrained locally)
- [ ] downstream tooling (clippy, rust-analyzer) loads workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk manifest-only changes: updates workspace dependency declarations and cleans up a stray merge conflict marker. Main risk is potential downstream build/lockfile churn from newly declared external crates and renamed internal git utility crate.
> 
> **Overview**
> Fixes workspace metadata resolution by declaring previously missing `[workspace.dependencies]` entries (adds multiple internal `path` crates and several external crates like `askama`, `tar`, and `v8`).
> 
> Removes the nonexistent `utils/git` workspace member/`codex-git` reference in favor of `codex-git-utils`, and cleans up an unmerged conflict marker in `cli/Cargo.toml` while keeping `codex-sandboxing` as a workspace dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 551bb9872f6e4ffb5098bd6741cc0d4d00937bfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Fix workspace dependency declarations so metadata loading succeeds

### What Changed
- Added missing workspace dependencies for local crates and external libraries so workspace members can load correctly
- Removed an invalid workspace member entry for a folder that does not exist
- Cleared a merge conflict marker in the CLI manifest and kept the sandboxing dependency in place

### Impact
`✅ Workspace metadata loads successfully`
`✅ Fewer IDE and CI failures when scanning the workspace`
`✅ No broken workspace member references`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=0OgVQLNtyrtKExrrqt2gK7D4j0bWStAZlvWtGTC_kTE&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
