### PR TITLE
docs(readme): add Phenotype fork-context preamble

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,30 @@
+<!-- PHENOTYPE FORK CONTEXT — see "About this fork" below -->
+
+## About this fork
+
+`KooshaPari/helios-cli` is a Phenotype-org fork of [OpenAI Codex CLI](https://github.com/openai/codex). The upstream README is preserved verbatim below; this preamble documents fork-specific divergence so downstream consumers can tell what is upstream behavior versus a Phenotype patch.
+
+**Why we fork:** Codex CLI is one of the agent backends wired into the Phenotype `thegent` dispatcher. We carry security and workspace fixes ahead of upstream merge cadence and ship them via this fork's tagged releases.
+
+**Recent Phenotype-specific changes:**
+
+- **#527 — `fix(workspace): declare 19 missing workspace dependencies`** — restores `cargo metadata`/`cargo build` resolution in `codex-rs/` after upstream workspace drift.
+- **#526 — `fix(deps): bump 10 HIGH CVEs in codex-rs`** — `aws-lc-sys`, `quinn-proto`, `rustls-webpki` upgrades; closes RUSTSEC advisories that upstream had not yet absorbed.
+- **#525 — `fix(workspace): unblock codex-rs cargo resolution`** — preparatory unblock for the CVE sweep.
+- **#524 / #523 / #522** — OpenSSF Scorecard workflow, `CODE_OF_CONDUCT.md`, `.github/FUNDING.yml` — Phenotype-org hygiene baseline.
+- **#519–#521** — pinned floating external GitHub Actions to commit SHAs across `stage-gates.yml`, `issue-labeler.yml`, `issue-deduplicator.yml`.
+- **#518** — bootstrapped a VitePress docs deploy workflow.
+
+**Where to find Phenotype-specific docs:**
+
+- Roadmap and fork strategy: [`PLAN.md`](./PLAN.md)
+- Phenotype contribution conventions: [`docs/contributing.md`](./docs/contributing.md) and the upstream `AGENTS.md` chain in `docs/agents_md.md`
+- Phenotype org context: [`KooshaPari/phenotype-infrakit`](https://github.com/KooshaPari/phenotype-infrakit) and the `thegent` dispatcher
+
+**Upstream tracking:** we periodically rebase or merge from `openai/codex@main`. Open a PR against this fork for Phenotype-specific changes; upstreamable fixes should also be PR'd to `openai/codex` directly.
+
+---
+
 <p align="center"><code>npm i -g @openai/codex</code><br />or <code>brew install --cask codex</code></p>
 <p align="center"><strong>Codex CLI</strong> is a coding agent from OpenAI that runs locally on your computer.
 <p align="center">


### PR DESCRIPTION
## Summary

- Prepend a Phenotype fork-context preamble to README.md so downstream readers can distinguish upstream Codex CLI behavior from this fork's patches.
- Preserves the upstream README verbatim below the preamble — no replacement, no deletion.
- Enumerates recent fork-specific PRs: #525 / #526 (codex-rs CVE sweep), #527 (workspace deps), #524 OSSF Scorecard, #523 CoC, #522 funding, #519–#521 action SHA pinning, #518 VitePress docs deploy.
- Points readers at PLAN.md, docs/contributing.md, and the phenotype-infrakit / thegent ecosystem.

Per audit finding: helios-cli previously shipped OpenAI Codex CLI's README verbatim with no fork framing.

## Test plan

- [x] README renders correctly (markdown only; no code paths touched)
- [x] Upstream README content preserved unchanged below the preamble
- [x] All referenced PR numbers (#518–#527) verified against gh pr list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that prepends fork context to `README.md`; no runtime behavior, build, or dependency changes.
> 
> **Overview**
> Adds a new **"About this fork"** preamble to `README.md` describing this repo as a Phenotype-org fork of OpenAI Codex CLI, why it diverges, and how it tracks upstream.
> 
> Lists recent Phenotype-specific PRs and links to fork-specific docs (`PLAN.md`, `docs/contributing.md`, `docs/agents_md.md`) while keeping the upstream README content intact below the new section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abd5f51e22d6865250f923ccf928df927214a528. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->