### PR TITLE
chore: add standard README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ If you want Codex in your code editor (VS Code, Cursor, Windsurf), <a href="http
 [![Phenotype](https://img.shields.io/badge/Phenotype-org-blueviolet)](https://github.com/KooshaPari)
 
 
+[![Build](https://img.shields.io/github/actions/workflow/status/KooshaPari/helios-cli/rust-ci.yml?branch=main&label=build)](https://github.com/KooshaPari/helios-cli/actions/workflows/rust-ci.yml)
+[![Release](https://img.shields.io/github/v/release/KooshaPari/helios-cli?include_prereleases&sort=semver)](https://github.com/KooshaPari/helios-cli/releases)
+[![License](https://img.shields.io/github/license/KooshaPari/helios-cli)](LICENSE)
+[![Phenotype](https://img.shields.io/badge/Phenotype-org-blueviolet)](https://github.com/KooshaPari)
+
+
 **Status:** stable
 
 A multi-model coding agent CLI framework built with Bazel, Rust, and TypeScript. HeliosCLI provides a unified interface for integrating coding agents from OpenAI Codex, Claude, Gemini, and other AI models with a local sandboxing and execution engine.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ If you want Codex in your code editor (VS Code, Cursor, Windsurf), <a href="http
 
 # HeliosCLI
 
+[![Build](https://img.shields.io/github/actions/workflow/status/KooshaPari/helios-cli/rust-ci.yml?branch=main&label=build)](https://github.com/KooshaPari/helios-cli/actions/workflows/rust-ci.yml)
+[![Release](https://img.shields.io/github/v/release/KooshaPari/helios-cli?include_prereleases&sort=semver)](https://github.com/KooshaPari/helios-cli/releases)
+[![License](https://img.shields.io/github/license/KooshaPari/helios-cli)](LICENSE)
+[![Phenotype](https://img.shields.io/badge/Phenotype-org-blueviolet)](https://github.com/KooshaPari)
+
+
 **Status:** stable
 
 A multi-model coding agent CLI framework built with Bazel, Rust, and TypeScript. HeliosCLI provides a unified interface for integrating coding agents from OpenAI Codex, Claude, Gemini, and other AI models with a local sandboxing and execution engine.


### PR DESCRIPTION
## Summary

Adds standard badges to the README:
- **Build**: GitHub Actions CI status (main branch)
- **Release**: Latest release badge
- **License**: License badge
- **Phenotype**: Org affiliation badge

## Test plan
- [ ] Verify badges render correctly in PR preview
- [ ] Check all badge URLs resolve correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change; the only risk is cosmetic (duplicate badge block / broken badge links).
> 
> **Overview**
> Adds a set of Shields.io badges to `README.md` under **HeliosCLI** for CI build status, latest release, license, and Phenotype org affiliation (currently inserted twice in the file).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56b069acfa0d36e6b75dbb6eda3c6863a2281352. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->