### PR TITLE
chore: pin GitHub Actions to immutable SHAs

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -14,7 +14,7 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cargo-machete.yml
+++ b/.github/workflows/cargo-machete.yml
@@ -14,7 +14,7 @@ jobs:
   detect-unused-dependencies:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - uses: taiki-e/install-action@v2
         with:

--- a/.github/workflows/cargo-semver-checks.yml
+++ b/.github/workflows/cargo-semver-checks.yml
@@ -6,5 +6,5 @@ jobs:
   semver-checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: obi1kenobi/cargo-semver-checks-action@v2

--- a/.github/workflows/codeql-rust.yml
+++ b/.github/workflows/codeql-rust.yml
@@ -20,7 +20,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/namespace-audit-retro.yml
+++ b/.github/workflows/namespace-audit-retro.yml
@@ -20,7 +20,7 @@ jobs:
   audit-open-items:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Run namespace audit
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/policy-gate.yml
+++ b/.github/workflows/policy-gate.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pr-babysit-watch.yml
+++ b/.github/workflows/pr-babysit-watch.yml
@@ -24,7 +24,7 @@ jobs:
       checks: read
       issues: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Run open PR babysit sweep
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -19,7 +19,7 @@ jobs:
       actions: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/stage-gates.yml
+++ b/.github/workflows/stage-gates.yml
@@ -21,7 +21,7 @@ jobs:
       gates: ${{ steps.detect.outputs.gates }}
       lang: ${{ steps.detect-lang.outputs.lang }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Detect stage from branch
         id: detect
@@ -94,7 +94,7 @@ jobs:
     if: contains(needs.detect-stage.outputs.gates, 'format')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Format check (Rust)
         if: needs.detect-stage.outputs.lang == 'rust'
         run: cargo fmt --all --check --manifest-path codex-rs/Cargo.toml
@@ -113,7 +113,7 @@ jobs:
     if: contains(needs.detect-stage.outputs.gates, 'lint')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Install Linux build dependencies (Rust)
         if: needs.detect-stage.outputs.lang == 'rust'
         run: |
@@ -137,7 +137,7 @@ jobs:
     if: contains(needs.detect-stage.outputs.gates, 'secrets')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
       - uses: gitleaks/gitleaks-action@v2
@@ -149,7 +149,7 @@ jobs:
     if: contains(needs.detect-stage.outputs.gates, 'unit')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Install Linux build dependencies (Rust)
         if: needs.detect-stage.outputs.lang == 'rust'
         run: |
@@ -173,7 +173,7 @@ jobs:
     if: contains(needs.detect-stage.outputs.gates, 'integration')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Install Linux build dependencies (Rust)
         if: needs.detect-stage.outputs.lang == 'rust'
         run: |
@@ -197,7 +197,7 @@ jobs:
     if: contains(needs.detect-stage.outputs.gates, 'coverage-')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Install Linux build dependencies (Rust)
         if: needs.detect-stage.outputs.lang == 'rust'
         run: |
@@ -239,7 +239,7 @@ jobs:
     if: contains(needs.detect-stage.outputs.gates, 'sast')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: SAST (Rust)
         if: needs.detect-stage.outputs.lang == 'rust'
         run: cargo install cargo-audit && cargo audit --file codex-rs/Cargo.lock
@@ -258,7 +258,7 @@ jobs:
     if: contains(needs.detect-stage.outputs.gates, 'dep-audit')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Dep audit (Rust)
         if: needs.detect-stage.outputs.lang == 'rust'
         run: cargo install cargo-deny && cargo deny --manifest-path codex-rs/Cargo.toml check
@@ -277,7 +277,7 @@ jobs:
     if: contains(needs.detect-stage.outputs.gates, 'license') && secrets.FOSSA_API_KEY != ''
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: License scan
         uses: fossas/fossa-action@29693cc50323968e039056be419b32989fc5880c  # was: @main
         with:
@@ -288,7 +288,7 @@ jobs:
     if: contains(needs.detect-stage.outputs.gates, 'e2e-smoke')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Run smoke E2E tests
         run: |
           if [ -f Makefile ] && grep -q 'e2e-smoke' Makefile; then
@@ -302,7 +302,7 @@ jobs:
     if: contains(needs.detect-stage.outputs.gates, 'e2e-full')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Run full E2E tests
         run: |
           if [ -f Makefile ] && grep -q 'e2e-full' Makefile; then
@@ -316,7 +316,7 @@ jobs:
     if: contains(needs.detect-stage.outputs.gates, 'perf')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Run performance benchmarks
         run: |
           if [ -f Makefile ] && grep -q 'bench' Makefile; then
@@ -330,7 +330,7 @@ jobs:
     if: contains(needs.detect-stage.outputs.gates, 'sla-validation')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Validate SLA compliance
         run: |
           if [ -f Makefile ] && grep -q 'sla-check' Makefile; then
@@ -344,7 +344,7 @@ jobs:
     if: contains(needs.detect-stage.outputs.gates, 'coderabbit')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Trigger CodeRabbit review
         run: |
           echo "CodeRabbit review triggered for stage ${{ needs.detect-stage.outputs.stage }}"
@@ -357,7 +357,7 @@ jobs:
     if: contains(needs.detect-stage.outputs.gates, 'gca-review')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: GCA review gate
         run: echo "GCA review required for stage ${{ needs.detect-stage.outputs.stage }}. Ensure GCA sign-off before merge."
 
@@ -375,7 +375,7 @@ jobs:
     if: contains(needs.detect-stage.outputs.gates, 'sbom')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Generate SBOM
         uses: anchore/sbom-action@v0
         with:
@@ -386,7 +386,7 @@ jobs:
     if: contains(needs.detect-stage.outputs.gates, 'artifact-checksum')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Build and checksum artifacts
         run: |
           if [ -f Makefile ] && grep -q 'build' Makefile; then
@@ -407,7 +407,7 @@ jobs:
     if: contains(needs.detect-stage.outputs.gates, 'targeted-regression')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Run targeted regression tests
         run: |
           if [ -f Makefile ] && grep -q 'regression' Makefile; then


### PR DESCRIPTION
Pin GitHub Actions to immutable SHA references for supply chain security.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to GitHub Actions workflow references and should not affect application runtime behavior, though they can impact CI execution if the pinned digest is incorrect or later revoked.
> 
> **Overview**
> Updates multiple GitHub Actions workflows to **pin `actions/checkout` to the immutable commit SHA for v4.1.1** instead of the floating `@v4` tag.
> 
> This hardens CI/CD against action supply-chain drift while keeping workflow logic and job steps otherwise unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2081b58a7b41ef069fd0f295021216b34828fa54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->