### PR TITLE
chore: pin setup-python to immutable SHA

### DIFF
--- a/.github/workflows/rusty-v8-release.yml
+++ b/.github/workflows/rusty-v8-release.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d870656
         with:
           python-version: "3.14"
 
@@ -81,7 +81,7 @@ jobs:
         uses: bazelbuild/setup-bazelisk@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d870656
         with:
           python-version: "3.14"
 

--- a/.github/workflows/v8-canary.yml
+++ b/.github/workflows/v8-canary.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d870656
         with:
           python-version: "3.14"
 
@@ -78,7 +78,7 @@ jobs:
         uses: bazelbuild/setup-bazelisk@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d870656
         with:
           python-version: "3.14"
 


### PR DESCRIPTION
## **User description**
Pins setup-python@v5 to a26af69be951a213d495a4c3e4e4022e16d87065

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow hardening change that only affects CI by pinning the `actions/setup-python` dependency; no product code or build logic changes.
> 
> **Overview**
> Pins `actions/setup-python` to a specific commit SHA in the `rusty-v8-release` and `v8-canary` GitHub Actions workflows (replacing the floating `@v6` tag) to make Python setup deterministic and reduce supply-chain risk.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2930cb981013782aea0fb48877382111474734f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Pin Python setup to a fixed version in release workflows**

### What Changed
- The release and canary GitHub Actions workflows now use a fixed `actions/setup-python` revision instead of a moving version tag.
- Python setup for both metadata and build jobs is now locked down in the two release pipelines.

### Impact
`✅ Fewer CI breakages from upstream action changes`
`✅ More predictable release workflow runs`
`✅ Lower supply-chain risk in Python setup`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=LMfhrPfZa98dLJVuTXfU-Yr4z43lxLvNqFuLhQLBbYA&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
