### PR TITLE
[codex] resolve helios-cli merge conflicts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,7 @@ jobs:
         run: |
           set -euo pipefail
           # Use a rust-release version that includes all native binaries.
-<<<<<<< HEAD
-          CODEX_VERSION=0.107.0
-=======
           CODEX_VERSION=0.115.0
->>>>>>> upstream_main
           OUTPUT_DIR="${RUNNER_TEMP}"
           python3 ./scripts/stage_npm_packages.py \
             --release-version "$CODEX_VERSION" \
@@ -52,12 +48,8 @@ jobs:
           echo "pack_output=$PACK_OUTPUT" >> "$GITHUB_OUTPUT"
 
       - name: Upload staged npm package artifact
-<<<<<<< HEAD
         if: steps.stage_npm_package.outcome == 'success'
-        uses: actions/upload-artifact@v6
-=======
         uses: actions/upload-artifact@v7
->>>>>>> upstream_main
         with:
           name: codex-npm-staging
           path: ${{ steps.stage_npm_package.outputs.pack_output }}

--- a/docs/js_repl.md
+++ b/docs/js_repl.md
@@ -78,10 +78,6 @@ imported local file. They are not resolved relative to the imported file's locat
 - `codex.homeDir`: effective home directory path from the kernel environment.
 - `codex.tmpDir`: per-session scratch directory path.
 - `codex.tool(name, args?)`: executes a normal Codex tool call from inside `js_repl` (including shell tools like `shell` / `shell_command` when available).
-<<<<<<< HEAD
-- Each `codex.tool(...)` call emits a bounded summary at `info` level from the `codex_core::tools::js_repl` logger. At `trace` level, the same path also logs the exact raw response object or error string seen by JavaScript.
-- To share generated images with the model, write a file under `codex.tmpDir`, call `await codex.tool("view_image", { path: "/absolute/path" })`, then delete the file.
-=======
 - `codex.emitImage(imageLike)`: explicitly adds one image to the outer `js_repl` function output each time you call it.
 - `codex.tool(...)` and `codex.emitImage(...)` keep stable helper identities across cells. Saved references and persisted objects can reuse them in later cells, but async callbacks that fire after a cell finishes still fail because no exec is active.
 - Imported local files run in the same VM context, so they can also access `codex.*`, the captured `console`, and Node-like `import.meta` helpers.
@@ -93,7 +89,6 @@ imported local file. They are not resolved relative to the imported file's locat
 - Example of sharing an in-memory Playwright screenshot: `await codex.emitImage({ bytes: await page.screenshot({ type: "jpeg", quality: 85 }), mimeType: "image/jpeg", detail: "original" })`.
 - Example of sharing a local image tool result: `await codex.emitImage(codex.tool("view_image", { path: "/absolute/path", detail: "original" }))`.
 - When encoding an image to send with `codex.emitImage(...)` or `view_image`, prefer JPEG at about 85 quality when lossy compression is acceptable; use PNG when transparency or lossless detail matters. Smaller uploads are faster and less likely to hit size limits.
->>>>>>> upstream_main
 
 Avoid writing directly to `process.stdout` / `process.stderr` / `process.stdin`; the kernel uses a JSON-line transport over stdio.
 

--- a/package.json
+++ b/package.json
@@ -3,15 +3,10 @@
   "private": true,
   "description": "Tools for repo-wide maintenance.",
   "scripts": {
-<<<<<<< HEAD
     "lint": "oxlint .",
     "format": "oxfmt --check *.json *.md docs/*.md .github/workflows/*.yml **/*.js",
-    "format:fix": "oxfmt --write *.json *.md docs/*.md .github/workflows/*.yml **/*.js"
-=======
-    "format": "prettier --check *.json *.md docs/*.md .github/workflows/*.yml **/*.js",
-    "format:fix": "prettier --write *.json *.md docs/*.md .github/workflows/*.yml **/*.js",
+    "format:fix": "oxfmt --write *.json *.md docs/*.md .github/workflows/*.yml **/*.js",
     "write-hooks-schema": "cargo run --manifest-path ./codex-rs/Cargo.toml -p codex-hooks --bin write_hooks_schema_fixtures"
->>>>>>> upstream_main
   },
   "devDependencies": {
     "oxfmt": "^0.35.0",


### PR DESCRIPTION
Resolve the merge-conflict markers in `package.json`, `.github/workflows/ci.yml`, and `docs/js_repl.md`.

The branch still has unrelated local edits in `CHANGELOG.md` and `Cargo.toml`, which were left untouched.
