### PR TITLE
docs(iconography): complete Fluent + Material icon sets (20+20)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
-# Claude AI Agent Guide - heliosCLI
+# Claude AI Agent Guide - helios-cli
 
-heliosCLI is a multi-runtime AI coding CLI (Codex, Claude, Gemini, Cursor, Copilot) built with a Bazel monorepo, Rust core (`codex-rs`), and TypeScript CLI (`codex-cli`). It integrates with `thegent` for agent orchestration.
+helios-cli is a multi-runtime AI coding CLI (Codex, Claude, Gemini, Cursor, Copilot) built with a Bazel monorepo, Rust core (`codex-rs`), and TypeScript CLI (`codex-cli`). It integrates with `thegent` for agent orchestration.
 
 **Authority and Scope**
 
@@ -57,7 +57,7 @@ bazel run //codex-cli:codex -- --help
 ## 2. Repository Structure
 
 ```
-heliosCLI/
+helios-cli/
 ├── codex-rs/           # Rust core (exec engine, protocol, sandbox)
 │   ├── core/           # Core types, models, config
 │   ├── exec/           # Execution engine
@@ -77,7 +77,7 @@ heliosCLI/
 
 ## 3. Build System (Bazel)
 
-heliosCLI uses Bazel as the primary build system with Cargo and pnpm as secondary.
+helios-cli uses Bazel as the primary build system with Cargo and pnpm as secondary.
 
 ```bash
 # Build all targets
@@ -191,9 +191,9 @@ Root-level markdown: only `README.md`, `CHANGELOG.md`, `AGENTS.md`, `CLAUDE.md`.
 
 ## 8. Worktree Discipline
 
-- Feature work goes in `repos/worktrees/heliosCLI/<topic>/`
-- Legacy `heliosCLI-wtrees/` and `PROJECT-wtrees/` roots are migration-only and must not receive new work
-- Canonical `heliosCLI/` stays on `main`
+- Feature work goes in `repos/worktrees/helios-cli/<topic>/`
+- Legacy `helios-cli-wtrees/` and `PROJECT-wtrees/` roots are migration-only and must not receive new work
+- Canonical `helios-cli/` stays on `main`
 - Never commit feature branches directly to canonical `main`
 
 ---

--- a/codex-rs/app-server-protocol/src/protocol/common.rs
+++ b/codex-rs/app-server-protocol/src/protocol/common.rs
@@ -224,8 +224,6 @@ client_request_definitions! {
         params: v2::ThreadUnsubscribeParams,
         response: v2::ThreadUnsubscribeResponse,
     },
-<<<<<<< HEAD
-=======
     #[experimental("thread/increment_elicitation")]
     /// Increment the thread-local out-of-band elicitation counter.
     ///
@@ -243,7 +241,6 @@ client_request_definitions! {
         params: v2::ThreadDecrementElicitationParams,
         response: v2::ThreadDecrementElicitationResponse,
     },
->>>>>>> upstream_main
     ThreadSetName => "thread/name/set" {
         params: v2::ThreadSetNameParams,
         response: v2::ThreadSetNameResponse,
@@ -756,8 +753,6 @@ server_request_definitions! {
         response: v2::ToolRequestUserInputResponse,
     },
 
-<<<<<<< HEAD
-=======
     /// Request input for an MCP server elicitation.
     McpServerElicitationRequest => "mcpServer/elicitation/request" {
         params: v2::McpServerElicitationRequestParams,
@@ -770,7 +765,6 @@ server_request_definitions! {
         response: v2::PermissionsRequestApprovalResponse,
     },
 
->>>>>>> upstream_main
     /// Execute a dynamic tool call on the client.
     DynamicToolCall => "item/tool/call" {
         params: v2::DynamicToolCallParams,
@@ -887,10 +881,7 @@ server_notification_definitions! {
     ThreadArchived => "thread/archived" (v2::ThreadArchivedNotification),
     ThreadUnarchived => "thread/unarchived" (v2::ThreadUnarchivedNotification),
     ThreadClosed => "thread/closed" (v2::ThreadClosedNotification),
-<<<<<<< HEAD
-=======
     SkillsChanged => "skills/changed" (v2::SkillsChangedNotification),
->>>>>>> upstream_main
     ThreadNameUpdated => "thread/name/updated" (v2::ThreadNameUpdatedNotification),
     ThreadTokenUsageUpdated => "thread/tokenUsage/updated" (v2::ThreadTokenUsageUpdatedNotification),
     TurnStarted => "turn/started" (v2::TurnStartedNotification),
@@ -935,11 +926,8 @@ server_notification_definitions! {
     ThreadRealtimeStarted => "thread/realtime/started" (v2::ThreadRealtimeStartedNotification),
     #[experimental("thread/realtime/itemAdded")]
     ThreadRealtimeItemAdded => "thread/realtime/itemAdded" (v2::ThreadRealtimeItemAddedNotification),
-<<<<<<< HEAD
-=======
     #[experimental("thread/realtime/transcriptUpdated")]
     ThreadRealtimeTranscriptUpdated => "thread/realtime/transcriptUpdated" (v2::ThreadRealtimeTranscriptUpdatedNotification),
->>>>>>> upstream_main
     #[experimental("thread/realtime/outputAudio/delta")]
     ThreadRealtimeOutputAudioDelta => "thread/realtime/outputAudio/delta" (v2::ThreadRealtimeOutputAudioDeltaNotification),
     #[experimental("thread/realtime/error")]
@@ -969,20 +957,16 @@ mod tests {
     use codex_protocol::ThreadId;
     use codex_protocol::account::PlanType;
     use codex_protocol::parse_command::ParsedCommand;
-<<<<<<< HEAD
     use codex_protocol::protocol::AskForApproval;
-=======
     use codex_protocol::protocol::RealtimeConversationVersion;
->>>>>>> upstream_main
     use codex_utils_absolute_path::AbsolutePathBuf;
     use pretty_assertions::assert_eq;
     use serde_json::json;
     use std::path::PathBuf;
 
-<<<<<<< HEAD
     fn absolute_path(path: &str) -> AbsolutePathBuf {
         AbsolutePathBuf::from_absolute_path(path).expect("absolute path")
-=======
+    }
     fn absolute_path_string(path: &str) -> String {
         let trimmed = path.trim_start_matches('/');
         if cfg!(windows) {
@@ -994,7 +978,6 @@ mod tests {
 
     fn absolute_path(path: &str) -> AbsolutePathBuf {
         AbsolutePathBuf::from_absolute_path(absolute_path_string(path)).expect("absolute path")
->>>>>>> upstream_main
     }
 
     #[test]
@@ -1631,10 +1614,7 @@ mod tests {
                     sample_rate: 24_000,
                     num_channels: 1,
                     samples_per_channel: Some(512),
-<<<<<<< HEAD
-=======
                     item_id: None,
->>>>>>> upstream_main
                 },
             },
         );
@@ -1647,12 +1627,9 @@ mod tests {
                         "data": "AQID",
                         "sampleRate": 24000,
                         "numChannels": 1,
-<<<<<<< HEAD
                         "samplesPerChannel": 512
-=======
                         "samplesPerChannel": 512,
                         "itemId": null
->>>>>>> upstream_main
                     }
                 }
             }),
@@ -1689,10 +1666,7 @@ mod tests {
             ServerNotification::ThreadRealtimeStarted(v2::ThreadRealtimeStartedNotification {
                 thread_id: "thr_123".to_string(),
                 session_id: Some("sess_456".to_string()),
-<<<<<<< HEAD
-=======
                 version: RealtimeConversationVersion::V1,
->>>>>>> upstream_main
             });
         let reason = crate::experimental_api::ExperimentalApi::experimental_reason(&notification);
         assert_eq!(reason, Some("thread/realtime/started"));
@@ -1708,10 +1682,7 @@ mod tests {
                     sample_rate: 24_000,
                     num_channels: 1,
                     samples_per_channel: Some(512),
-<<<<<<< HEAD
-=======
                     item_id: None,
->>>>>>> upstream_main
                 },
             },
         );

--- a/codex-rs/app-server-protocol/src/protocol/thread_history.rs
+++ b/codex-rs/app-server-protocol/src/protocol/thread_history.rs
@@ -1201,10 +1201,7 @@ mod tests {
     use crate::protocol::v2::CommandExecutionSource;
     use codex_protocol::ThreadId;
     use codex_protocol::dynamic_tools::DynamicToolCallOutputContentItem as CoreDynamicToolCallOutputContentItem;
-<<<<<<< HEAD
-=======
     use codex_protocol::items::HookPromptFragment as CoreHookPromptFragment;
->>>>>>> upstream_main
     use codex_protocol::items::TurnItem as CoreTurnItem;
     use codex_protocol::items::UserMessageItem as CoreUserMessageItem;
     use codex_protocol::items::build_hook_prompt_message;

--- a/codex-rs/app-server-protocol/src/protocol/v1.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v1.rs
@@ -2,7 +2,11 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use codex_git_utils::GitSha;
+use uuid::Uuid;
 use codex_protocol::ThreadId;
+use codex_protocol::user_input::ByteRange;
+use codex_protocol::user_input::TextElement;
+use codex_protocol::protocol::EventMsg;
 use codex_protocol::config_types::ForcedLoginMethod;
 use codex_protocol::config_types::ReasoningSummary;
 use codex_protocol::config_types::SandboxMode;
@@ -243,7 +247,6 @@ pub struct SandboxSettings {
 pub struct InterruptConversationResponse {
     pub abort_reason: TurnAbortReason,
 }
-<<<<<<< HEAD
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
@@ -292,8 +295,8 @@ pub struct V1ByteRange {
     pub end: usize,
 }
 
-impl From<CoreByteRange> for V1ByteRange {
-    fn from(value: CoreByteRange) -> Self {
+impl From<ByteRange> for V1ByteRange {
+    fn from(value: ByteRange) -> Self {
         Self {
             start: value.start,
             end: value.end,
@@ -301,7 +304,7 @@ impl From<CoreByteRange> for V1ByteRange {
     }
 }
 
-impl From<V1ByteRange> for CoreByteRange {
+impl From<V1ByteRange> for ByteRange {
     fn from(value: V1ByteRange) -> Self {
         Self {
             start: value.start,
@@ -373,5 +376,3 @@ pub struct SessionConfiguredNotification {
 pub struct AuthStatusChangeNotification {
     pub auth_method: Option<AuthMode>,
 }
-=======
->>>>>>> upstream_main

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -72,11 +72,7 @@ use codex_protocol::protocol::RateLimitSnapshot as CoreRateLimitSnapshot;
 use codex_protocol::protocol::RateLimitWindow as CoreRateLimitWindow;
 use codex_protocol::protocol::ReadOnlyAccess as CoreReadOnlyAccess;
 use codex_protocol::protocol::RealtimeAudioFrame as CoreRealtimeAudioFrame;
-<<<<<<< HEAD
-use codex_protocol::protocol::RejectConfig as CoreRejectConfig;
-=======
 use codex_protocol::protocol::RealtimeConversationVersion;
->>>>>>> upstream_main
 use codex_protocol::protocol::ReviewDecision as CoreReviewDecision;
 use codex_protocol::protocol::SessionSource as CoreSessionSource;
 use codex_protocol::protocol::SkillDependencies as CoreSkillDependencies;
@@ -2843,8 +2839,6 @@ pub enum ThreadUnsubscribeStatus {
     Unsubscribed,
 }
 
-<<<<<<< HEAD
-=======
 /// Parameters for `thread/increment_elicitation`.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
@@ -2885,7 +2879,6 @@ pub struct ThreadDecrementElicitationResponse {
     pub paused: bool,
 }
 
->>>>>>> upstream_main
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
 #[ts(export_to = "v2/")]
@@ -3784,10 +3777,7 @@ pub struct ThreadRealtimeAudioChunk {
     pub sample_rate: u32,
     pub num_channels: u16,
     pub samples_per_channel: Option<u32>,
-<<<<<<< HEAD
-=======
     pub item_id: Option<String>,
->>>>>>> upstream_main
 }
 
 impl From<CoreRealtimeAudioFrame> for ThreadRealtimeAudioChunk {
@@ -3797,20 +3787,14 @@ impl From<CoreRealtimeAudioFrame> for ThreadRealtimeAudioChunk {
             sample_rate,
             num_channels,
             samples_per_channel,
-<<<<<<< HEAD
-=======
             item_id,
->>>>>>> upstream_main
         } = value;
         Self {
             data,
             sample_rate,
             num_channels,
             samples_per_channel,
-<<<<<<< HEAD
-=======
             item_id,
->>>>>>> upstream_main
         }
     }
 }
@@ -3822,20 +3806,14 @@ impl From<ThreadRealtimeAudioChunk> for CoreRealtimeAudioFrame {
             sample_rate,
             num_channels,
             samples_per_channel,
-<<<<<<< HEAD
-=======
             item_id,
->>>>>>> upstream_main
         } = value;
         Self {
             data,
             sample_rate,
             num_channels,
             samples_per_channel,
-<<<<<<< HEAD
-=======
             item_id,
->>>>>>> upstream_main
         }
     }
 }
@@ -3908,10 +3886,7 @@ pub struct ThreadRealtimeStopResponse {}
 pub struct ThreadRealtimeStartedNotification {
     pub thread_id: String,
     pub session_id: Option<String>,
-<<<<<<< HEAD
-=======
     pub version: RealtimeConversationVersion,
->>>>>>> upstream_main
 }
 
 /// EXPERIMENTAL - raw non-audio thread realtime item emitted by the backend.
@@ -3923,8 +3898,6 @@ pub struct ThreadRealtimeItemAddedNotification {
     pub item: JsonValue,
 }
 
-<<<<<<< HEAD
-=======
 /// EXPERIMENTAL - flat transcript delta emitted whenever realtime
 /// transcript text changes.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, JsonSchema, TS)]
@@ -3936,7 +3909,6 @@ pub struct ThreadRealtimeTranscriptUpdatedNotification {
     pub text: String,
 }
 
->>>>>>> upstream_main
 /// EXPERIMENTAL - streamed output audio emitted by thread realtime.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
@@ -4840,8 +4812,6 @@ pub struct ThreadClosedNotification {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
 #[ts(export_to = "v2/")]
-<<<<<<< HEAD
-=======
 /// Notification emitted when watched local skill files change.
 ///
 /// Treat this as an invalidation signal and re-run `skills/list` with the
@@ -4851,7 +4821,6 @@ pub struct SkillsChangedNotification {}
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
 #[ts(export_to = "v2/")]
->>>>>>> upstream_main
 pub struct ThreadNameUpdatedNotification {
     pub thread_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -5337,8 +5306,6 @@ pub struct FileChangeRequestApprovalResponse {
     pub decision: FileChangeApprovalDecision,
 }
 
-<<<<<<< HEAD
-=======
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
 #[ts(rename_all = "camelCase")]
@@ -5805,7 +5772,6 @@ impl From<rmcp::model::CreateElicitationResult> for McpServerElicitationRequestR
     }
 }
 
->>>>>>> upstream_main
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
 #[ts(export_to = "v2/")]

--- a/codex-rs/app-server-test-client/src/lib.rs
+++ b/codex-rs/app-server-test-client/src/lib.rs
@@ -53,13 +53,10 @@ use codex_app_server_protocol::RequestId;
 use codex_app_server_protocol::SandboxPolicy;
 use codex_app_server_protocol::ServerNotification;
 use codex_app_server_protocol::ServerRequest;
-<<<<<<< HEAD
-=======
 use codex_app_server_protocol::ThreadDecrementElicitationParams;
 use codex_app_server_protocol::ThreadDecrementElicitationResponse;
 use codex_app_server_protocol::ThreadIncrementElicitationParams;
 use codex_app_server_protocol::ThreadIncrementElicitationResponse;
->>>>>>> upstream_main
 use codex_app_server_protocol::ThreadItem;
 use codex_app_server_protocol::ThreadListParams;
 use codex_app_server_protocol::ThreadListResponse;
@@ -860,7 +857,6 @@ async fn thread_resume_follow(
     .await
 }
 
-<<<<<<< HEAD
 fn watch(endpoint: &Endpoint, config_overrides: &[String]) -> Result<()> {
     let mut client = CodexClient::connect(endpoint, config_overrides)?;
 
@@ -872,7 +868,6 @@ fn watch(endpoint: &Endpoint, config_overrides: &[String]) -> Result<()> {
 }
 
 fn trigger_cmd_approval(
-=======
 async fn watch(endpoint: &Endpoint, config_overrides: &[String]) -> Result<()> {
     with_client("watch", endpoint, config_overrides, |client| {
         let initialize = client.initialize()?;
@@ -885,7 +880,6 @@ async fn watch(endpoint: &Endpoint, config_overrides: &[String]) -> Result<()> {
 }
 
 async fn trigger_cmd_approval(
->>>>>>> upstream_main
     endpoint: &Endpoint,
     config_overrides: &[String],
     user_message: Option<String>,
@@ -1251,7 +1245,6 @@ fn live_elicitation_timeout_pause(
         "Use the `exec_command` tool exactly once. Set its `cmd` field to the exact shell command below. Do not rewrite it, do not split it, do not call any other tool, do not set `yield_time_ms`, and wait for the command to finish before replying.\n\n{command}\n\nAfter the command finishes, reply with exactly `DONE`."
     );
 
-<<<<<<< HEAD
     let completion = client.wait_for_login_completion(&login_response.login_id)?;
     println!("< loginChatGptComplete notification: {completion:?}");
 
@@ -1308,7 +1301,6 @@ fn thread_list(endpoint: &Endpoint, config_overrides: &[String], limit: u32) -> 
         archived: None,
         cwd: None,
         search_term: None,
-=======
     let started_at = Instant::now();
     let turn_response = client.turn_start(TurnStartParams {
         thread_id: thread_id.clone(),
@@ -1321,7 +1313,6 @@ fn thread_list(endpoint: &Endpoint, config_overrides: &[String], limit: u32) -> 
         effort: Some(ReasoningEffort::High),
         cwd: Some(workspace),
         ..Default::default()
->>>>>>> upstream_main
     })?;
     println!("< turn/start response: {turn_response:?}");
 

--- a/codex-rs/app-server/src/bespoke_event_handling.rs
+++ b/codex-rs/app-server/src/bespoke_event_handling.rs
@@ -77,10 +77,7 @@ use codex_app_server_protocol::ReasoningTextDeltaNotification;
 use codex_app_server_protocol::RequestId;
 use codex_app_server_protocol::ServerNotification;
 use codex_app_server_protocol::ServerRequestPayload;
-<<<<<<< HEAD
-=======
 use codex_app_server_protocol::SkillsChangedNotification;
->>>>>>> upstream_main
 use codex_app_server_protocol::TerminalInteractionNotification;
 use codex_app_server_protocol::ThreadItem;
 use codex_app_server_protocol::ThreadNameUpdatedNotification;
@@ -89,10 +86,7 @@ use codex_app_server_protocol::ThreadRealtimeErrorNotification;
 use codex_app_server_protocol::ThreadRealtimeItemAddedNotification;
 use codex_app_server_protocol::ThreadRealtimeOutputAudioDeltaNotification;
 use codex_app_server_protocol::ThreadRealtimeStartedNotification;
-<<<<<<< HEAD
-=======
 use codex_app_server_protocol::ThreadRealtimeTranscriptUpdatedNotification;
->>>>>>> upstream_main
 use codex_app_server_protocol::ThreadRollbackResponse;
 use codex_app_server_protocol::ThreadTokenUsage;
 use codex_app_server_protocol::ThreadTokenUsageUpdatedNotification;
@@ -141,10 +135,7 @@ use codex_protocol::request_permissions::RequestPermissionProfile as CoreRequest
 use codex_protocol::request_permissions::RequestPermissionsResponse as CoreRequestPermissionsResponse;
 use codex_protocol::request_user_input::RequestUserInputAnswer as CoreRequestUserInputAnswer;
 use codex_protocol::request_user_input::RequestUserInputResponse as CoreRequestUserInputResponse;
-<<<<<<< HEAD
-=======
 use codex_sandboxing::policy_transforms::intersect_permission_profiles;
->>>>>>> upstream_main
 use codex_shell_command::parse_command::shlex_join;
 use std::collections::HashMap;
 use std::convert::TryFrom;
@@ -201,8 +192,6 @@ async fn resolve_server_request_on_thread_listener(
     }
 }
 
-<<<<<<< HEAD
-=======
 fn guardian_auto_approval_review_notification(
     conversation_id: &ThreadId,
     event_turn_id: &str,
@@ -263,7 +252,6 @@ fn guardian_auto_approval_review_notification(
     }
 }
 
->>>>>>> upstream_main
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn apply_bespoke_event_handling(
     event: Event,
@@ -282,11 +270,8 @@ pub(crate) async fn apply_bespoke_event_handling(
         msg,
     } = event;
     match msg {
-<<<<<<< HEAD
         EventMsg::TurnStarted(_) => {
-=======
         EventMsg::TurnStarted(payload) => {
->>>>>>> upstream_main
             // While not technically necessary as it was already done on TurnComplete, be extra cautios and abort any pending server requests.
             outgoing.abort_pending_server_requests().await;
             thread_watch_manager
@@ -387,10 +372,7 @@ pub(crate) async fn apply_bespoke_event_handling(
                 let notification = ThreadRealtimeStartedNotification {
                     thread_id: conversation_id.to_string(),
                     session_id: event.session_id,
-<<<<<<< HEAD
-=======
                     version: event.version,
->>>>>>> upstream_main
                 };
                 outgoing
                     .send_server_notification(ServerNotification::ThreadRealtimeStarted(
@@ -402,10 +384,8 @@ pub(crate) async fn apply_bespoke_event_handling(
         EventMsg::RealtimeConversationRealtime(event) => {
             if let ApiVersion::V2 = api_version {
                 match event.payload {
-<<<<<<< HEAD
                     RealtimeEvent::SessionCreated { .. } => {}
                     RealtimeEvent::SessionUpdated { .. } => {}
-=======
                     RealtimeEvent::SessionUpdated { .. } => {}
                     RealtimeEvent::InputAudioSpeechStarted(event) => {
                         let notification = ThreadRealtimeItemAddedNotification {
@@ -445,7 +425,6 @@ pub(crate) async fn apply_bespoke_event_handling(
                             )
                             .await;
                     }
->>>>>>> upstream_main
                     RealtimeEvent::AudioOut(audio) => {
                         let notification = ThreadRealtimeOutputAudioDeltaNotification {
                             thread_id: conversation_id.to_string(),
@@ -457,8 +436,6 @@ pub(crate) async fn apply_bespoke_event_handling(
                             )
                             .await;
                     }
-<<<<<<< HEAD
-=======
                     RealtimeEvent::ResponseCancelled(event) => {
                         let notification = ThreadRealtimeItemAddedNotification {
                             thread_id: conversation_id.to_string(),
@@ -473,7 +450,6 @@ pub(crate) async fn apply_bespoke_event_handling(
                             ))
                             .await;
                     }
->>>>>>> upstream_main
                     RealtimeEvent::ConversationItemAdded(item) => {
                         let notification = ThreadRealtimeItemAddedNotification {
                             thread_id: conversation_id.to_string(),
@@ -485,8 +461,6 @@ pub(crate) async fn apply_bespoke_event_handling(
                             ))
                             .await;
                     }
-<<<<<<< HEAD
-=======
                     RealtimeEvent::ConversationItemDone { .. } => {}
                     RealtimeEvent::HandoffRequested(handoff) => {
                         let notification = ThreadRealtimeItemAddedNotification {
@@ -505,7 +479,6 @@ pub(crate) async fn apply_bespoke_event_handling(
                             ))
                             .await;
                     }
->>>>>>> upstream_main
                     RealtimeEvent::Error(message) => {
                         let notification = ThreadRealtimeErrorNotification {
                             thread_id: conversation_id.to_string(),
@@ -817,8 +790,6 @@ pub(crate) async fn apply_bespoke_event_handling(
                 }
             }
         }
-<<<<<<< HEAD
-=======
         EventMsg::ElicitationRequest(request) => {
             if matches!(api_version, ApiVersion::V2) {
                 let permission_guard = thread_watch_manager
@@ -927,7 +898,6 @@ pub(crate) async fn apply_bespoke_event_handling(
                 }
             }
         }
->>>>>>> upstream_main
         EventMsg::DynamicToolCallRequest(request) => {
             if matches!(api_version, ApiVersion::V2) {
                 let call_id = request.call_id;

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -1,10 +1,7 @@
 use crate::bespoke_event_handling::apply_bespoke_event_handling;
-<<<<<<< HEAD
-=======
 use crate::command_exec::CommandExecManager;
 use crate::command_exec::StartCommandExecParams;
 use crate::config_api::apply_runtime_feature_enablement;
->>>>>>> upstream_main
 use crate::error_code::INPUT_TOO_LARGE_ERROR_CODE;
 use crate::error_code::INTERNAL_ERROR_CODE;
 use crate::error_code::INVALID_PARAMS_ERROR_CODE;
@@ -85,7 +82,6 @@ use codex_app_server_protocol::MockExperimentalMethodParams;
 use codex_app_server_protocol::MockExperimentalMethodResponse;
 use codex_app_server_protocol::ModelListParams;
 use codex_app_server_protocol::ModelListResponse;
-<<<<<<< HEAD
 use codex_app_server_protocol::NewConversationParams;
 use codex_app_server_protocol::NewConversationResponse;
 use codex_app_server_protocol::ProductSurface as ApiProductSurface;
@@ -94,7 +90,6 @@ use codex_app_server_protocol::RemoveConversationSubscriptionResponse;
 use codex_app_server_protocol::RequestId;
 use codex_app_server_protocol::ResumeConversationParams;
 use codex_app_server_protocol::ResumeConversationResponse;
-=======
 use codex_app_server_protocol::PluginDetail;
 use codex_app_server_protocol::PluginInstallParams;
 use codex_app_server_protocol::PluginInstallResponse;
@@ -109,7 +104,6 @@ use codex_app_server_protocol::PluginSummary;
 use codex_app_server_protocol::PluginUninstallParams;
 use codex_app_server_protocol::PluginUninstallResponse;
 use codex_app_server_protocol::RequestId;
->>>>>>> upstream_main
 use codex_app_server_protocol::ReviewDelivery as ApiReviewDelivery;
 use codex_app_server_protocol::ReviewStartParams;
 use codex_app_server_protocol::ReviewStartResponse;
@@ -117,13 +111,10 @@ use codex_app_server_protocol::ReviewTarget as ApiReviewTarget;
 use codex_app_server_protocol::SandboxMode;
 use codex_app_server_protocol::ServerNotification;
 use codex_app_server_protocol::ServerRequestResolvedNotification;
-<<<<<<< HEAD
 use codex_app_server_protocol::SessionConfiguredNotification;
 use codex_app_server_protocol::SetDefaultModelParams;
 use codex_app_server_protocol::SetDefaultModelResponse;
-=======
 use codex_app_server_protocol::SkillSummary;
->>>>>>> upstream_main
 use codex_app_server_protocol::SkillsConfigWriteParams;
 use codex_app_server_protocol::SkillsConfigWriteResponse;
 use codex_app_server_protocol::SkillsListParams;
@@ -216,10 +207,7 @@ use codex_core::auth::CLIENT_ID;
 use codex_core::auth::login_with_api_key;
 use codex_core::config::Config;
 use codex_core::config::ConfigOverrides;
-<<<<<<< HEAD
 use codex_core::config::ConfigService;
-=======
->>>>>>> upstream_main
 use codex_core::config::NetworkProxyAuditMetadata;
 use codex_core::config::edit::ConfigEdit;
 use codex_core::config::edit::ConfigEditsBuilder;
@@ -298,10 +286,7 @@ use codex_protocol::protocol::RolloutItem;
 use codex_protocol::protocol::SessionConfiguredEvent;
 use codex_protocol::protocol::SessionMetaLine;
 use codex_protocol::protocol::USER_MESSAGE_BEGIN;
-<<<<<<< HEAD
-=======
 use codex_protocol::protocol::W3cTraceContext;
->>>>>>> upstream_main
 use codex_protocol::user_input::MAX_USER_INPUT_TEXT_CHARS;
 use codex_protocol::user_input::UserInput as CoreInputItem;
 use codex_rmcp_client::perform_oauth_login_return_url;
@@ -342,13 +327,10 @@ use uuid::Uuid;
 #[cfg(test)]
 use codex_app_server_protocol::ServerRequest;
 
-<<<<<<< HEAD
-=======
 mod apps_list_helpers;
 mod plugin_app_helpers;
 mod plugin_mcp_oauth;
 
->>>>>>> upstream_main
 use crate::filters::compute_source_filters;
 use crate::filters::source_kind_matches;
 use crate::thread_state::ThreadListenerCommand;
@@ -388,7 +370,6 @@ enum ThreadShutdownResult {
     Complete,
     SubmitFailed,
     TimedOut,
-<<<<<<< HEAD
 }
 
 fn convert_remote_scope(scope: ApiHazelnutScope) -> RemoteSkillHazelnutScope {
@@ -407,8 +388,6 @@ fn convert_remote_product_surface(product_surface: ApiProductSurface) -> RemoteS
         ApiProductSurface::Api => RemoteSkillProductSurface::Api,
         ApiProductSurface::Atlas => RemoteSkillProductSurface::Atlas,
     }
-=======
->>>>>>> upstream_main
 }
 
 impl Drop for ActiveLogin {
@@ -455,10 +434,7 @@ struct ListenerTaskContext {
     thread_watch_manager: ThreadWatchManager,
     fallback_model_provider: String,
     codex_home: PathBuf,
-<<<<<<< HEAD
     single_client_mode: bool,
-=======
->>>>>>> upstream_main
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -467,8 +443,6 @@ enum EnsureConversationListenerResult {
     ConnectionClosed,
 }
 
-<<<<<<< HEAD
-=======
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum RefreshTokenRequestOutcome {
     NotAttemptedOrSucceeded,
@@ -476,7 +450,6 @@ enum RefreshTokenRequestOutcome {
     FailedPermanently,
 }
 
->>>>>>> upstream_main
 pub(crate) struct CodexMessageProcessorArgs {
     pub(crate) auth_manager: Arc<AuthManager>,
     pub(crate) thread_manager: Arc<ThreadManager>,
@@ -705,10 +678,7 @@ impl CodexMessageProcessor {
         connection_id: ConnectionId,
         request: ClientRequest,
         app_server_client_name: Option<String>,
-<<<<<<< HEAD
-=======
         request_context: RequestContext,
->>>>>>> upstream_main
     ) {
         let to_connection_request_id = |request_id| ConnectionRequestId {
             connection_id,
@@ -819,7 +789,6 @@ impl CodexMessageProcessor {
                 self.skills_config_write(to_connection_request_id(request_id), params)
                     .await;
             }
-<<<<<<< HEAD
             ClientRequest::TurnStart { request_id, params } => {
                 self.turn_start(
                     to_connection_request_id(request_id),
@@ -827,11 +796,9 @@ impl CodexMessageProcessor {
                     app_server_client_name.clone(),
                 )
                 .await;
-=======
             ClientRequest::PluginInstall { request_id, params } => {
                 self.plugin_install(to_connection_request_id(request_id), params)
                     .await;
->>>>>>> upstream_main
             }
             ClientRequest::PluginUninstall { request_id, params } => {
                 self.plugin_uninstall(to_connection_request_id(request_id), params)
@@ -938,7 +905,6 @@ impl CodexMessageProcessor {
                 self.get_account(to_connection_request_id(request_id), params)
                     .await;
             }
-<<<<<<< HEAD
             ClientRequest::ResumeConversation { request_id, params } => {
                 self.handle_resume_conversation(to_connection_request_id(request_id), params)
                     .await;
@@ -979,8 +945,6 @@ impl CodexMessageProcessor {
                 self.remove_thread_listener(to_connection_request_id(request_id), params)
                     .await;
             }
-=======
->>>>>>> upstream_main
             ClientRequest::GitDiffToRemote { request_id, params } => {
                 self.git_diff_to_origin(to_connection_request_id(request_id), params.cwd)
                     .await;
@@ -1824,12 +1788,10 @@ impl CodexMessageProcessor {
             None => None,
         };
         let windows_sandbox_level = WindowsSandboxLevel::from_config(&self.config);
-<<<<<<< HEAD
         let exec_params = ExecParams {
             command: params.command,
             cwd,
             expiration: timeout_ms.into(),
-=======
         let output_bytes_cap = if disable_output_cap {
             None
         } else {
@@ -1854,7 +1816,6 @@ impl CodexMessageProcessor {
             cwd: cwd.clone(),
             expiration,
             capture_policy,
->>>>>>> upstream_main
             env,
             network: started_network_proxy
                 .as_ref()
@@ -1954,9 +1915,7 @@ impl CodexMessageProcessor {
         }
     }
 
-<<<<<<< HEAD
     async fn thread_start(&self, request_id: ConnectionRequestId, params: ThreadStartParams) {
-=======
     async fn command_exec_write(
         &self,
         request_id: ConnectionRequestId,
@@ -2008,7 +1967,6 @@ impl CodexMessageProcessor {
         params: ThreadStartParams,
         request_context: RequestContext,
     ) {
->>>>>>> upstream_main
         let ThreadStartParams {
             model,
             model_provider,
@@ -2041,13 +1999,10 @@ impl CodexMessageProcessor {
             personality,
         );
         typesafe_overrides.ephemeral = ephemeral;
-<<<<<<< HEAD
         let cli_overrides = self.cli_overrides.clone();
         let cloud_requirements = self.current_cloud_requirements();
-=======
         let cloud_requirements = self.current_cloud_requirements();
         let cli_overrides = self.current_cli_overrides();
->>>>>>> upstream_main
         let listener_task_context = ListenerTaskContext {
             thread_manager: Arc::clone(&self.thread_manager),
             thread_state_manager: self.thread_state_manager.clone(),
@@ -2055,7 +2010,6 @@ impl CodexMessageProcessor {
             thread_watch_manager: self.thread_watch_manager.clone(),
             fallback_model_provider: self.config.model_provider_id.clone(),
             codex_home: self.config.codex_home.clone(),
-<<<<<<< HEAD
             single_client_mode: self.single_client_mode,
         };
 
@@ -2063,7 +2017,6 @@ impl CodexMessageProcessor {
             Self::thread_start_task(
                 listener_task_context,
                 cli_overrides,
-=======
         };
         let request_trace = request_context.request_trace();
         let runtime_feature_enablement = self.current_runtime_feature_enablement();
@@ -2072,7 +2025,6 @@ impl CodexMessageProcessor {
                 listener_task_context,
                 cli_overrides,
                 runtime_feature_enablement,
->>>>>>> upstream_main
                 cloud_requirements,
                 request_id,
                 config,
@@ -2081,11 +2033,9 @@ impl CodexMessageProcessor {
                 persist_extended_history,
                 service_name,
                 experimental_raw_events,
-<<<<<<< HEAD
             )
             .await;
         });
-=======
                 request_trace,
             )
             .await;
@@ -2144,17 +2094,13 @@ impl CodexMessageProcessor {
         thread
             .submit_with_trace(op, self.request_trace_context(request_id).await)
             .await
->>>>>>> upstream_main
     }
 
     #[allow(clippy::too_many_arguments)]
     async fn thread_start_task(
         listener_task_context: ListenerTaskContext,
         cli_overrides: Vec<(String, TomlValue)>,
-<<<<<<< HEAD
-=======
         runtime_feature_enablement: BTreeMap<String, bool>,
->>>>>>> upstream_main
         cloud_requirements: CloudRequirementsLoader,
         request_id: ConnectionRequestId,
         config_overrides: Option<HashMap<String, serde_json::Value>>,
@@ -2163,10 +2109,7 @@ impl CodexMessageProcessor {
         persist_extended_history: bool,
         service_name: Option<String>,
         experimental_raw_events: bool,
-<<<<<<< HEAD
-=======
         request_trace: Option<W3cTraceContext>,
->>>>>>> upstream_main
     ) {
         let config = match derive_config_from_params(
             &cli_overrides,
@@ -2180,15 +2123,12 @@ impl CodexMessageProcessor {
         {
             Ok(config) => config,
             Err(err) => {
-<<<<<<< HEAD
                 let error = JSONRPCErrorError {
                     code: INVALID_REQUEST_ERROR_CODE,
                     message: format!("error deriving config: {err}"),
                     data: None,
                 };
-=======
                 let error = config_load_error(&err);
->>>>>>> upstream_main
                 listener_task_context
                     .outgoing
                     .send_error(request_id, error)
@@ -2232,9 +2172,7 @@ impl CodexMessageProcessor {
                 core_dynamic_tools,
                 persist_extended_history,
                 service_name,
-<<<<<<< HEAD
             )
-=======
                 request_trace,
             )
             .instrument(tracing::info_span!(
@@ -2243,7 +2181,6 @@ impl CodexMessageProcessor {
                 thread_start.dynamic_tool_count = core_dynamic_tool_count,
                 thread_start.persist_extended_history = persist_extended_history,
             ))
->>>>>>> upstream_main
             .await
         {
             Ok(new_conv) => {
@@ -2275,14 +2212,11 @@ impl CodexMessageProcessor {
                         experimental_raw_events,
                         ApiVersion::V2,
                     )
-<<<<<<< HEAD
-=======
                     .instrument(tracing::info_span!(
                         "app_server.thread_start.attach_listener",
                         otel.name = "app_server.thread_start.attach_listener",
                         thread_start.experimental_raw_events = experimental_raw_events,
                     ))
->>>>>>> upstream_main
                     .await,
                     thread_id,
                     request_id.connection_id,
@@ -2291,15 +2225,12 @@ impl CodexMessageProcessor {
 
                 listener_task_context
                     .thread_watch_manager
-<<<<<<< HEAD
                     .upsert_thread(thread.clone())
-=======
                     .upsert_thread_silently(thread.clone())
                     .instrument(tracing::info_span!(
                         "app_server.thread_start.upsert_thread",
                         otel.name = "app_server.thread_start.upsert_thread",
                     ))
->>>>>>> upstream_main
                     .await;
 
                 thread.status = resolve_thread_status(
@@ -2329,13 +2260,10 @@ impl CodexMessageProcessor {
                 listener_task_context
                     .outgoing
                     .send_response(request_id, response)
-<<<<<<< HEAD
-=======
                     .instrument(tracing::info_span!(
                         "app_server.thread_start.send_response",
                         otel.name = "app_server.thread_start.send_response",
                     ))
->>>>>>> upstream_main
                     .await;
 
                 let notif = ThreadStartedNotification { thread };
@@ -3601,10 +3529,8 @@ impl CodexMessageProcessor {
 
         for connection_id in connection_ids {
             Self::log_listener_attach_result(
-<<<<<<< HEAD
                 self.ensure_conversation_listener(thread_id, connection_id, false, ApiVersion::V2)
                     .await,
-=======
                 self.ensure_conversation_listener(
                     thread_id,
                     connection_id,
@@ -3612,7 +3538,6 @@ impl CodexMessageProcessor {
                     ApiVersion::V2,
                 )
                 .await,
->>>>>>> upstream_main
                 thread_id,
                 connection_id,
                 "thread",
@@ -3767,7 +3692,6 @@ impl CodexMessageProcessor {
                     "thread",
                 );
 
-<<<<<<< HEAD
                 let Some(mut thread) = self
                     .load_thread_from_rollout_or_send_internal(
                         request_id.clone(),
@@ -3778,7 +3702,6 @@ impl CodexMessageProcessor {
                     .await
                 else {
                     return;
-=======
                 let mut thread = match self
                     .load_thread_from_resume_source_or_send_internal(
                         thread_id,
@@ -3795,7 +3718,6 @@ impl CodexMessageProcessor {
                         self.send_internal_error(request_id, message).await;
                         return;
                     }
->>>>>>> upstream_main
                 };
 
                 self.thread_watch_manager
@@ -4005,10 +3927,7 @@ impl CodexMessageProcessor {
                     request_id: request_id.clone(),
                     rollout_path: rollout_path.clone(),
                     config_snapshot,
-<<<<<<< HEAD
-=======
                     thread_summary,
->>>>>>> upstream_main
                 }),
             );
             if listener_command_tx.send(command).is_err() {
@@ -4344,7 +4263,6 @@ impl CodexMessageProcessor {
             "thread",
         );
 
-<<<<<<< HEAD
         let mut thread = match read_summary_from_rollout(
             rollout_path.as_path(),
             fallback_model_provider.as_str(),
@@ -4380,7 +4298,6 @@ impl CodexMessageProcessor {
                 .await;
                 return;
             }
-=======
         // Persistent forks materialize their own rollout immediately. Ephemeral forks stay
         // pathless, so they rebuild their visible history from the copied source rollout instead.
         let mut thread = if let Some(fork_rollout_path) = session_configured.rollout_path.as_ref() {
@@ -4447,7 +4364,6 @@ impl CodexMessageProcessor {
         {
             self.send_internal_error(request_id, message).await;
             return;
->>>>>>> upstream_main
         }
 
         self.thread_watch_manager
@@ -4547,7 +4463,6 @@ impl CodexMessageProcessor {
         }
     }
 
-<<<<<<< HEAD
     async fn handle_list_conversations(
         &self,
         request_id: ConnectionRequestId,
@@ -4587,8 +4502,6 @@ impl CodexMessageProcessor {
         };
     }
 
-=======
->>>>>>> upstream_main
     async fn list_threads_common(
         &self,
         requested_page_size: usize,
@@ -5053,11 +4966,8 @@ impl CodexMessageProcessor {
             config.mcp_oauth_credentials_store_mode,
             http_headers,
             env_http_headers,
-<<<<<<< HEAD
             scopes.as_deref().unwrap_or_default(),
-=======
             &resolved_scopes.scopes,
->>>>>>> upstream_main
             server.oauth_resource.as_deref(),
             timeout_secs,
             config.mcp_oauth_callback_port,
@@ -5227,7 +5137,6 @@ impl CodexMessageProcessor {
         }
     }
 
-<<<<<<< HEAD
     fn validate_v1_input_limit(items: &[WireInputItem]) -> Result<(), JSONRPCErrorError> {
         let actual_chars: usize = items.iter().map(WireInputItem::text_char_count).sum();
         if actual_chars > MAX_USER_INPUT_TEXT_CHARS {
@@ -5236,8 +5145,6 @@ impl CodexMessageProcessor {
         Ok(())
     }
 
-=======
->>>>>>> upstream_main
     fn validate_v2_input_limit(items: &[V2UserInput]) -> Result<(), JSONRPCErrorError> {
         let actual_chars: usize = items.iter().map(V2UserInput::text_char_count).sum();
         if actual_chars > MAX_USER_INPUT_TEXT_CHARS {
@@ -5282,7 +5189,6 @@ impl CodexMessageProcessor {
     }
 
     async fn wait_for_thread_shutdown(thread: &Arc<CodexThread>) -> ThreadShutdownResult {
-<<<<<<< HEAD
         match thread.submit(Op::Shutdown).await {
             Ok(_) => {
                 let wait_for_shutdown = async {
@@ -5303,23 +5209,18 @@ impl CodexMessageProcessor {
                 }
             }
             Err(_) => ThreadShutdownResult::SubmitFailed,
-=======
         match tokio::time::timeout(Duration::from_secs(10), thread.shutdown_and_wait()).await {
             Ok(Ok(())) => ThreadShutdownResult::Complete,
             Ok(Err(_)) => ThreadShutdownResult::SubmitFailed,
             Err(_) => ThreadShutdownResult::TimedOut,
->>>>>>> upstream_main
         }
     }
 
     async fn finalize_thread_teardown(&mut self, thread_id: ThreadId) {
         self.pending_thread_unloads.lock().await.remove(&thread_id);
         self.outgoing
-<<<<<<< HEAD
             .cancel_requests_for_thread(thread_id, None)
-=======
             .cancel_requests_for_thread(thread_id, /*error*/ None)
->>>>>>> upstream_main
             .await;
         self.thread_state_manager
             .remove_thread_state(thread_id)
@@ -5382,11 +5283,8 @@ impl CodexMessageProcessor {
             // Any pending app-server -> client requests for this thread can no longer be
             // answered; cancel their callbacks before shutdown/unload.
             self.outgoing
-<<<<<<< HEAD
                 .cancel_requests_for_thread(thread_id, None)
-=======
                 .cancel_requests_for_thread(thread_id, /*error*/ None)
->>>>>>> upstream_main
                 .await;
             self.thread_state_manager
                 .remove_thread_state(thread_id)
@@ -5558,7 +5456,6 @@ impl CodexMessageProcessor {
         })
     }
 
-<<<<<<< HEAD
     async fn send_user_message(
         &self,
         request_id: ConnectionRequestId,
@@ -5691,8 +5588,6 @@ impl CodexMessageProcessor {
             .await;
     }
 
-=======
->>>>>>> upstream_main
     async fn apps_list(&self, request_id: ConnectionRequestId, params: AppsListParams) {
         let mut config = match self.load_latest_config(/*fallback_cwd*/ None).await {
             Ok(config) => config,
@@ -5799,31 +5694,22 @@ impl CodexMessageProcessor {
 
         if accessible_connectors.is_some() || all_connectors.is_some() {
             let merged = connectors::with_app_enabled_state(
-<<<<<<< HEAD
                 Self::merge_loaded_apps(
-=======
                 apps_list_helpers::merge_loaded_apps(
->>>>>>> upstream_main
                     all_connectors.as_deref(),
                     accessible_connectors.as_deref(),
                 ),
                 &config,
             );
-<<<<<<< HEAD
             if Self::should_send_app_list_updated_notification(
-=======
             if apps_list_helpers::should_send_app_list_updated_notification(
->>>>>>> upstream_main
                 merged.as_slice(),
                 accessible_loaded,
                 all_loaded,
             ) {
-<<<<<<< HEAD
                 Self::send_app_list_updated_notification(&outgoing, merged.clone()).await;
-=======
                 apps_list_helpers::send_app_list_updated_notification(&outgoing, merged.clone())
                     .await;
->>>>>>> upstream_main
                 last_notified_apps = Some(merged);
             }
         }
@@ -5897,32 +5783,23 @@ impl CodexMessageProcessor {
                     accessible_connectors.as_deref()
                 };
             let merged = connectors::with_app_enabled_state(
-<<<<<<< HEAD
                 Self::merge_loaded_apps(
-=======
                 apps_list_helpers::merge_loaded_apps(
->>>>>>> upstream_main
                     all_connectors_for_update,
                     accessible_connectors_for_update,
                 ),
                 &config,
             );
-<<<<<<< HEAD
             if Self::should_send_app_list_updated_notification(
-=======
             if apps_list_helpers::should_send_app_list_updated_notification(
->>>>>>> upstream_main
                 merged.as_slice(),
                 accessible_loaded,
                 all_loaded,
             ) && last_notified_apps.as_ref() != Some(&merged)
             {
-<<<<<<< HEAD
                 Self::send_app_list_updated_notification(&outgoing, merged.clone()).await;
-=======
                 apps_list_helpers::send_app_list_updated_notification(&outgoing, merged.clone())
                     .await;
->>>>>>> upstream_main
                 last_notified_apps = Some(merged.clone());
             }
 
@@ -5941,7 +5818,6 @@ impl CodexMessageProcessor {
         }
     }
 
-<<<<<<< HEAD
     fn merge_loaded_apps(
         all_connectors: Option<&[AppInfo]>,
         accessible_connectors: Option<&[AppInfo]>,
@@ -5998,8 +5874,6 @@ impl CodexMessageProcessor {
             .await;
     }
 
-=======
->>>>>>> upstream_main
     async fn skills_list(&self, request_id: ConnectionRequestId, params: SkillsListParams) {
         let SkillsListParams {
             cwds,
@@ -6388,7 +6262,6 @@ impl CodexMessageProcessor {
             plugins_manager.install_plugin(request).await
         };
 
-<<<<<<< HEAD
         // Record the pending interrupt so we can reply when TurnAborted arrives.
         {
             let pending_interrupts = self
@@ -6399,7 +6272,6 @@ impl CodexMessageProcessor {
             thread_state
                 .pending_interrupts
                 .push((request, ApiVersion::V1));
-=======
         match install_result {
             Ok(result) => {
                 let config = match self.load_latest_config(config_cwd).await {
@@ -6539,12 +6411,9 @@ impl CodexMessageProcessor {
                     }
                 }
             }
->>>>>>> upstream_main
         }
     }
 
-<<<<<<< HEAD
-=======
     async fn plugin_uninstall(
         &self,
         request_id: ConnectionRequestId,
@@ -6623,7 +6492,6 @@ impl CodexMessageProcessor {
         }
     }
 
->>>>>>> upstream_main
     async fn turn_start(
         &self,
         request_id: ConnectionRequestId,
@@ -6767,12 +6635,9 @@ impl CodexMessageProcessor {
             .await;
             return;
         }
-<<<<<<< HEAD
-=======
         self.outgoing
             .record_request_turn_id(&request_id, &params.expected_turn_id)
             .await;
->>>>>>> upstream_main
         if let Err(error) = Self::validate_v2_input_limit(&params.input) {
             self.outgoing.send_error(request_id, error).await;
             return;
@@ -6867,11 +6732,8 @@ impl CodexMessageProcessor {
             .ensure_conversation_listener(
                 thread_id,
                 request_id.connection_id,
-<<<<<<< HEAD
                 false,
-=======
                 /*raw_events_enabled*/ false,
->>>>>>> upstream_main
                 ApiVersion::V2,
             )
             .await
@@ -6910,13 +6772,11 @@ impl CodexMessageProcessor {
             return;
         };
 
-<<<<<<< HEAD
         let submit = thread
             .submit(Op::RealtimeConversationStart(ConversationStartParams {
                 prompt: params.prompt,
                 session_id: params.session_id,
             }))
-=======
         let submit = self
             .submit_core_op(
                 &request_id,
@@ -6926,7 +6786,6 @@ impl CodexMessageProcessor {
                     session_id: params.session_id,
                 }),
             )
->>>>>>> upstream_main
             .await;
 
         match submit {
@@ -6957,12 +6816,10 @@ impl CodexMessageProcessor {
             return;
         };
 
-<<<<<<< HEAD
         let submit = thread
             .submit(Op::RealtimeConversationAudio(ConversationAudioParams {
                 frame: params.audio.into(),
             }))
-=======
         let submit = self
             .submit_core_op(
                 &request_id,
@@ -6971,7 +6828,6 @@ impl CodexMessageProcessor {
                     frame: params.audio.into(),
                 }),
             )
->>>>>>> upstream_main
             .await;
 
         match submit {
@@ -7002,19 +6858,16 @@ impl CodexMessageProcessor {
             return;
         };
 
-<<<<<<< HEAD
         let submit = thread
             .submit(Op::RealtimeConversationText(ConversationTextParams {
                 text: params.text,
             }))
-=======
         let submit = self
             .submit_core_op(
                 &request_id,
                 thread.as_ref(),
                 Op::RealtimeConversationText(ConversationTextParams { text: params.text }),
             )
->>>>>>> upstream_main
             .await;
 
         match submit {
@@ -7045,13 +6898,10 @@ impl CodexMessageProcessor {
             return;
         };
 
-<<<<<<< HEAD
         let submit = thread.submit(Op::RealtimeConversationClose).await;
-=======
         let submit = self
             .submit_core_op(&request_id, thread.as_ref(), Op::RealtimeConversationClose)
             .await;
->>>>>>> upstream_main
 
         match submit {
             Ok(_) => {
@@ -7361,10 +7211,7 @@ impl CodexMessageProcessor {
                 thread_watch_manager: self.thread_watch_manager.clone(),
                 fallback_model_provider: self.config.model_provider_id.clone(),
                 codex_home: self.config.codex_home.clone(),
-<<<<<<< HEAD
                 single_client_mode: self.single_client_mode,
-=======
->>>>>>> upstream_main
             },
             conversation_id,
             connection_id,
@@ -7452,10 +7299,7 @@ impl CodexMessageProcessor {
                 thread_watch_manager: self.thread_watch_manager.clone(),
                 fallback_model_provider: self.config.model_provider_id.clone(),
                 codex_home: self.config.codex_home.clone(),
-<<<<<<< HEAD
                 single_client_mode: self.single_client_mode,
-=======
->>>>>>> upstream_main
             },
             conversation_id,
             conversation,
@@ -7487,10 +7331,7 @@ impl CodexMessageProcessor {
             thread_watch_manager,
             fallback_model_provider,
             codex_home,
-<<<<<<< HEAD
             single_client_mode,
-=======
->>>>>>> upstream_main
         } = listener_task_context;
         let outgoing_for_task = Arc::clone(&outgoing);
         tokio::spawn(async move {
@@ -7509,7 +7350,6 @@ impl CodexMessageProcessor {
                             }
                         };
 
-<<<<<<< HEAD
                         // For now, we send a notification for every event,
                         // JSON-serializing the `Event` as-is, but these should
                         // be migrated to be variants of `ServerNotification`
@@ -7544,14 +7384,12 @@ impl CodexMessageProcessor {
                             if !single_client_mode {
                                 thread_state.track_current_turn_event(&event.msg);
                             }
-=======
                         // Track the event before emitting any typed
                         // translations so thread-local state such as raw event
                         // opt-in stays synchronized with the conversation.
                         let raw_events_enabled = {
                             let mut thread_state = thread_state.lock().await;
                             thread_state.track_current_turn_event(&event.msg);
->>>>>>> upstream_main
                             thread_state.experimental_raw_events
                         };
                         let subscribed_connection_ids = thread_state_manager
@@ -7586,10 +7424,7 @@ impl CodexMessageProcessor {
                         };
                         handle_thread_listener_command(
                             conversation_id,
-<<<<<<< HEAD
-=======
                             &conversation,
->>>>>>> upstream_main
                             codex_home.as_path(),
                             &thread_state_manager,
                             &thread_state,
@@ -7898,8 +7733,6 @@ impl CodexMessageProcessor {
             WindowsSandboxSetupMode::Unelevated => CoreWindowsSandboxSetupMode::Unelevated,
         };
         let config = Arc::clone(&self.config);
-<<<<<<< HEAD
-=======
         let cloud_requirements = self.current_cloud_requirements();
         let command_cwd = params
             .cwd
@@ -7907,7 +7740,6 @@ impl CodexMessageProcessor {
             .unwrap_or_else(|| config.cwd.clone());
         let cli_overrides = self.current_cli_overrides();
         let runtime_feature_enablement = self.current_runtime_feature_enablement();
->>>>>>> upstream_main
         let outgoing = Arc::clone(&self.outgoing);
         let connection_id = request_id.connection_id;
 
@@ -7965,15 +7797,12 @@ impl CodexMessageProcessor {
     }
 }
 
-<<<<<<< HEAD
 async fn handle_thread_listener_command(
     conversation_id: ThreadId,
-=======
 #[allow(clippy::too_many_arguments)]
 async fn handle_thread_listener_command(
     conversation_id: ThreadId,
     conversation: &Arc<CodexThread>,
->>>>>>> upstream_main
     codex_home: &Path,
     thread_state_manager: &ThreadStateManager,
     thread_state: &Arc<Mutex<ThreadState>>,
@@ -7985,10 +7814,7 @@ async fn handle_thread_listener_command(
         ThreadListenerCommand::SendThreadResumeResponse(resume_request) => {
             handle_pending_thread_resume_request(
                 conversation_id,
-<<<<<<< HEAD
-=======
                 conversation,
->>>>>>> upstream_main
                 codex_home,
                 thread_state_manager,
                 thread_state,
@@ -8014,10 +7840,7 @@ async fn handle_thread_listener_command(
     }
 }
 
-<<<<<<< HEAD
-=======
 #[allow(clippy::too_many_arguments)]
->>>>>>> upstream_main
 async fn handle_pending_thread_resume_request(
     conversation_id: ThreadId,
     conversation: &Arc<CodexThread>,
@@ -8113,7 +7936,6 @@ async fn handle_pending_thread_resume_request(
     let _attached = thread_state_manager
         .try_add_connection_to_thread(conversation_id, connection_id)
         .await;
-<<<<<<< HEAD
 }
 
 async fn resolve_pending_server_request(
@@ -8139,8 +7961,6 @@ async fn resolve_pending_server_request(
             },
         ))
         .await;
-=======
->>>>>>> upstream_main
 }
 
 enum ThreadTurnSource<'a> {
@@ -9138,10 +8958,7 @@ mod tests {
     use anyhow::Result;
     use codex_app_server_protocol::ServerRequestPayload;
     use codex_app_server_protocol::ToolRequestUserInputParams;
-<<<<<<< HEAD
-=======
     use codex_protocol::openai_models::ReasoningEffort;
->>>>>>> upstream_main
     use codex_protocol::protocol::SessionSource;
     use codex_protocol::protocol::SubAgentSource;
     use pretty_assertions::assert_eq;
@@ -9643,10 +9460,7 @@ mod tests {
                     request_id: sent_request_id,
                     ..
                 }),
-<<<<<<< HEAD
-=======
             ..
->>>>>>> upstream_main
         } = request_message
         else {
             panic!("expected tool request to be sent to the subscribed connection");
@@ -9710,7 +9524,6 @@ mod tests {
     }
 
     #[tokio::test]
-<<<<<<< HEAD
     async fn removing_listeners_retains_thread_listener_when_last_subscriber_leaves() -> Result<()>
     {
         let manager = ThreadStateManager::new();
@@ -9848,8 +9661,6 @@ mod tests {
     }
 
     #[tokio::test]
-=======
->>>>>>> upstream_main
     async fn removing_thread_state_clears_listener_and_active_turn_history() -> Result<()> {
         let manager = ThreadStateManager::new();
         let thread_id = ThreadId::from_string("ad7f0408-99b8-4f6e-a46f-bd0eec433370")?;

--- a/codex-rs/app-server/src/message_processor.rs
+++ b/codex-rs/app-server/src/message_processor.rs
@@ -12,11 +12,8 @@ use crate::config_api::ConfigApi;
 use crate::error_code::INTERNAL_ERROR_CODE;
 use crate::error_code::INVALID_REQUEST_ERROR_CODE;
 use crate::external_agent_config_api::ExternalAgentConfigApi;
-<<<<<<< HEAD
-=======
 use crate::fs_api::FsApi;
 use crate::fs_watch::FsWatchManager;
->>>>>>> upstream_main
 use crate::outgoing_message::ConnectionId;
 use crate::outgoing_message::ConnectionRequestId;
 use crate::outgoing_message::OutgoingMessageSender;
@@ -34,10 +31,8 @@ use codex_app_server_protocol::ConfigReadParams;
 use codex_app_server_protocol::ConfigValueWriteParams;
 use codex_app_server_protocol::ConfigWarningNotification;
 use codex_app_server_protocol::ExperimentalApi;
-<<<<<<< HEAD
 use codex_app_server_protocol::ExternalAgentConfigDetectParams;
 use codex_app_server_protocol::ExternalAgentConfigImportParams;
-=======
 use codex_app_server_protocol::ExperimentalFeatureEnablementSetParams;
 use codex_app_server_protocol::ExternalAgentConfigDetectParams;
 use codex_app_server_protocol::ExternalAgentConfigImportParams;
@@ -50,7 +45,6 @@ use codex_app_server_protocol::FsRemoveParams;
 use codex_app_server_protocol::FsUnwatchParams;
 use codex_app_server_protocol::FsWatchParams;
 use codex_app_server_protocol::FsWriteFileParams;
->>>>>>> upstream_main
 use codex_app_server_protocol::InitializeResponse;
 use codex_app_server_protocol::JSONRPCError;
 use codex_app_server_protocol::JSONRPCErrorError;
@@ -74,10 +68,7 @@ use codex_core::default_client::get_codex_user_agent;
 use codex_core::default_client::set_default_client_residency_requirement;
 use codex_core::default_client::set_default_originator;
 use codex_core::models_manager::collaboration_mode_presets::CollaborationModesConfig;
-<<<<<<< HEAD
-=======
 use codex_features::Feature;
->>>>>>> upstream_main
 use codex_feedback::CodexFeedback;
 use codex_login::auth::ExternalAuthRefreshContext;
 use codex_login::auth::ExternalAuthRefreshReason;
@@ -167,12 +158,9 @@ pub(crate) struct MessageProcessor {
     codex_message_processor: CodexMessageProcessor,
     config_api: ConfigApi,
     external_agent_config_api: ExternalAgentConfigApi,
-<<<<<<< HEAD
-=======
     fs_api: FsApi,
     auth_manager: Arc<AuthManager>,
     fs_watch_manager: FsWatchManager,
->>>>>>> upstream_main
     config: Arc<Config>,
     config_warnings: Arc<Vec<ConfigWarningNotification>>,
 }
@@ -183,10 +171,7 @@ pub(crate) struct ConnectionSessionState {
     pub(crate) experimental_api_enabled: bool,
     pub(crate) opted_out_notification_methods: HashSet<String>,
     pub(crate) app_server_client_name: Option<String>,
-<<<<<<< HEAD
-=======
     pub(crate) client_version: Option<String>,
->>>>>>> upstream_main
 }
 
 pub(crate) struct MessageProcessorArgs {
@@ -239,7 +224,6 @@ impl MessageProcessor {
         auth_manager.set_external_auth_refresher(Arc::new(ExternalAuthRefreshBridge {
             outgoing: outgoing.clone(),
         }));
-<<<<<<< HEAD
         let thread_manager = Arc::new(ThreadManager::new(
             config.codex_home.clone(),
             auth_manager.clone(),
@@ -251,7 +235,6 @@ impl MessageProcessor {
                     .enabled(codex_core::features::Feature::DefaultModeRequestUserInput),
             },
         ));
-=======
         let analytics_events_client =
             AnalyticsEventsClient::new(Arc::clone(&config), Arc::clone(&auth_manager));
         thread_manager
@@ -260,7 +243,6 @@ impl MessageProcessor {
 
         let cli_overrides = Arc::new(RwLock::new(cli_overrides));
         let runtime_feature_enablement = Arc::new(RwLock::new(BTreeMap::new()));
->>>>>>> upstream_main
         let cloud_requirements = Arc::new(RwLock::new(cloud_requirements));
         let codex_message_processor = CodexMessageProcessor::new(CodexMessageProcessorArgs {
             auth_manager: auth_manager.clone(),
@@ -289,23 +271,17 @@ impl MessageProcessor {
             analytics_events_client,
         );
         let external_agent_config_api = ExternalAgentConfigApi::new(config.codex_home.clone());
-<<<<<<< HEAD
-=======
         let fs_api = FsApi::default();
         let fs_watch_manager = FsWatchManager::new(outgoing.clone());
->>>>>>> upstream_main
 
         Self {
             outgoing,
             codex_message_processor,
             config_api,
             external_agent_config_api,
-<<<<<<< HEAD
-=======
             fs_api,
             auth_manager,
             fs_watch_manager,
->>>>>>> upstream_main
             config,
             config_warnings: Arc::new(config_warnings),
         }
@@ -567,7 +543,6 @@ impl MessageProcessor {
                         message: "Already initialized".to_string(),
                         data: None,
                     };
-<<<<<<< HEAD
                     self.outgoing.send_error(request_id, error).await;
                     return;
                 } else {
@@ -632,9 +607,7 @@ impl MessageProcessor {
                     self.codex_message_processor
                         .connection_initialized(connection_id)
                         .await;
-=======
                     self.outgoing.send_error(connection_request_id, error).await;
->>>>>>> upstream_main
                     return;
                 }
 
@@ -927,16 +900,13 @@ impl MessageProcessor {
                 // inline the full `CodexMessageProcessor::process_request` future, which
                 // can otherwise push worker-thread stack usage over the edge.
                 self.codex_message_processor
-<<<<<<< HEAD
                     .process_request(connection_id, other, session.app_server_client_name.clone())
-=======
                     .process_request(
                         connection_id,
                         other,
                         session.app_server_client_name.clone(),
                         request_context,
                     )
->>>>>>> upstream_main
                     .boxed()
                     .await;
             }
@@ -1035,8 +1005,6 @@ impl MessageProcessor {
             Err(error) => self.outgoing.send_error(request_id, error).await,
         }
     }
-<<<<<<< HEAD
-=======
 
     async fn handle_fs_read_file(&self, request_id: ConnectionRequestId, params: FsReadFileParams) {
         match self.fs_api.read_file(params).await {
@@ -1126,7 +1094,6 @@ impl MessageProcessor {
             Err(error) => self.outgoing.send_error(request_id, error).await,
         }
     }
->>>>>>> upstream_main
 }
 
 #[cfg(test)]

--- a/codex-rs/app-server/src/outgoing_message.rs
+++ b/codex-rs/app-server/src/outgoing_message.rs
@@ -10,13 +10,10 @@ use codex_app_server_protocol::Result;
 use codex_app_server_protocol::ServerNotification;
 use codex_app_server_protocol::ServerRequest;
 use codex_app_server_protocol::ServerRequestPayload;
-<<<<<<< HEAD
 use codex_protocol::ThreadId;
-=======
 use codex_otel::span_w3c_trace_context;
 use codex_protocol::ThreadId;
 use codex_protocol::protocol::W3cTraceContext;
->>>>>>> upstream_main
 use serde::Serialize;
 use tokio::sync::Mutex;
 use tokio::sync::mpsc;
@@ -117,13 +114,10 @@ pub(crate) struct OutgoingMessageSender {
     next_server_request_id: AtomicI64,
     sender: mpsc::Sender<OutgoingEnvelope>,
     request_id_to_callback: Mutex<HashMap<RequestId, PendingCallbackEntry>>,
-<<<<<<< HEAD
-=======
     /// Incoming requests that are still waiting on a final response or error.
     /// We keep them here because this is where responses, errors, and
     /// disconnect cleanup all get handled.
     request_contexts: Mutex<HashMap<ConnectionRequestId, RequestContext>>,
->>>>>>> upstream_main
 }
 
 #[derive(Clone)]
@@ -174,13 +168,10 @@ impl ThreadScopedOutgoingMessageSender {
             .await;
     }
 
-<<<<<<< HEAD
-=======
     pub(crate) async fn send_global_server_notification(&self, notification: ServerNotification) {
         self.outgoing.send_server_notification(notification).await;
     }
 
->>>>>>> upstream_main
     pub(crate) async fn abort_pending_server_requests(&self) {
         self.outgoing
             .cancel_requests_for_thread(
@@ -222,8 +213,6 @@ impl OutgoingMessageSender {
         }
     }
 
-<<<<<<< HEAD
-=======
     pub(crate) async fn register_request_context(&self, request_context: RequestContext) {
         let mut request_contexts = self.request_contexts.lock().await;
         if request_contexts
@@ -273,19 +262,15 @@ impl OutgoingMessageSender {
         self.request_contexts.lock().await.len()
     }
 
->>>>>>> upstream_main
     pub(crate) async fn send_request(
         &self,
         request: ServerRequestPayload,
     ) -> (RequestId, oneshot::Receiver<ClientRequestResult>) {
-<<<<<<< HEAD
         self.send_request_to_connections(None, request, None).await
-=======
         self.send_request_to_connections(
             /*connection_ids*/ None, request, /*thread_id*/ None,
         )
         .await
->>>>>>> upstream_main
     }
 
     fn next_request_id(&self) -> RequestId {
@@ -332,10 +317,7 @@ impl OutgoingMessageSender {
                         .send(OutgoingEnvelope::ToConnection {
                             connection_id: *connection_id,
                             message: outgoing_message.clone(),
-<<<<<<< HEAD
-=======
                             write_complete_tx: None,
->>>>>>> upstream_main
                         })
                         .await
                     {
@@ -370,10 +352,7 @@ impl OutgoingMessageSender {
                 .send(OutgoingEnvelope::ToConnection {
                     connection_id,
                     message: OutgoingMessage::Request(request),
-<<<<<<< HEAD
-=======
                     write_complete_tx: None,
->>>>>>> upstream_main
                 })
                 .await
             {
@@ -417,7 +396,6 @@ impl OutgoingMessageSender {
         self.take_request_callback(id).await.is_some()
     }
 
-<<<<<<< HEAD
     async fn take_request_callback(
         &self,
         id: &RequestId,
@@ -460,7 +438,6 @@ impl OutgoingMessageSender {
                 }
             }
             entries
-=======
     pub(crate) async fn cancel_all_requests(&self, error: Option<JSONRPCErrorError>) {
         let entries = {
             let mut request_id_to_callback = self.request_id_to_callback.lock().await;
@@ -468,15 +445,12 @@ impl OutgoingMessageSender {
                 .drain()
                 .map(|(_, entry)| entry)
                 .collect::<Vec<_>>()
->>>>>>> upstream_main
         };
 
         if let Some(error) = error {
             for entry in entries {
                 if let Err(err) = entry.callback.send(Err(error.clone())) {
                     let request_id = entry.request.id();
-<<<<<<< HEAD
-=======
                     warn!("could not notify callback for {request_id:?} due to: {err:?}");
                 }
             }
@@ -533,7 +507,6 @@ impl OutgoingMessageSender {
             for entry in entries {
                 if let Err(err) = entry.callback.send(Err(error.clone())) {
                     let request_id = entry.request.id();
->>>>>>> upstream_main
                     warn!("could not notify callback for {request_id:?} due to: {err:?}",);
                 }
             }
@@ -728,10 +701,7 @@ mod tests {
     use codex_app_server_protocol::ConfigWarningNotification;
     use codex_app_server_protocol::DynamicToolCallParams;
     use codex_app_server_protocol::FileChangeRequestApprovalParams;
-<<<<<<< HEAD
     use codex_app_server_protocol::LoginChatGptCompleteNotification;
-=======
->>>>>>> upstream_main
     use codex_app_server_protocol::ModelRerouteReason;
     use codex_app_server_protocol::ModelReroutedNotification;
     use codex_app_server_protocol::RateLimitSnapshot;

--- a/codex-rs/app-server/src/thread_state.rs
+++ b/codex-rs/app-server/src/thread_state.rs
@@ -148,10 +148,7 @@ impl Default for ThreadEntry {
 struct ThreadStateManagerInner {
     live_connections: HashSet<ConnectionId>,
     threads: HashMap<ThreadId, ThreadEntry>,
-<<<<<<< HEAD
     subscription_state_by_id: HashMap<Uuid, SubscriptionState>,
-=======
->>>>>>> upstream_main
     thread_ids_by_connection: HashMap<ConnectionId, HashSet<ThreadId>>,
 }
 
@@ -181,7 +178,6 @@ impl ThreadStateManager {
             .map(|thread_entry| thread_entry.connection_ids.iter().copied().collect())
             .unwrap_or_default()
     }
-<<<<<<< HEAD
 
     pub(crate) async fn thread_state(&self, thread_id: ThreadId) -> Arc<Mutex<ThreadState>> {
         let mut state = self.state.lock().await;
@@ -250,12 +246,10 @@ impl ThreadStateManager {
             }
         }
         Some(thread_id)
-=======
 
     pub(crate) async fn thread_state(&self, thread_id: ThreadId) -> Arc<Mutex<ThreadState>> {
         let mut state = self.state.lock().await;
         state.threads.entry(thread_id).or_default().state.clone()
->>>>>>> upstream_main
     }
 
     pub(crate) async fn remove_thread_state(&self, thread_id: ThreadId) {
@@ -265,12 +259,9 @@ impl ThreadStateManager {
                 .threads
                 .remove(&thread_id)
                 .map(|thread_entry| thread_entry.state);
-<<<<<<< HEAD
             state
                 .subscription_state_by_id
                 .retain(|_, state| state.thread_id != thread_id);
-=======
->>>>>>> upstream_main
             state.thread_ids_by_connection.retain(|_, thread_ids| {
                 thread_ids.remove(&thread_id);
                 !thread_ids.is_empty()
@@ -289,7 +280,6 @@ impl ThreadStateManager {
             );
             thread_state.clear_listener();
         }
-<<<<<<< HEAD
     }
 
     pub(crate) async fn unsubscribe_connection_from_thread(
@@ -369,7 +359,6 @@ impl ThreadStateManager {
         {
             let mut thread_state_guard = thread_state.lock().await;
             thread_state_guard.set_experimental_raw_events(experimental_raw_events);
-=======
     }
 
     pub(crate) async fn clear_all_listeners(&self) {
@@ -392,12 +381,9 @@ impl ThreadStateManager {
                 "clearing thread listener during app-server shutdown"
             );
             thread_state.clear_listener();
->>>>>>> upstream_main
         }
     }
 
-<<<<<<< HEAD
-=======
     pub(crate) async fn unsubscribe_connection_from_thread(
         &self,
         thread_id: ThreadId,
@@ -440,7 +426,6 @@ impl ThreadStateManager {
             .is_some_and(|thread_entry| !thread_entry.connection_ids.is_empty())
     }
 
->>>>>>> upstream_main
     pub(crate) async fn try_ensure_connection_subscribed(
         &self,
         thread_id: ThreadId,
@@ -501,12 +486,9 @@ impl ThreadStateManager {
                 .thread_ids_by_connection
                 .remove(&connection_id)
                 .unwrap_or_default();
-<<<<<<< HEAD
             state
                 .subscription_state_by_id
                 .retain(|_, state| state.connection_id != connection_id);
-=======
->>>>>>> upstream_main
             for thread_id in &thread_ids {
                 if let Some(thread_entry) = state.threads.get_mut(thread_id) {
                     thread_entry.connection_ids.remove(&connection_id);

--- a/codex-rs/app-server/src/thread_status.rs
+++ b/codex-rs/app-server/src/thread_status.rs
@@ -707,8 +707,6 @@ mod tests {
                 status: ThreadStatus::NotLoaded,
             },
         );
-<<<<<<< HEAD
-=======
     }
 
     #[tokio::test]
@@ -748,7 +746,6 @@ mod tests {
                 },
             },
         );
->>>>>>> upstream_main
     }
 
     async fn wait_for_status(

--- a/codex-rs/app-server/src/transport.rs
+++ b/codex-rs/app-server/src/transport.rs
@@ -719,12 +719,9 @@ pub(crate) async fn route_outgoing_envelope(
 mod tests {
     use super::*;
     use crate::error_code::OVERLOADED_ERROR_CODE;
-<<<<<<< HEAD
-=======
     use codex_app_server_protocol::CommandExecutionRequestApprovalSkillMetadata;
     use codex_app_server_protocol::ConfigWarningNotification;
     use codex_app_server_protocol::ServerNotification;
->>>>>>> upstream_main
     use codex_utils_absolute_path::AbsolutePathBuf;
     use pretty_assertions::assert_eq;
     use serde_json::json;
@@ -1232,11 +1229,8 @@ mod tests {
             .recv()
             .await
             .expect("request should be delivered to the connection");
-<<<<<<< HEAD
         let json = serde_json::to_value(message).expect("request should serialize");
-=======
         let json = serde_json::to_value(message.message).expect("request should serialize");
->>>>>>> upstream_main
         let allowed_path = absolute_path("/tmp/allowed").to_string_lossy().into_owned();
         assert_eq!(
             json["params"]["additionalPermissions"],

--- a/codex-rs/app-server/tests/common/mcp_process.rs
+++ b/codex-rs/app-server/tests/common/mcp_process.rs
@@ -366,8 +366,6 @@ impl McpProcess {
         self.send_request("thread/name/set", params).await
     }
 
-<<<<<<< HEAD
-=======
     /// Send a `thread/metadata/update` JSON-RPC request.
     pub async fn send_thread_metadata_update_request(
         &mut self,
@@ -377,7 +375,6 @@ impl McpProcess {
         self.send_request("thread/metadata/update", params).await
     }
 
->>>>>>> upstream_main
     /// Send a `thread/unsubscribe` JSON-RPC request.
     pub async fn send_thread_unsubscribe_request(
         &mut self,

--- a/codex-rs/app-server/tests/suite/v2/app_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/app_list.rs
@@ -565,7 +565,6 @@ async fn list_apps_waits_for_accessible_data_before_emitting_directory_updates()
         })
         .await?;
 
-<<<<<<< HEAD
     let maybe_update = timeout(
         Duration::from_millis(150),
         read_app_list_updated_notification(&mut mcp),
@@ -576,8 +575,6 @@ async fn list_apps_waits_for_accessible_data_before_emitting_directory_updates()
         "unexpected directory-only app/list update before accessible apps loaded"
     );
 
-=======
->>>>>>> upstream_main
     let expected = vec![
         AppInfo {
             id: "beta".to_string(),
@@ -611,10 +608,8 @@ async fn list_apps_waits_for_accessible_data_before_emitting_directory_updates()
         },
     ];
 
-<<<<<<< HEAD
     let update = read_app_list_updated_notification(&mut mcp).await?;
     assert_eq!(update.data, expected);
-=======
     loop {
         let update = read_app_list_updated_notification(&mut mcp).await?;
         if update.data == expected {
@@ -626,7 +621,6 @@ async fn list_apps_waits_for_accessible_data_before_emitting_directory_updates()
             "unexpected directory-only app/list update before accessible apps loaded"
         );
     }
->>>>>>> upstream_main
 
     let response: JSONRPCResponse = timeout(
         DEFAULT_TIMEOUT,
@@ -656,10 +650,7 @@ async fn list_apps_does_not_emit_empty_interim_updates() -> Result<()> {
         install_url: None,
         is_accessible: false,
         is_enabled: true,
-<<<<<<< HEAD
-=======
         plugin_display_names: Vec::new(),
->>>>>>> upstream_main
     }];
     let (server_url, server_handle) = start_apps_server_with_delays(
         connectors.clone(),
@@ -715,10 +706,7 @@ async fn list_apps_does_not_emit_empty_interim_updates() -> Result<()> {
         install_url: Some("https://chatgpt.com/apps/alpha/alpha".to_string()),
         is_accessible: false,
         is_enabled: true,
-<<<<<<< HEAD
-=======
         plugin_display_names: Vec::new(),
->>>>>>> upstream_main
     }];
 
     let update = read_app_list_updated_notification(&mut mcp).await?;
@@ -1161,10 +1149,7 @@ async fn list_apps_force_refetch_patches_updates_from_cached_snapshots() -> Resu
                 install_url: Some("https://chatgpt.com/apps/beta-app/beta".to_string()),
                 is_accessible: true,
                 is_enabled: true,
-<<<<<<< HEAD
-=======
                 plugin_display_names: Vec::new(),
->>>>>>> upstream_main
             },
             AppInfo {
                 id: "alpha".to_string(),
@@ -1179,10 +1164,7 @@ async fn list_apps_force_refetch_patches_updates_from_cached_snapshots() -> Resu
                 install_url: Some("https://chatgpt.com/apps/alpha/alpha".to_string()),
                 is_accessible: false,
                 is_enabled: true,
-<<<<<<< HEAD
-=======
                 plugin_display_names: Vec::new(),
->>>>>>> upstream_main
             },
         ]
     );

--- a/codex-rs/app-server/tests/suite/v2/initialize.rs
+++ b/codex-rs/app-server/tests/suite/v2/initialize.rs
@@ -14,11 +14,8 @@ use codex_app_server_protocol::ThreadStartResponse;
 use codex_app_server_protocol::TurnStartParams;
 use codex_app_server_protocol::TurnStartResponse;
 use codex_app_server_protocol::UserInput as V2UserInput;
-<<<<<<< HEAD
-=======
 use codex_utils_absolute_path::AbsolutePathBuf;
 use codex_utils_cargo_bin::cargo_bin;
->>>>>>> upstream_main
 use core_test_support::fs_wait;
 use pretty_assertions::assert_eq;
 use serde_json::Value;
@@ -211,7 +208,6 @@ async fn turn_start_notify_payload_includes_initialize_client_name() -> Result<(
     let responses = vec![create_final_assistant_message_sse_response("Done")?];
     let server = create_mock_responses_server_sequence_unchecked(responses).await;
     let codex_home = TempDir::new()?;
-<<<<<<< HEAD
     let notify_script = codex_home.path().join("notify.py");
     std::fs::write(
         &notify_script,
@@ -228,7 +224,6 @@ tmp_path.replace(payload_path)
     let notify_script = notify_script
         .to_str()
         .expect("notify script path should be valid UTF-8");
-=======
     let notify_file = codex_home.path().join("notify.json");
     let notify_capture = cargo_bin("codex-app-server-test-notify-capture")?;
     let notify_capture = notify_capture
@@ -237,20 +232,16 @@ tmp_path.replace(payload_path)
     let notify_file_str = notify_file
         .to_str()
         .expect("notify file path should be valid UTF-8");
->>>>>>> upstream_main
     create_config_toml_with_extra(
         codex_home.path(),
         &server.uri(),
         "never",
         &format!(
-<<<<<<< HEAD
             "notify = [\"python3\", {}]",
             toml_basic_string(notify_script)
-=======
             "notify = [{}, {}]",
             toml_basic_string(notify_capture),
             toml_basic_string(notify_file_str)
->>>>>>> upstream_main
         ),
     )?;
 
@@ -334,12 +325,9 @@ model_provider = "mock_provider"
 
 {extra}
 
-<<<<<<< HEAD
-=======
 [features]
 shell_snapshot = false
 
->>>>>>> upstream_main
 [model_providers.mock_provider]
 name = "Mock provider for test"
 base_url = "{server_uri}/v1"

--- a/codex-rs/app-server/tests/suite/v2/mod.rs
+++ b/codex-rs/app-server/tests/suite/v2/mod.rs
@@ -24,10 +24,7 @@ mod plugin_read;
 mod plugin_uninstall;
 mod rate_limits;
 mod realtime_conversation;
-<<<<<<< HEAD
-=======
 mod request_permissions;
->>>>>>> upstream_main
 mod request_user_input;
 mod review;
 mod safety_check_downgrade;

--- a/codex-rs/app-server/tests/suite/v2/realtime_conversation.rs
+++ b/codex-rs/app-server/tests/suite/v2/realtime_conversation.rs
@@ -5,10 +5,7 @@ use app_test_support::create_mock_responses_server_sequence_unchecked;
 use app_test_support::to_response;
 use codex_app_server_protocol::JSONRPCError;
 use codex_app_server_protocol::JSONRPCResponse;
-<<<<<<< HEAD
-=======
 use codex_app_server_protocol::LoginAccountResponse;
->>>>>>> upstream_main
 use codex_app_server_protocol::RequestId;
 use codex_app_server_protocol::ThreadRealtimeAppendAudioParams;
 use codex_app_server_protocol::ThreadRealtimeAppendAudioResponse;
@@ -24,19 +21,16 @@ use codex_app_server_protocol::ThreadRealtimeStartResponse;
 use codex_app_server_protocol::ThreadRealtimeStartedNotification;
 use codex_app_server_protocol::ThreadRealtimeStopParams;
 use codex_app_server_protocol::ThreadRealtimeStopResponse;
-<<<<<<< HEAD
 use codex_app_server_protocol::ThreadStartParams;
 use codex_app_server_protocol::ThreadStartResponse;
 use codex_core::features::FEATURES;
 use codex_core::features::Feature;
-=======
 use codex_app_server_protocol::ThreadRealtimeTranscriptUpdatedNotification;
 use codex_app_server_protocol::ThreadStartParams;
 use codex_app_server_protocol::ThreadStartResponse;
 use codex_features::FEATURES;
 use codex_features::Feature;
 use codex_protocol::protocol::RealtimeConversationVersion;
->>>>>>> upstream_main
 use core_test_support::responses::start_websocket_server;
 use core_test_support::skip_if_no_network;
 use pretty_assertions::assert_eq;
@@ -48,10 +42,7 @@ use tempfile::TempDir;
 use tokio::time::timeout;
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
-<<<<<<< HEAD
-=======
 const STARTUP_CONTEXT_HEADER: &str = "Startup context from Codex.";
->>>>>>> upstream_main
 
 #[tokio::test]
 async fn realtime_conversation_streams_v2_notifications() -> Result<()> {
@@ -60,7 +51,6 @@ async fn realtime_conversation_streams_v2_notifications() -> Result<()> {
     let responses_server = create_mock_responses_server_sequence_unchecked(Vec::new()).await;
     let realtime_server = start_websocket_server(vec![vec![
         vec![json!({
-<<<<<<< HEAD
             "type": "session.created",
             "session": { "id": "sess_backend" }
         })],
@@ -68,22 +58,17 @@ async fn realtime_conversation_streams_v2_notifications() -> Result<()> {
             "type": "session.updated",
             "session": { "backend_prompt": "backend prompt" }
         })],
-=======
             "type": "session.updated",
             "session": { "id": "sess_backend", "instructions": "backend prompt" }
         })],
         vec![],
->>>>>>> upstream_main
         vec![
             json!({
                 "type": "response.output_audio.delta",
                 "delta": "AQID",
                 "sample_rate": 24_000,
-<<<<<<< HEAD
                 "num_channels": 1,
-=======
                 "channels": 1,
->>>>>>> upstream_main
                 "samples_per_channel": 512
             }),
             json!({
@@ -95,8 +80,6 @@ async fn realtime_conversation_streams_v2_notifications() -> Result<()> {
                 }
             }),
             json!({
-<<<<<<< HEAD
-=======
                 "type": "conversation.item.input_audio_transcription.delta",
                 "delta": "delegate now"
             }),
@@ -115,15 +98,11 @@ async fn realtime_conversation_streams_v2_notifications() -> Result<()> {
                 }
             }),
             json!({
->>>>>>> upstream_main
                 "type": "error",
                 "message": "upstream boom"
             }),
         ],
-<<<<<<< HEAD
-=======
         vec![],
->>>>>>> upstream_main
     ]])
     .await;
 
@@ -137,10 +116,7 @@ async fn realtime_conversation_streams_v2_notifications() -> Result<()> {
 
     let mut mcp = McpProcess::new(codex_home.path()).await?;
     mcp.initialize().await?;
-<<<<<<< HEAD
-=======
     login_with_api_key(&mut mcp, "sk-test-key").await?;
->>>>>>> upstream_main
 
     let thread_start_request_id = mcp
         .send_thread_start_request(ThreadStartParams::default())
@@ -171,8 +147,6 @@ async fn realtime_conversation_streams_v2_notifications() -> Result<()> {
             .await?;
     assert_eq!(started.thread_id, thread_start.thread.id);
     assert!(started.session_id.is_some());
-<<<<<<< HEAD
-=======
     assert_eq!(started.version, RealtimeConversationVersion::V2);
 
     let startup_context_request = realtime_server.wait_for_request(0, 0).await;
@@ -186,7 +160,6 @@ async fn realtime_conversation_streams_v2_notifications() -> Result<()> {
             .context("expected startup context instructions")?
             .contains(STARTUP_CONTEXT_HEADER)
     );
->>>>>>> upstream_main
 
     let audio_append_request_id = mcp
         .send_thread_realtime_append_audio_request(ThreadRealtimeAppendAudioParams {
@@ -196,10 +169,7 @@ async fn realtime_conversation_streams_v2_notifications() -> Result<()> {
                 sample_rate: 24_000,
                 num_channels: 1,
                 samples_per_channel: Some(480),
-<<<<<<< HEAD
-=======
                 item_id: None,
->>>>>>> upstream_main
             },
         })
         .await?;
@@ -241,8 +211,6 @@ async fn realtime_conversation_streams_v2_notifications() -> Result<()> {
     assert_eq!(item_added.thread_id, output_audio.thread_id);
     assert_eq!(item_added.item["type"], json!("message"));
 
-<<<<<<< HEAD
-=======
     let first_transcript_update = read_notification::<ThreadRealtimeTranscriptUpdatedNotification>(
         &mut mcp,
         "thread/realtime/transcriptUpdated",
@@ -277,7 +245,6 @@ async fn realtime_conversation_streams_v2_notifications() -> Result<()> {
     );
     assert_eq!(handoff_item_added.item["active_transcript"], json!([]));
 
->>>>>>> upstream_main
     let realtime_error =
         read_notification::<ThreadRealtimeErrorNotification>(&mut mcp, "thread/realtime/error")
             .await?;
@@ -288,21 +255,16 @@ async fn realtime_conversation_streams_v2_notifications() -> Result<()> {
         read_notification::<ThreadRealtimeClosedNotification>(&mut mcp, "thread/realtime/closed")
             .await?;
     assert_eq!(closed.thread_id, output_audio.thread_id);
-<<<<<<< HEAD
     assert_eq!(closed.reason.as_deref(), Some("transport_closed"));
-=======
     assert_eq!(closed.reason.as_deref(), Some("error"));
->>>>>>> upstream_main
 
     let connections = realtime_server.connections();
     assert_eq!(connections.len(), 1);
     let connection = &connections[0];
-<<<<<<< HEAD
     assert_eq!(connection.len(), 3);
     assert_eq!(
         connection[0].body_json()["type"].as_str(),
         Some("session.create")
-=======
     assert_eq!(connection.len(), 4);
     assert_eq!(
         connection[0].body_json()["type"].as_str(),
@@ -313,7 +275,6 @@ async fn realtime_conversation_streams_v2_notifications() -> Result<()> {
             .as_str()
             .context("expected startup context instructions")?
             .contains(STARTUP_CONTEXT_HEADER)
->>>>>>> upstream_main
     );
     let mut request_types = [
         connection[1].body_json()["type"]
@@ -324,25 +285,19 @@ async fn realtime_conversation_streams_v2_notifications() -> Result<()> {
             .as_str()
             .context("expected websocket request type")?
             .to_string(),
-<<<<<<< HEAD
-=======
         connection[3].body_json()["type"]
             .as_str()
             .context("expected websocket request type")?
             .to_string(),
->>>>>>> upstream_main
     ];
     request_types.sort();
     assert_eq!(
         request_types,
         [
             "conversation.item.create".to_string(),
-<<<<<<< HEAD
             "response.input_audio.delta".to_string(),
-=======
             "input_audio_buffer.append".to_string(),
             "response.create".to_string(),
->>>>>>> upstream_main
         ]
     );
 
@@ -357,13 +312,10 @@ async fn realtime_conversation_stop_emits_closed_notification() -> Result<()> {
     let responses_server = create_mock_responses_server_sequence_unchecked(Vec::new()).await;
     let realtime_server = start_websocket_server(vec![vec![
         vec![json!({
-<<<<<<< HEAD
             "type": "session.created",
             "session": { "id": "sess_backend" }
-=======
             "type": "session.updated",
             "session": { "id": "sess_backend", "instructions": "backend prompt" }
->>>>>>> upstream_main
         })],
         vec![],
     ]])
@@ -379,10 +331,7 @@ async fn realtime_conversation_stop_emits_closed_notification() -> Result<()> {
 
     let mut mcp = McpProcess::new(codex_home.path()).await?;
     mcp.initialize().await?;
-<<<<<<< HEAD
-=======
     login_with_api_key(&mut mcp, "sk-test-key").await?;
->>>>>>> upstream_main
 
     let thread_start_request_id = mcp
         .send_thread_start_request(ThreadStartParams::default())
@@ -501,8 +450,6 @@ async fn read_notification<T: DeserializeOwned>(mcp: &mut McpProcess, method: &s
     Ok(serde_json::from_value(params)?)
 }
 
-<<<<<<< HEAD
-=======
 async fn login_with_api_key(mcp: &mut McpProcess, api_key: &str) -> Result<()> {
     let request_id = mcp.send_login_account_api_key_request(api_key).await?;
     let response: JSONRPCResponse = timeout(
@@ -516,7 +463,6 @@ async fn login_with_api_key(mcp: &mut McpProcess, api_key: &str) -> Result<()> {
     Ok(())
 }
 
->>>>>>> upstream_main
 fn create_config_toml(
     codex_home: &Path,
     responses_server_uri: &str,
@@ -539,13 +485,10 @@ sandbox_mode = "read-only"
 model_provider = "mock_provider"
 experimental_realtime_ws_base_url = "{realtime_server_uri}"
 
-<<<<<<< HEAD
-=======
 [realtime]
 version = "v2"
 type = "conversational"
 
->>>>>>> upstream_main
 [features]
 {realtime_feature_key} = {realtime_enabled}
 

--- a/codex-rs/app-server/tests/suite/v2/thread_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_list.rs
@@ -557,18 +557,15 @@ sqlite = true
     // `thread/list` only applies `search_term` on the sqlite path. In this test we
     // create rollouts manually, so we must also create the sqlite DB and mark backfill
     // complete; otherwise app-server will permanently use filesystem fallback.
-<<<<<<< HEAD
     let state_db = codex_state::StateRuntime::init(
         codex_home.path().to_path_buf(),
         "mock_provider".into(),
         None,
     )
     .await?;
-=======
     let state_db =
         codex_state::StateRuntime::init(codex_home.path().to_path_buf(), "mock_provider".into())
             .await?;
->>>>>>> upstream_main
     state_db.mark_backfill_complete(None).await?;
 
     let mut mcp = init_mcp(codex_home.path()).await?;

--- a/codex-rs/app-server/tests/suite/v2/thread_resume.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_resume.rs
@@ -6,11 +6,8 @@ use app_test_support::create_apply_patch_sse_response;
 use app_test_support::create_fake_rollout_with_text_elements;
 use app_test_support::create_final_assistant_message_sse_response;
 use app_test_support::create_mock_responses_server_repeating_assistant;
-<<<<<<< HEAD
 use app_test_support::create_mock_responses_server_sequence;
-=======
 use app_test_support::create_mock_responses_server_sequence_unchecked;
->>>>>>> upstream_main
 use app_test_support::create_shell_command_sse_response;
 use app_test_support::rollout_path;
 use app_test_support::to_response;
@@ -1035,11 +1032,8 @@ async fn thread_resume_replays_pending_command_execution_request_approval() -> R
         )?,
         create_final_assistant_message_sse_response("done")?,
     ];
-<<<<<<< HEAD
     let server = create_mock_responses_server_sequence(responses).await;
-=======
     let server = create_mock_responses_server_sequence_unchecked(responses).await;
->>>>>>> upstream_main
     let codex_home = TempDir::new()?;
     create_config_toml(codex_home.path(), &server.uri())?;
 
@@ -1154,10 +1148,7 @@ async fn thread_resume_replays_pending_command_execution_request_approval() -> R
         primary.read_stream_until_notification_message("turn/completed"),
     )
     .await??;
-<<<<<<< HEAD
-=======
     wait_for_responses_request_count(&server, 3).await?;
->>>>>>> upstream_main
 
     Ok(())
 }
@@ -1180,11 +1171,8 @@ async fn thread_resume_replays_pending_file_change_request_approval() -> Result<
         create_apply_patch_sse_response(patch, "patch-call")?,
         create_final_assistant_message_sse_response("done")?,
     ];
-<<<<<<< HEAD
     let server = create_mock_responses_server_sequence(responses).await;
-=======
     let server = create_mock_responses_server_sequence_unchecked(responses).await;
->>>>>>> upstream_main
     create_config_toml(&codex_home, &server.uri())?;
 
     let mut primary = McpProcess::new(&codex_home).await?;
@@ -1327,10 +1315,7 @@ async fn thread_resume_replays_pending_file_change_request_approval() -> Result<
         primary.read_stream_until_notification_message("turn/completed"),
     )
     .await??;
-<<<<<<< HEAD
-=======
     wait_for_responses_request_count(&server, 3).await?;
->>>>>>> upstream_main
 
     Ok(())
 }

--- a/codex-rs/app-server/tests/suite/v2/thread_start.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_start.rs
@@ -195,8 +195,6 @@ model_reasoning_effort = "high"
 }
 
 #[tokio::test]
-<<<<<<< HEAD
-=======
 async fn thread_start_accepts_flex_service_tier() -> Result<()> {
     let server = create_mock_responses_server_repeating_assistant("Done").await;
 
@@ -225,7 +223,6 @@ async fn thread_start_accepts_flex_service_tier() -> Result<()> {
 }
 
 #[tokio::test]
->>>>>>> upstream_main
 async fn thread_start_accepts_metrics_service_name() -> Result<()> {
     let server = create_mock_responses_server_repeating_assistant("Done").await;
 

--- a/codex-rs/app-server/tests/suite/v2/thread_unsubscribe.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_unsubscribe.rs
@@ -1,10 +1,7 @@
 use anyhow::Context;
 use anyhow::Result;
 use app_test_support::McpProcess;
-<<<<<<< HEAD
-=======
 use app_test_support::create_final_assistant_message_sse_response;
->>>>>>> upstream_main
 use app_test_support::create_mock_responses_server_repeating_assistant;
 use app_test_support::create_mock_responses_server_sequence_unchecked;
 use app_test_support::create_shell_command_sse_response;
@@ -38,8 +35,6 @@ use tokio::time::timeout;
 
 const DEFAULT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
-<<<<<<< HEAD
-=======
 async fn wait_for_responses_request_count_to_stabilize(
     server: &wiremock::MockServer,
     expected_count: usize,
@@ -85,7 +80,6 @@ async fn wait_for_responses_request_count_to_stabilize(
     Ok(())
 }
 
->>>>>>> upstream_main
 #[tokio::test]
 async fn thread_unsubscribe_unloads_thread_and_emits_thread_closed_notification() -> Result<()> {
     let server = create_mock_responses_server_repeating_assistant("Done").await;
@@ -158,26 +152,20 @@ async fn thread_unsubscribe_during_turn_interrupts_turn_and_emits_thread_closed(
     let working_directory = tmp.path().join("workdir");
     std::fs::create_dir(&working_directory)?;
 
-<<<<<<< HEAD
     let server =
         create_mock_responses_server_sequence_unchecked(vec![create_shell_command_sse_response(
-=======
     let server = create_mock_responses_server_sequence_unchecked(vec![
         create_shell_command_sse_response(
->>>>>>> upstream_main
             shell_command.clone(),
             Some(&working_directory),
             Some(10_000),
             "call_sleep",
-<<<<<<< HEAD
         )?])
         .await;
-=======
         )?,
         create_final_assistant_message_sse_response("Done")?,
     ])
     .await;
->>>>>>> upstream_main
     create_config_toml(&codex_home, &server.uri())?;
 
     let mut mcp = McpProcess::new(&codex_home).await?;
@@ -233,8 +221,6 @@ async fn thread_unsubscribe_during_turn_interrupts_turn_and_emits_thread_closed(
     };
     assert_eq!(payload.thread_id, thread_id);
 
-<<<<<<< HEAD
-=======
     wait_for_responses_request_count_to_stabilize(
         &server,
         1,
@@ -242,7 +228,6 @@ async fn thread_unsubscribe_during_turn_interrupts_turn_and_emits_thread_closed(
     )
     .await?;
 
->>>>>>> upstream_main
     Ok(())
 }
 

--- a/codex-rs/app-server/tests/suite/v2/turn_start.rs
+++ b/codex-rs/app-server/tests/suite/v2/turn_start.rs
@@ -1661,8 +1661,6 @@ async fn turn_start_file_change_approval_v2() -> Result<()> {
     )
     .await??;
 
-<<<<<<< HEAD
-=======
     Ok(())
 }
 
@@ -2040,7 +2038,6 @@ config_file = "./custom-role.toml"
     .await??;
     assert_eq!(turn_completed.thread_id, thread.id);
 
->>>>>>> upstream_main
     Ok(())
 }
 

--- a/codex-rs/app-server/tests/suite/v2/turn_steer.rs
+++ b/codex-rs/app-server/tests/suite/v2/turn_steer.rs
@@ -133,11 +133,8 @@ async fn turn_steer_rejects_oversized_text_input() -> Result<()> {
 
     let _task_started: JSONRPCNotification = timeout(
         DEFAULT_READ_TIMEOUT,
-<<<<<<< HEAD
         mcp.read_stream_until_notification_message("codex/event/task_started"),
-=======
         mcp.read_stream_until_notification_message("turn/started"),
->>>>>>> upstream_main
     )
     .await??;
 

--- a/codex-rs/chatgpt/src/connectors.rs
+++ b/codex-rs/chatgpt/src/connectors.rs
@@ -157,7 +157,6 @@ pub fn merge_connectors_with_accessible(
     filter_disallowed_connectors(merged)
 }
 
-<<<<<<< HEAD
 async fn list_directory_connectors(config: &Config) -> anyhow::Result<Vec<DirectoryApp>> {
     let mut apps = Vec::new();
     let mut next_token: Option<String> = None;
@@ -396,8 +395,6 @@ fn normalize_connector_value(value: Option<&str>) -> Option<String> {
         .filter(|value| !value.is_empty())
         .map(str::to_string)
 }
-=======
->>>>>>> upstream_main
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -611,12 +611,9 @@ async fn cli_main(
                 &mut interactive.config_overrides,
                 root_config_overrides.clone(),
             );
-<<<<<<< HEAD
             let exit_info = run_interactive_tui(interactive, codex_linux_sandbox_exe).await?;
-=======
             let exit_info =
                 run_interactive_tui(interactive, root_remote.clone(), arg0_paths.clone()).await?;
->>>>>>> upstream_main
             handle_app_exit(exit_info)?;
         }
         Some(Subcommand::Exec(mut exec_cli)) => {
@@ -638,12 +635,9 @@ async fn cli_main(
             codex_exec::run_main(exec_cli, codex_linux_sandbox_exe).await?;
         }
         Some(Subcommand::McpServer) => {
-<<<<<<< HEAD
             codex_mcp_server::run_main(codex_linux_sandbox_exe, root_config_overrides).await?;
-=======
             reject_remote_mode_for_subcommand(root_remote.as_deref(), "mcp-server")?;
             codex_mcp_server::run_main(arg0_paths.clone(), root_config_overrides).await?;
->>>>>>> upstream_main
         }
         Some(Subcommand::Mcp(mut mcp_cli)) => {
             reject_remote_mode_for_subcommand(root_remote.as_deref(), "mcp")?;
@@ -714,16 +708,13 @@ async fn cli_main(
                 all,
                 config_overrides,
             );
-<<<<<<< HEAD
             let exit_info = run_interactive_tui(interactive, codex_linux_sandbox_exe).await?;
-=======
             let exit_info = run_interactive_tui(
                 interactive,
                 remote.remote.or(root_remote.clone()),
                 arg0_paths.clone(),
             )
             .await?;
->>>>>>> upstream_main
             handle_app_exit(exit_info)?;
         }
         Some(Subcommand::Fork(ForkCommand {
@@ -741,16 +732,13 @@ async fn cli_main(
                 all,
                 config_overrides,
             );
-<<<<<<< HEAD
             let exit_info = run_interactive_tui(interactive, codex_linux_sandbox_exe).await?;
-=======
             let exit_info = run_interactive_tui(
                 interactive,
                 remote.remote.or(root_remote.clone()),
                 arg0_paths.clone(),
             )
             .await?;
->>>>>>> upstream_main
             handle_app_exit(exit_info)?;
         }
         Some(Subcommand::Login(mut login_cli)) => {
@@ -1008,18 +996,15 @@ async fn run_debug_clear_memories_command(
     let state_path = state_db_path(config.sqlite_home.as_path());
     let mut cleared_state_db = false;
     if tokio::fs::try_exists(&state_path).await? {
-<<<<<<< HEAD
         let state_db = StateRuntime::init(
             config.sqlite_home.clone(),
             config.model_provider_id.clone(),
             None,
         )
         .await?;
-=======
         let state_db =
             StateRuntime::init(config.sqlite_home.clone(), config.model_provider_id.clone())
                 .await?;
->>>>>>> upstream_main
         state_db.reset_memory_data_for_fresh_start().await?;
         cleared_state_db = true;
     }
@@ -1073,12 +1058,9 @@ fn reject_remote_mode_for_subcommand(remote: Option<&str>, subcommand: &str) -> 
 
 async fn run_interactive_tui(
     mut interactive: TuiCli,
-<<<<<<< HEAD
     codex_linux_sandbox_exe: Arg0DispatchPaths,
-=======
     remote: Option<String>,
     arg0_paths: Arg0DispatchPaths,
->>>>>>> upstream_main
 ) -> std::io::Result<AppExitInfo> {
     if let Some(prompt) = interactive.prompt.take() {
         // Normalize CRLF/CR to LF so CLI-provided text can't leak `\r` into TUI state.
@@ -1103,9 +1085,7 @@ async fn run_interactive_tui(
         }
     }
 
-<<<<<<< HEAD
     codex_tui::run_main(interactive, codex_linux_sandbox_exe).await
-=======
     let use_app_server_tui = codex_tui::should_use_app_server_tui(&interactive).await?;
     let normalized_remote = remote
         .as_deref()
@@ -1193,7 +1173,6 @@ fn into_legacy_app_exit_info(exit_info: codex_tui_app_server::AppExitInfo) -> Ap
         update_action: exit_info.update_action.map(into_legacy_update_action),
         exit_reason: into_legacy_exit_reason(exit_info.exit_reason),
     }
->>>>>>> upstream_main
 }
 
 fn confirm(prompt: &str) -> std::io::Result<bool> {

--- a/codex-rs/cli/src/mcp_cmd.rs
+++ b/codex-rs/cli/src/mcp_cmd.rs
@@ -332,13 +332,10 @@ async fn run_add(config_overrides: &CliConfigOverrides, add_args: AddArgs) -> Re
                 config.mcp_oauth_credentials_store_mode,
                 oauth_config.http_headers,
                 oauth_config.env_http_headers,
-<<<<<<< HEAD
                 &Vec::new(),
                 None,
-=======
                 &resolved_scopes,
                 /*oauth_resource*/ None,
->>>>>>> upstream_main
                 config.mcp_oauth_callback_port,
                 config.mcp_oauth_callback_url.as_deref(),
             )
@@ -428,11 +425,8 @@ async fn run_login(config_overrides: &CliConfigOverrides, login_args: LoginArgs)
         config.mcp_oauth_credentials_store_mode,
         http_headers,
         env_http_headers,
-<<<<<<< HEAD
         &scopes,
-=======
         &resolved_scopes,
->>>>>>> upstream_main
         server.oauth_resource.as_deref(),
         config.mcp_oauth_callback_port,
         config.mcp_oauth_callback_url.as_deref(),

--- a/codex-rs/cli/tests/debug_clear_memories.rs
+++ b/codex-rs/cli/tests/debug_clear_memories.rs
@@ -16,17 +16,14 @@ fn codex_command(codex_home: &Path) -> Result<assert_cmd::Command> {
 #[tokio::test]
 async fn debug_clear_memories_resets_state_and_removes_memory_dir() -> Result<()> {
     let codex_home = TempDir::new()?;
-<<<<<<< HEAD
     let runtime = StateRuntime::init(
         codex_home.path().to_path_buf(),
         "test-provider".to_string(),
         None,
     )
     .await?;
-=======
     let runtime =
         StateRuntime::init(codex_home.path().to_path_buf(), "test-provider".to_string()).await?;
->>>>>>> upstream_main
     drop(runtime);
 
     let thread_id = "00000000-0000-0000-0000-000000000123";

--- a/codex-rs/cloud-requirements/src/lib.rs
+++ b/codex-rs/cloud-requirements/src/lib.rs
@@ -18,13 +18,10 @@ use codex_backend_client::Client as BackendClient;
 use codex_core::AuthManager;
 use codex_core::auth::AuthCredentialsStoreMode;
 use codex_core::auth::CodexAuth;
-<<<<<<< HEAD
 use codex_core::config_loader::CloudRequirementsLoadError;
-=======
 use codex_core::auth::RefreshTokenError;
 use codex_core::config_loader::CloudRequirementsLoadError;
 use codex_core::config_loader::CloudRequirementsLoadErrorCode;
->>>>>>> upstream_main
 use codex_core::config_loader::CloudRequirementsLoader;
 use codex_core::config_loader::ConfigRequirementsToml;
 use codex_core::util::backoff;
@@ -51,14 +48,11 @@ const CLOUD_REQUIREMENTS_MAX_ATTEMPTS: usize = 5;
 const CLOUD_REQUIREMENTS_CACHE_FILENAME: &str = "cloud-requirements-cache.json";
 const CLOUD_REQUIREMENTS_CACHE_REFRESH_INTERVAL: Duration = Duration::from_secs(5 * 60);
 const CLOUD_REQUIREMENTS_CACHE_TTL: Duration = Duration::from_secs(30 * 60);
-<<<<<<< HEAD
-=======
 const CLOUD_REQUIREMENTS_FETCH_ATTEMPT_METRIC: &str = "codex.cloud_requirements.fetch_attempt";
 const CLOUD_REQUIREMENTS_FETCH_FINAL_METRIC: &str = "codex.cloud_requirements.fetch_final";
 const CLOUD_REQUIREMENTS_LOAD_METRIC: &str = "codex.cloud_requirements.load";
 const CLOUD_REQUIREMENTS_LOAD_FAILED_MESSAGE: &str = "failed to load your workspace-managed config";
 const CLOUD_REQUIREMENTS_AUTH_RECOVERY_FAILED_MESSAGE: &str = "Your authentication session could not be refreshed automatically. Please log out and sign in again.";
->>>>>>> upstream_main
 const CLOUD_REQUIREMENTS_CACHE_WRITE_HMAC_KEY: &[u8] =
     b"codex-cloud-requirements-cache-v3-064f8542-75b4-494c-a294-97d3ce597271";
 const CLOUD_REQUIREMENTS_CACHE_READ_HMAC_KEYS: &[&[u8]] =
@@ -288,7 +282,6 @@ impl CloudRequirementsService {
                     self.timeout.as_secs()
                 );
                 tracing::error!("{message}");
-<<<<<<< HEAD
                 if let Some(metrics) = codex_otel::metrics::global() {
                     let _ = metrics.counter(
                         "codex.cloud_requirements.load_failure",
@@ -303,7 +296,6 @@ impl CloudRequirementsService {
                     self.timeout.as_secs()
                 ))
             })??;
-=======
                 emit_load_metric("startup", "error");
             })
             .map_err(|_| {
@@ -324,7 +316,6 @@ impl CloudRequirementsService {
                 return Err(err);
             }
         };
->>>>>>> upstream_main
 
         match result.as_ref() {
             Some(requirements) => {
@@ -377,7 +368,6 @@ impl CloudRequirementsService {
             }
         }
 
-<<<<<<< HEAD
         self.fetch_with_retries(&auth, chatgpt_user_id, account_id)
             .await
             .ok_or_else(|| {
@@ -388,9 +378,7 @@ impl CloudRequirementsService {
                 );
                 CloudRequirementsLoadError::new(message)
             })
-=======
         self.fetch_with_retries(auth, "startup").await
->>>>>>> upstream_main
     }
 
     async fn fetch_with_retries(
@@ -518,9 +506,7 @@ impl CloudRequirementsService {
                     Ok(requirements) => requirements,
                     Err(err) => {
                         tracing::error!(error = %err, "Failed to parse cloud requirements");
-<<<<<<< HEAD
                         return None;
-=======
                         emit_fetch_final_metric(
                             trigger,
                             "error",
@@ -533,7 +519,6 @@ impl CloudRequirementsService {
                             /*status_code*/ None,
                             CLOUD_REQUIREMENTS_LOAD_FAILED_MESSAGE,
                         ));
->>>>>>> upstream_main
                     }
                 },
                 None => None,
@@ -807,15 +792,12 @@ pub fn cloud_requirements_loader(
     CloudRequirementsLoader::new(async move {
         task.await.map_err(|err| {
             tracing::error!(error = %err, "Cloud requirements task failed");
-<<<<<<< HEAD
             CloudRequirementsLoadError::new(format!("cloud requirements load failed: {err}"))
-=======
             CloudRequirementsLoadError::new(
                 CloudRequirementsLoadErrorCode::Internal,
                 /*status_code*/ None,
                 format!("cloud requirements load failed: {err}"),
             )
->>>>>>> upstream_main
         })?
     })
 }
@@ -2019,10 +2001,7 @@ enabled = false
             err.to_string(),
             "failed to load your workspace-managed config"
         );
-<<<<<<< HEAD
-=======
         assert_eq!(err.code(), CloudRequirementsLoadErrorCode::RequestFailed);
->>>>>>> upstream_main
         assert_eq!(
             fetcher.request_count.load(Ordering::SeqCst),
             CLOUD_REQUIREMENTS_MAX_ATTEMPTS
@@ -2051,14 +2030,11 @@ enabled = false
                 allowed_approval_policies: Some(vec![AskForApproval::Never]),
                 allowed_sandbox_modes: None,
                 allowed_web_search_modes: None,
-<<<<<<< HEAD
                 mcp_servers: None,
-=======
                 guardian_developer_instructions: None,
                 feature_requirements: None,
                 mcp_servers: None,
                 apps: None,
->>>>>>> upstream_main
                 rules: None,
                 enforce_residency: None,
                 network: None,
@@ -2081,14 +2057,11 @@ enabled = false
                 allowed_approval_policies: Some(vec![AskForApproval::OnRequest]),
                 allowed_sandbox_modes: None,
                 allowed_web_search_modes: None,
-<<<<<<< HEAD
                 mcp_servers: None,
-=======
                 guardian_developer_instructions: None,
                 feature_requirements: None,
                 mcp_servers: None,
                 apps: None,
->>>>>>> upstream_main
                 rules: None,
                 enforce_residency: None,
                 network: None,

--- a/codex-rs/codex-api/src/endpoint/realtime_websocket/methods.rs
+++ b/codex-rs/codex-api/src/endpoint/realtime_websocket/methods.rs
@@ -328,11 +328,8 @@ impl RealtimeWebsocketWriter {
         let payload = serde_json::to_string(message)
             .map_err(|err| ApiError::Stream(format!("failed to encode realtime request: {err}")))?;
         debug!(?message, "realtime websocket request");
-<<<<<<< HEAD
-=======
         self.send_payload(payload).await
     }
->>>>>>> upstream_main
 
     pub async fn send_payload(&self, payload: String) -> Result<(), ApiError> {
         if self.is_closed.load(Ordering::SeqCst) {
@@ -374,12 +371,8 @@ impl RealtimeWebsocketEvents {
 
             match msg {
                 Message::Text(text) => {
-<<<<<<< HEAD
-                    if let Some(event) = parse_realtime_event(&text) {
-=======
                     if let Some(mut event) = parse_realtime_event(&text, self.event_parser) {
                         self.update_active_transcript(&mut event).await;
->>>>>>> upstream_main
                         debug!(?event, "realtime websocket parsed event");
                         return Ok(Some(event));
                     }
@@ -483,14 +476,12 @@ impl RealtimeWebsocketClient {
         request.headers_mut().extend(headers);
 
         info!("connecting realtime websocket: {ws_url}");
-<<<<<<< HEAD
         let (stream, response) =
             tokio_tungstenite::connect_async_with_config(request, Some(websocket_config()), false)
                 .await
                 .map_err(|err| {
                     ApiError::Stream(format!("failed to connect realtime websocket: {err}"))
                 })?;
-=======
         // Realtime websocket TLS should honor the same custom-CA env vars as the rest of Codex's
         // outbound HTTPS and websocket traffic.
         let connector = maybe_build_rustls_client_config_with_custom_ca()
@@ -504,7 +495,6 @@ impl RealtimeWebsocketClient {
         )
         .await
         .map_err(|err| ApiError::Stream(format!("failed to connect realtime websocket: {err}")))?;
->>>>>>> upstream_main
         info!(
             ws_url = %ws_url,
             status = %response.status(),
@@ -512,17 +502,14 @@ impl RealtimeWebsocketClient {
         );
 
         let (stream, rx_message) = WsStream::new(stream);
-<<<<<<< HEAD
-        let connection = RealtimeWebsocketConnection::new(stream, rx_message);
         debug!(
             conversation_id = config.session_id.as_deref().unwrap_or("<none>"),
             "realtime websocket sending session.create"
-=======
+        );
         let connection = RealtimeWebsocketConnection::new(stream, rx_message, config.event_parser);
         debug!(
             session_id = config.session_id.as_deref().unwrap_or("<none>"),
             "realtime websocket sending session.update"
->>>>>>> upstream_main
         );
         connection
             .writer

--- a/codex-rs/config/src/cloud_requirements.rs
+++ b/codex-rs/config/src/cloud_requirements.rs
@@ -6,7 +6,6 @@ use std::fmt;
 use std::future::Future;
 use thiserror::Error;
 
-<<<<<<< HEAD
 #[derive(Clone, Debug, Eq, Error, PartialEq)]
 #[error("{message}")]
 pub struct CloudRequirementsLoadError {
@@ -19,7 +18,6 @@ impl CloudRequirementsLoadError {
             message: message.into(),
         }
     }
-=======
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum CloudRequirementsLoadErrorCode {
     Auth,
@@ -57,7 +55,6 @@ impl CloudRequirementsLoadError {
     pub fn status_code(&self) -> Option<u16> {
         self.status_code
     }
->>>>>>> upstream_main
 }
 
 #[derive(Clone)]

--- a/codex-rs/config/src/lib.rs
+++ b/codex-rs/config/src/lib.rs
@@ -11,10 +11,7 @@ mod state;
 pub const CONFIG_TOML_FILE: &str = "config.toml";
 
 pub use cloud_requirements::CloudRequirementsLoadError;
-<<<<<<< HEAD
-=======
 pub use cloud_requirements::CloudRequirementsLoadErrorCode;
->>>>>>> upstream_main
 pub use cloud_requirements::CloudRequirementsLoader;
 pub use config_requirements::AppRequirementToml;
 pub use config_requirements::AppsRequirementsToml;

--- a/codex-rs/core/src/agent/control.rs
+++ b/codex-rs/core/src/agent/control.rs
@@ -20,11 +20,9 @@ use crate::thread_manager::ThreadManagerState;
 use codex_features::Feature;
 use codex_protocol::AgentPath;
 use codex_protocol::ThreadId;
-<<<<<<< HEAD
 use codex_protocol::models::FunctionCallOutputPayload;
 use codex_protocol::models::ResponseItem;
 use codex_protocol::protocol::InitialHistory;
-=======
 use codex_protocol::items::TurnItem;
 use codex_protocol::models::ContentItem;
 use codex_protocol::models::FunctionCallOutputPayload;
@@ -32,7 +30,6 @@ use codex_protocol::models::ResponseInputItem;
 use codex_protocol::models::ResponseItem;
 use codex_protocol::protocol::InitialHistory;
 use codex_protocol::protocol::InterAgentCommunication;
->>>>>>> upstream_main
 use codex_protocol::protocol::Op;
 use codex_protocol::protocol::RolloutItem;
 use codex_protocol::protocol::SessionSource;
@@ -50,14 +47,11 @@ use tracing::warn;
 
 const AGENT_NAMES: &str = include_str!("agent_names.txt");
 const FORKED_SPAWN_AGENT_OUTPUT_MESSAGE: &str = "You are the newly spawned agent. The prior conversation history was forked from your parent agent. Treat the next user message as your new task, and use the forked history only as background context.";
-<<<<<<< HEAD
 
 #[derive(Clone, Debug, Default)]
 pub(crate) struct SpawnAgentOptions {
     pub(crate) fork_parent_spawn_call_id: Option<String>,
 }
-=======
->>>>>>> upstream_main
 
 #[derive(Clone, Debug, Default)]
 pub(crate) struct SpawnAgentOptions {
@@ -134,13 +128,11 @@ impl AgentControl {
         items: Vec<UserInput>,
         session_source: Option<SessionSource>,
     ) -> CodexResult<ThreadId> {
-<<<<<<< HEAD
         self.spawn_agent_with_options(config, items, session_source, SpawnAgentOptions::default())
             .await
     }
 
     pub(crate) async fn spawn_agent_with_options(
-=======
         Ok(self
             .spawn_agent_internal(config, items, session_source, SpawnAgentOptions::default())
             .await?
@@ -148,15 +140,12 @@ impl AgentControl {
     }
 
     pub(crate) async fn spawn_agent_with_metadata(
->>>>>>> upstream_main
         &self,
         config: crate::config::Config,
         items: Vec<UserInput>,
         session_source: Option<SessionSource>,
         options: SpawnAgentOptions,
-<<<<<<< HEAD
     ) -> CodexResult<ThreadId> {
-=======
     ) -> CodexResult<LiveAgent> {
         self.spawn_agent_internal(config, items, session_source, options)
             .await
@@ -169,7 +158,6 @@ impl AgentControl {
         session_source: Option<SessionSource>,
         options: SpawnAgentOptions,
     ) -> CodexResult<LiveAgent> {
->>>>>>> upstream_main
         let state = self.upgrade()?;
         let mut reservation = self.state.reserve_spawn_slot(config.agent_max_threads)?;
         let inherited_shell_snapshot = self
@@ -238,11 +226,8 @@ impl AgentControl {
                                 "parent thread rollout unavailable for fork: {parent_thread_id}"
                             ))
                         })?;
-<<<<<<< HEAD
                     let mut forked_rollout_items =
-=======
                     let mut forked_rollout_items: Vec<RolloutItem> =
->>>>>>> upstream_main
                         RolloutRecorder::get_rollout_history(&rollout_path)
                             .await?
                             .get_rollout_items();
@@ -263,13 +248,10 @@ impl AgentControl {
                             initial_history,
                             self.clone(),
                             session_source,
-<<<<<<< HEAD
                             false,
-=======
                             /*persist_extended_history*/ false,
                             inherited_shell_snapshot,
                             inherited_exec_policy,
->>>>>>> upstream_main
                         )
                         .await?
                 } else {
@@ -278,15 +260,12 @@ impl AgentControl {
                             config,
                             self.clone(),
                             session_source,
-<<<<<<< HEAD
                             false,
                             None,
-=======
                             /*persist_extended_history*/ false,
                             /*metrics_service_name*/ None,
                             inherited_shell_snapshot,
                             inherited_exec_policy,
->>>>>>> upstream_main
                         )
                         .await?
                 }
@@ -728,7 +707,6 @@ impl AgentControl {
         &self,
         parent_thread_id: ThreadId,
     ) -> String {
-<<<<<<< HEAD
         let Ok(state) = self.upgrade() else {
             return String::new();
         };
@@ -757,7 +735,6 @@ impl AgentControl {
         }
         agents.sort();
         agents.join("\n")
-=======
         let Ok(agents) = self.open_thread_spawn_children(parent_thread_id).await else {
             return String::new();
         };
@@ -838,7 +815,6 @@ impl AgentControl {
         }
 
         Ok(agents)
->>>>>>> upstream_main
     }
 
     /// Starts a detached watcher for sub-agents spawned from another thread.
@@ -1215,7 +1191,6 @@ fn thread_spawn_depth(session_source: &SessionSource) -> Option<i32> {
     }
 }
 #[cfg(test)]
-<<<<<<< HEAD
 mod tests {
     use super::*;
     use crate::CodexAuth;
@@ -2225,7 +2200,5 @@ mod tests {
             .expect("resumed child shutdown should submit");
     }
 }
-=======
 #[path = "control_tests.rs"]
 mod tests;
->>>>>>> upstream_main

--- a/codex-rs/core/src/agent/mod.rs
+++ b/codex-rs/core/src/agent/mod.rs
@@ -6,11 +6,8 @@ pub(crate) mod status;
 
 pub(crate) use codex_protocol::protocol::AgentStatus;
 pub(crate) use control::AgentControl;
-<<<<<<< HEAD
 pub(crate) use guards::exceeds_thread_spawn_depth_limit;
 pub(crate) use guards::next_thread_spawn_depth;
-=======
 pub(crate) use registry::exceeds_thread_spawn_depth_limit;
 pub(crate) use registry::next_thread_spawn_depth;
->>>>>>> upstream_main
 pub(crate) use status::agent_status_from_event;

--- a/codex-rs/core/src/agent/role.rs
+++ b/codex-rs/core/src/agent/role.rs
@@ -419,7 +419,6 @@ Rules:
 }
 
 #[cfg(test)]
-<<<<<<< HEAD
 mod tests {
     use super::*;
     use crate::config::ConfigBuilder;
@@ -764,7 +763,5 @@ enabled = false
         );
     }
 }
-=======
 #[path = "role_tests.rs"]
 mod tests;
->>>>>>> upstream_main

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -507,17 +507,14 @@ impl ModelClient {
 
     /// Returns whether the Responses-over-WebSocket transport is active for this session.
     ///
-<<<<<<< HEAD
     /// This combines provider capability and feature gating; both must be true for websocket paths
     /// to be eligible.
     ///
     /// If websockets are only enabled via model preference (no explicit feature flag), prefer the
     /// current v2 behavior.
     pub fn active_ws_version(&self, model_info: &ModelInfo) -> Option<ResponsesWebsocketVersion> {
-=======
     /// WebSocket use is controlled by provider capability and session-scoped fallback state.
     pub fn responses_websocket_enabled(&self) -> bool {
->>>>>>> upstream_main
         if !self.state.provider.supports_websockets
             || self.state.disable_websockets.load(Ordering::Relaxed)
             || (*CODEX_RS_SSE_FIXTURE).is_some()
@@ -525,15 +522,12 @@ impl ModelClient {
             return false;
         }
 
-<<<<<<< HEAD
         match self.state.responses_websocket_version {
             Some(version) => Some(version),
             None if model_info.prefer_websockets => Some(ResponsesWebsocketVersion::V2),
             None => None,
         }
-=======
         true
->>>>>>> upstream_main
     }
 
     /// Returns auth + provider configuration resolved from the current session auth state.

--- a/codex-rs/core/src/client_common.rs
+++ b/codex-rs/core/src/client_common.rs
@@ -89,17 +89,14 @@ fn reserialize_shell_outputs(items: &mut [ResponseItem]) {
         {
             shell_call_ids.insert(call_id.clone());
         }
-<<<<<<< HEAD
         ResponseItem::FunctionCallOutput { call_id, output }
         | ResponseItem::CustomToolCallOutput { call_id, output } => {
-=======
         ResponseItem::FunctionCallOutput {
             call_id, output, ..
         }
         | ResponseItem::CustomToolCallOutput {
             call_id, output, ..
         } => {
->>>>>>> upstream_main
             if shell_call_ids.remove(call_id)
                 && let Some(structured) = output
                     .text_content()
@@ -329,7 +326,6 @@ impl Stream for ResponseStream {
 }
 
 #[cfg(test)]
-<<<<<<< HEAD
 mod tests {
     use codex_api::ResponsesApiRequest;
     use codex_api::common::OpenAiVerbosity;
@@ -498,7 +494,5 @@ mod tests {
         );
     }
 }
-=======
 #[path = "client_common_tests.rs"]
 mod tests;
->>>>>>> upstream_main

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -27,13 +27,10 @@ use crate::compact_remote::run_inline_remote_auto_compact_task;
 use crate::config::ManagedFeatures;
 use crate::connectors;
 use crate::exec_policy::ExecPolicyManager;
-<<<<<<< HEAD
 use crate::features::FEATURES;
 use crate::features::Feature;
 use crate::features::Features;
 use crate::features::maybe_push_unstable_features_warning;
-=======
->>>>>>> upstream_main
 #[cfg(test)]
 use crate::models_manager::collaboration_mode_presets::CollaborationModesConfig;
 use crate::models_manager::manager::ModelsManager;
@@ -53,26 +50,20 @@ use crate::stream_events_utils::handle_output_item_done;
 use crate::stream_events_utils::last_assistant_message_from_item;
 use crate::stream_events_utils::raw_assistant_output_text_from_item;
 use crate::stream_events_utils::record_completed_response_item;
-<<<<<<< HEAD
 use crate::terminal;
 use crate::truncate::TruncationPolicy;
-=======
->>>>>>> upstream_main
 use crate::turn_metadata::TurnMetadataState;
 use crate::util::error_or_panic;
 use async_channel::Receiver;
 use async_channel::Sender;
 use chrono::Local;
 use chrono::Utc;
-<<<<<<< HEAD
-=======
 use codex_app_server_protocol::McpServerElicitationRequest;
 use codex_app_server_protocol::McpServerElicitationRequestParams;
 use codex_exec_server::Environment;
 use codex_features::FEATURES;
 use codex_features::Feature;
 use codex_features::unstable_features_warning_event;
->>>>>>> upstream_main
 use codex_hooks::HookEvent;
 use codex_hooks::HookEventAfterAgent;
 use codex_hooks::HookPayload;
@@ -130,11 +121,8 @@ use codex_protocol::request_user_input::RequestUserInputArgs;
 use codex_protocol::request_user_input::RequestUserInputResponse;
 use codex_rmcp_client::ElicitationResponse;
 use codex_rmcp_client::OAuthCredentialsStoreMode;
-<<<<<<< HEAD
-=======
 use codex_terminal_detection::user_agent;
 use codex_utils_output_truncation::TruncationPolicy;
->>>>>>> upstream_main
 use codex_utils_stream_parser::AssistantTextChunk;
 use codex_utils_stream_parser::AssistantTextStreamParser;
 use codex_utils_stream_parser::ProposedPlanSegment;
@@ -442,7 +430,6 @@ const DIRECT_APP_TOOL_EXPOSURE_THRESHOLD: usize = 100;
 
 impl Codex {
     /// Spawn a new [`Codex`] and initialize the session.
-<<<<<<< HEAD
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn spawn(
         mut config: Config,
@@ -457,7 +444,6 @@ impl Codex {
         persist_extended_history: bool,
         metrics_service_name: Option<String>,
     ) -> CodexResult<CodexSpawnOk> {
-=======
     pub(crate) async fn spawn(args: CodexSpawnArgs) -> CodexResult<CodexSpawnOk> {
         let parent_trace = match args.parent_trace {
             Some(trace) => {
@@ -502,7 +488,6 @@ impl Codex {
             inherited_exec_policy,
             parent_trace: _,
         } = args;
->>>>>>> upstream_main
         let (tx_sub, rx_sub) = async_channel::bounded(SUBMISSION_CHANNEL_CAPACITY);
         let (tx_event, rx_event) = async_channel::unbounded();
 
@@ -526,7 +511,6 @@ impl Codex {
         if config.features.enabled(Feature::JsRepl)
             && let Err(err) = resolve_compatible_node(config.js_repl_node_path.as_deref()).await
         {
-<<<<<<< HEAD
             let message = format!(
                 "Disabled `js_repl` for this session because the configured Node runtime is unavailable or incompatible. {err}"
             );
@@ -540,7 +524,6 @@ impl Codex {
             loaded_skills.allowed_skills_for_implicit_invocation();
         let user_instructions =
             get_user_instructions(&config, Some(&allowed_skills_for_implicit_invocation)).await;
-=======
             let _ = config.features.disable(Feature::JsRepl);
             let _ = config.features.disable(Feature::JsReplToolsOnly);
             let message = if config.features.enabled(Feature::JsRepl) {
@@ -565,7 +548,6 @@ impl Codex {
             let _ = config.features.disable(Feature::CodeMode);
             config.startup_warnings.push(message);
         }
->>>>>>> upstream_main
 
         let user_instructions = get_user_instructions(&config).await;
 
@@ -1093,10 +1075,7 @@ pub(crate) struct SessionConfiguration {
 
     collaboration_mode: CollaborationMode,
     model_reasoning_summary: Option<ReasoningSummaryConfig>,
-<<<<<<< HEAD
-=======
     service_tier: Option<ServiceTier>,
->>>>>>> upstream_main
 
     /// Developer instructions that supplement the base instructions.
     developer_instructions: Option<String>,
@@ -1181,12 +1160,9 @@ impl SessionConfiguration {
         }
         if let Some(summary) = updates.reasoning_summary {
             next_configuration.model_reasoning_summary = Some(summary);
-<<<<<<< HEAD
-=======
         }
         if let Some(service_tier) = updates.service_tier {
             next_configuration.service_tier = service_tier;
->>>>>>> upstream_main
         }
         if let Some(personality) = updates.personality {
             next_configuration.personality = Some(personality);
@@ -1403,11 +1379,8 @@ impl Session {
         let reasoning_summary = session_configuration
             .model_reasoning_summary
             .unwrap_or(model_info.default_reasoning_summary);
-<<<<<<< HEAD
         let otel_manager = otel_manager.clone().with_model(
-=======
         let session_telemetry = session_telemetry.clone().with_model(
->>>>>>> upstream_main
             session_configuration.collaboration_mode.model(),
             model_info.slug.as_str(),
         );
@@ -1587,34 +1560,28 @@ impl Session {
             session_init.ephemeral = config.ephemeral,
         ));
 
-<<<<<<< HEAD
         let history_meta_fut = async {
             if matches!(
                 session_configuration.session_source,
                 SessionSource::SubAgent(_)
             ) {
-=======
         let is_subagent = matches!(
             session_configuration.session_source,
             SessionSource::SubAgent(_)
         );
         let history_meta_fut = async {
             if is_subagent {
->>>>>>> upstream_main
                 (0, 0)
             } else {
                 crate::message_history::history_metadata(&config).await
             }
-<<<<<<< HEAD
         };
-=======
         }
         .instrument(info_span!(
             "session_init.history_metadata",
             otel.name = "session_init.history_metadata",
             session_init.is_subagent = is_subagent,
         ));
->>>>>>> upstream_main
         let auth_manager_clone = Arc::clone(&auth_manager);
         let config_for_mcp = Arc::clone(&config);
         let mcp_manager_for_mcp = Arc::clone(&mcp_manager);
@@ -1707,7 +1674,6 @@ impl Session {
         let account_id = auth.and_then(CodexAuth::get_account_id);
         let account_email = auth.and_then(CodexAuth::get_account_email);
         let originator = crate::default_client::originator().value;
-<<<<<<< HEAD
         let terminal_type = terminal::user_agent();
         let session_model = session_configuration.collaboration_mode.model().to_string();
         let mut otel_manager = OtelManager::new(
@@ -1724,7 +1690,6 @@ impl Session {
         );
         if let Some(service_name) = session_configuration.metrics_service_name.as_deref() {
             otel_manager = otel_manager.with_metrics_service_name(service_name);
-=======
         let terminal_type = user_agent();
         let session_model = session_configuration.collaboration_mode.model().to_string();
         let auth_env_telemetry = collect_auth_env_telemetry(
@@ -1746,7 +1711,6 @@ impl Session {
         .with_auth_env(auth_env_telemetry.to_otel_metadata());
         if let Some(service_name) = session_configuration.metrics_service_name.as_deref() {
             session_telemetry = session_telemetry.with_metrics_service_name(service_name);
->>>>>>> upstream_main
         }
         let network_proxy_audit_metadata = NetworkProxyAuditMetadata {
             conversation_id: Some(conversation_id.to_string()),
@@ -1759,17 +1723,14 @@ impl Session {
             model: Some(session_model.clone()),
             slug: Some(session_model),
         };
-<<<<<<< HEAD
         config.features.emit_metrics(&otel_manager);
         otel_manager.counter(
             "codex.thread.started",
             1,
-=======
         config.features.emit_metrics(&session_telemetry);
         session_telemetry.counter(
             THREAD_STARTED_METRIC,
             /*inc*/ 1,
->>>>>>> upstream_main
             &[(
                 "is_git",
                 if get_git_repo_root(&session_configuration.cwd).is_some() {
@@ -2248,10 +2209,7 @@ impl Session {
 
     async fn record_initial_history(&self, conversation_history: InitialHistory) {
         let turn_context = self.new_default_turn().await;
-<<<<<<< HEAD
         self.clear_mcp_tool_selection().await;
-=======
->>>>>>> upstream_main
         let is_subagent = {
             let state = self.state.lock().await;
             matches!(
@@ -2261,7 +2219,6 @@ impl Session {
         };
         match conversation_history {
             InitialHistory::New => {
-<<<<<<< HEAD
                 // Build and record initial items (user instructions + environment context)
                 // TODO(ccunningham): Defer initial context insertion until the first real turn
                 // starts so it reflects the actual first-turn settings (permissions, etc.) and
@@ -2292,7 +2249,6 @@ impl Session {
                     state.set_reference_context_item(reconstructed_rollout.reference_context_item);
                 }
                 self.set_previous_model(previous_model.clone()).await;
-=======
                 // Defer initial context insertion until the first real turn starts so
                 // turn/start overrides can be merged before we write model-visible context.
                 self.set_previous_turn_settings(/*previous_turn_settings*/ None)
@@ -2303,7 +2259,6 @@ impl Session {
                 let previous_turn_settings = self
                     .apply_rollout_reconstruction(&turn_context, &rollout_items)
                     .await;
->>>>>>> upstream_main
 
                 // If resuming, warn when the last recorded model differs from the current one.
                 let curr: &str = turn_context.model_info.slug.as_str();
@@ -2325,7 +2280,6 @@ impl Session {
                     .await;
                 }
 
-<<<<<<< HEAD
                 // Always add response items to conversation history
                 let reconstructed_history = reconstructed_rollout.history;
                 if !reconstructed_history.is_empty() {
@@ -2333,8 +2287,6 @@ impl Session {
                         .await;
                 }
 
-=======
->>>>>>> upstream_main
                 // Seed usage info from the recorded rollout so UIs can show token counts
                 // immediately on resume/fork.
                 if let Some(info) = Self::last_token_info_from_rollout(&rollout_items) {
@@ -2349,7 +2301,6 @@ impl Session {
                 }
             }
             InitialHistory::Forked(rollout_items) => {
-<<<<<<< HEAD
                 let restored_tool_selection =
                     Self::extract_mcp_tool_selection_from_rollout(&rollout_items);
                 let reconstructed_rollout = self
@@ -2364,10 +2315,8 @@ impl Session {
                     self.record_into_history(&reconstructed_history, &turn_context)
                         .await;
                 }
-=======
                 self.apply_rollout_reconstruction(&turn_context, &rollout_items)
                     .await;
->>>>>>> upstream_main
 
                 // Seed usage info from the recorded rollout so UIs can show token counts
                 // immediately on resume/fork.
@@ -2381,7 +2330,6 @@ impl Session {
                     self.persist_rollout_items(&rollout_items).await;
                 }
 
-<<<<<<< HEAD
                 // Append the current session's initial context after the reconstructed history.
                 let initial_context = self.build_initial_context(&turn_context, None).await;
                 self.record_conversation_items(&turn_context, &initial_context)
@@ -2391,8 +2339,6 @@ impl Session {
                     state.set_reference_context_item(Some(turn_context.to_turn_context_item()));
                 }
 
-=======
->>>>>>> upstream_main
                 // Forked threads should remain file-backed immediately after startup.
                 self.ensure_rollout_materialized().await;
 
@@ -2402,8 +2348,6 @@ impl Session {
                 }
             }
         }
-<<<<<<< HEAD
-=======
     }
 
     async fn apply_rollout_reconstruction(
@@ -2423,7 +2367,6 @@ impl Session {
         self.set_previous_turn_settings(previous_turn_settings.clone())
             .await;
         previous_turn_settings
->>>>>>> upstream_main
     }
 
     fn last_token_info_from_rollout(rollout_items: &[RolloutItem]) -> Option<TokenUsageInfo> {
@@ -3043,14 +2986,11 @@ impl Session {
     /// Emit an exec approval request event and await the user's decision.
     ///
     /// The request is keyed by `call_id` + `approval_id` so matching responses
-<<<<<<< HEAD
     /// are delivered to the correct in-flight turn. If the task is aborted,
     /// this returns the default `ReviewDecision` (`Denied`).
-=======
     /// are delivered to the correct in-flight turn. If the pending approval is
     /// cleared before a response arrives, treat it as an abort so interrupted
     /// turns do not continue on a synthetic denial.
->>>>>>> upstream_main
     ///
     /// Note that if `available_decisions` is `None`, then the other fields will
     /// be used to derive the available decisions via
@@ -3067,10 +3007,7 @@ impl Session {
         network_approval_context: Option<NetworkApprovalContext>,
         proposed_execpolicy_amendment: Option<ExecPolicyAmendment>,
         additional_permissions: Option<PermissionProfile>,
-<<<<<<< HEAD
-=======
         skill_metadata: Option<ExecApprovalRequestSkillMetadata>,
->>>>>>> upstream_main
         available_decisions: Option<Vec<ReviewDecision>>,
     ) -> ReviewDecision {
         //  command-level approvals use `call_id`.
@@ -3124,10 +3061,7 @@ impl Session {
             proposed_execpolicy_amendment,
             proposed_network_policy_amendments,
             additional_permissions,
-<<<<<<< HEAD
-=======
             skill_metadata,
->>>>>>> upstream_main
             available_decisions: Some(available_decisions),
             parsed_cmd,
         });
@@ -3258,8 +3192,6 @@ impl Session {
         rx_response.await.ok()
     }
 
-<<<<<<< HEAD
-=======
     pub async fn request_mcp_server_elicitation(
         &self,
         turn_context: &TurnContext,
@@ -3339,7 +3271,6 @@ impl Session {
         rx_response.await.ok()
     }
 
->>>>>>> upstream_main
     pub async fn notify_user_input_response(
         &self,
         sub_id: &str,
@@ -3637,11 +3568,9 @@ impl Session {
         let mut developer_sections = Vec::<String>::with_capacity(8);
         let mut contextual_user_sections = Vec::<String>::with_capacity(2);
         let shell = self.user_shell();
-<<<<<<< HEAD
         if let Some(model_switch_message) =
             crate::context_manager::updates::build_model_instructions_update_item(
                 previous_user_turn_model,
-=======
         let (
             reference_context_item,
             previous_turn_settings,
@@ -3661,7 +3590,6 @@ impl Session {
         if let Some(model_switch_message) =
             crate::context_manager::updates::build_model_instructions_update_item(
                 previous_turn_settings.as_ref(),
->>>>>>> upstream_main
                 turn_context,
             )
         {
@@ -3683,9 +3611,7 @@ impl Session {
             )
             .into_text(),
         );
-<<<<<<< HEAD
         if let Some(developer_instructions) = turn_context.developer_instructions.as_deref() {
-=======
         let separate_guardian_developer_message =
             crate::guardian::is_guardian_reviewer_source(&session_source);
         // Keep the guardian policy prompt out of the aggregated developer bundle so it
@@ -3693,7 +3619,6 @@ impl Session {
         if !separate_guardian_developer_message
             && let Some(developer_instructions) = turn_context.developer_instructions.as_deref()
         {
->>>>>>> upstream_main
             developer_sections.push(developer_instructions.to_string());
         }
         // Add developer instructions for memories.
@@ -3709,8 +3634,6 @@ impl Session {
             DeveloperInstructions::from_collaboration_mode(&collaboration_mode)
         {
             developer_sections.push(collab_instructions.into_text());
-<<<<<<< HEAD
-=======
         }
         if let Some(realtime_update) = crate::context_manager::updates::build_initial_realtime_item(
             reference_context_item.as_ref(),
@@ -3718,7 +3641,6 @@ impl Session {
             turn_context,
         ) {
             developer_sections.push(realtime_update.into_text());
->>>>>>> upstream_main
         }
         if self.features.enabled(Feature::Personality)
             && let Some(personality) = turn_context.personality
@@ -3739,10 +3661,8 @@ impl Session {
                 );
             }
         }
-<<<<<<< HEAD
         if turn_context.features.enabled(Feature::Apps) {
             developer_sections.push(render_apps_section());
-=======
         if turn_context.apps_enabled() {
             let mcp_connection_manager = self.services.mcp_connection_manager.read().await;
             let accessible_and_enabled_connectors =
@@ -3769,7 +3689,6 @@ impl Session {
         if let Some(plugin_section) = render_plugins_section(loaded_plugins.capability_summaries())
         {
             developer_sections.push(plugin_section);
->>>>>>> upstream_main
         }
         if turn_context.features.enabled(Feature::CodexGitCommit)
             && let Some(commit_message_instruction) = commit_message_trailer_instruction(
@@ -3798,11 +3717,8 @@ impl Session {
                 .serialize_to_xml(),
         );
 
-<<<<<<< HEAD
         let mut items = Vec::with_capacity(2);
-=======
         let mut items = Vec::with_capacity(3);
->>>>>>> upstream_main
         if let Some(developer_message) =
             crate::context_manager::updates::build_developer_update_item(developer_sections)
         {
@@ -3813,8 +3729,6 @@ impl Session {
         {
             items.push(contextual_user_message);
         }
-<<<<<<< HEAD
-=======
         // Emit the guardian policy prompt as a separate developer item so the guardian
         // subagent sees a distinct, easy-to-audit instruction block.
         if separate_guardian_developer_message
@@ -3826,7 +3740,6 @@ impl Session {
         {
             items.push(guardian_developer_message);
         }
->>>>>>> upstream_main
         items
     }
 
@@ -3875,12 +3788,9 @@ impl Session {
         };
         let should_inject_full_context = reference_context_item.is_none();
         let context_items = if should_inject_full_context {
-<<<<<<< HEAD
             self.build_initial_context(turn_context, previous_user_turn_model)
                 .await
-=======
             self.build_initial_context(turn_context).await
->>>>>>> upstream_main
         } else {
             // Steady-state path: append only context diffs to minimize token overhead.
             self.build_settings_update_items(reference_context_item.as_ref(), turn_context)
@@ -4545,7 +4455,6 @@ async fn submission_loop(sess: Arc<Session>, config: Arc<Config>, rx_sub: Receiv
                             ..Default::default()
                         },
                     )
-<<<<<<< HEAD
                 };
                 handlers::override_turn_context(
                     &sess,
@@ -4587,8 +4496,6 @@ async fn submission_loop(sess: Arc<Session>, config: Arc<Config>, rx_sub: Receiv
             }
             Op::GetHistoryEntryRequest { offset, log_id } => {
                 handlers::get_history_entry_request(&sess, &config, sub.id.clone(), offset, log_id)
-=======
->>>>>>> upstream_main
                     .await;
                     false
                 }
@@ -4871,10 +4778,7 @@ mod handlers {
                         windows_sandbox_level: None,
                         collaboration_mode,
                         reasoning_summary: summary,
-<<<<<<< HEAD
-=======
                         service_tier,
->>>>>>> upstream_main
                         final_output_json_schema: Some(final_output_json_schema),
                         personality,
                         app_server_client_name: None,
@@ -5669,17 +5573,14 @@ async fn spawn_review_thread(
         collaboration_mode: parent_turn_context.collaboration_mode.clone(),
         personality: parent_turn_context.personality,
         approval_policy: parent_turn_context.approval_policy.clone(),
-<<<<<<< HEAD
         // Enforce read-only sandbox for review threads so the reviewer cannot
         // modify files.
         sandbox_policy: Constrained::allow_only(SandboxPolicy::ReadOnly {
             access: Default::default(),
         }),
-=======
         sandbox_policy: parent_turn_context.sandbox_policy.clone(),
         file_system_sandbox_policy: parent_turn_context.file_system_sandbox_policy.clone(),
         network_sandbox_policy: parent_turn_context.network_sandbox_policy,
->>>>>>> upstream_main
         network: parent_turn_context.network.clone(),
         windows_sandbox_level: parent_turn_context.windows_sandbox_level,
         shell_environment_policy: parent_turn_context.shell_environment_policy.clone(),
@@ -7058,12 +6959,10 @@ fn realtime_text_for_event(msg: &EventMsg) -> Option<String> {
         | EventMsg::PatchApplyBegin(_)
         | EventMsg::PatchApplyEnd(_)
         | EventMsg::ViewImageToolCall(_)
-<<<<<<< HEAD
         | EventMsg::ExecApprovalRequest(_)
         | EventMsg::RequestUserInput(_)
         | EventMsg::DynamicToolCallRequest(_)
         | EventMsg::DynamicToolCallResponse(_)
-=======
         | EventMsg::ImageGenerationBegin(_)
         | EventMsg::ImageGenerationEnd(_)
         | EventMsg::ExecApprovalRequest(_)
@@ -7072,7 +6971,6 @@ fn realtime_text_for_event(msg: &EventMsg) -> Option<String> {
         | EventMsg::DynamicToolCallRequest(_)
         | EventMsg::DynamicToolCallResponse(_)
         | EventMsg::GuardianAssessment(_)
->>>>>>> upstream_main
         | EventMsg::ElicitationRequest(_)
         | EventMsg::ApplyPatchApprovalRequest(_)
         | EventMsg::DeprecationNotice(_)
@@ -7085,11 +6983,8 @@ fn realtime_text_for_event(msg: &EventMsg) -> Option<String> {
         | EventMsg::McpListToolsResponse(_)
         | EventMsg::ListCustomPromptsResponse(_)
         | EventMsg::ListSkillsResponse(_)
-<<<<<<< HEAD
         | EventMsg::ListRemoteSkillsResponse(_)
         | EventMsg::RemoteSkillDownloaded(_)
-=======
->>>>>>> upstream_main
         | EventMsg::SkillsUpdateAvailable
         | EventMsg::PlanUpdate(_)
         | EventMsg::TurnAborted(_)
@@ -7098,11 +6993,8 @@ fn realtime_text_for_event(msg: &EventMsg) -> Option<String> {
         | EventMsg::ExitedReviewMode(_)
         | EventMsg::RawResponseItem(_)
         | EventMsg::ItemStarted(_)
-<<<<<<< HEAD
-=======
         | EventMsg::HookStarted(_)
         | EventMsg::HookCompleted(_)
->>>>>>> upstream_main
         | EventMsg::AgentMessageContentDelta(_)
         | EventMsg::PlanDelta(_)
         | EventMsg::ReasoningContentDelta(_)
@@ -7358,13 +7250,10 @@ async fn handle_assistant_item_done_in_plan_mode(
     {
         maybe_complete_plan_item_from_message(sess, turn_context, state, item).await;
 
-<<<<<<< HEAD
         if let Some(turn_item) = handle_non_tool_response_item(item, true) {
-=======
         if let Some(turn_item) =
             handle_non_tool_response_item(sess, turn_context, item, /*plan_mode*/ true).await
         {
->>>>>>> upstream_main
             emit_turn_item_in_plan_mode(
                 sess,
                 turn_context,
@@ -7376,11 +7265,8 @@ async fn handle_assistant_item_done_in_plan_mode(
         }
 
         record_completed_response_item(sess, turn_context, item).await;
-<<<<<<< HEAD
         if let Some(agent_message) = last_assistant_message_from_item(item, true) {
-=======
         if let Some(agent_message) = last_assistant_message_from_item(item, /*plan_mode*/ true) {
->>>>>>> upstream_main
             *last_agent_message = Some(agent_message);
         }
         return true;
@@ -7541,9 +7427,7 @@ async fn try_run_sampling_request(
                 needs_follow_up |= output_result.needs_follow_up;
             }
             ResponseEvent::OutputItemAdded(item) => {
-<<<<<<< HEAD
                 if let Some(turn_item) = handle_non_tool_response_item(&item, plan_mode) {
-=======
                 if let Some(turn_item) = handle_non_tool_response_item(
                     sess.as_ref(),
                     turn_context.as_ref(),
@@ -7552,7 +7436,6 @@ async fn try_run_sampling_request(
                 )
                 .await
                 {
->>>>>>> upstream_main
                     let mut turn_item = turn_item;
                     let mut seeded_parsed: Option<ParsedAssistantTextDelta> = None;
                     let mut seeded_item_id: Option<String> = None;
@@ -7755,11 +7638,8 @@ async fn try_run_sampling_request(
 
 pub(super) fn get_last_assistant_message_from_turn(responses: &[ResponseItem]) -> Option<String> {
     for item in responses.iter().rev() {
-<<<<<<< HEAD
         if let Some(message) = last_assistant_message_from_item(item, false) {
-=======
         if let Some(message) = last_assistant_message_from_item(item, /*plan_mode*/ false) {
->>>>>>> upstream_main
             return Some(message);
         }
     }
@@ -7777,7 +7657,6 @@ pub(crate) use tests::make_session_and_context_with_rx;
 pub(crate) use tests::make_session_configuration_for_tests;
 
 #[cfg(test)]
-<<<<<<< HEAD
 mod tests {
     use super::*;
     use crate::CodexAuth;
@@ -10915,7 +10794,5 @@ mod tests {
         pretty_assertions::assert_eq!(output, expected);
     }
 }
-=======
 #[path = "codex_tests.rs"]
 mod tests;
->>>>>>> upstream_main

--- a/codex-rs/core/src/codex/rollout_reconstruction.rs
+++ b/codex-rs/core/src/codex/rollout_reconstruction.rs
@@ -1,19 +1,13 @@
 use super::*;
-<<<<<<< HEAD
-=======
 use crate::context_manager::is_user_turn_boundary;
->>>>>>> upstream_main
 
 // Return value of `Session::reconstruct_history_from_rollout`, bundling the rebuilt history with
 // the resume/fork hydration metadata derived from the same replay.
 #[derive(Debug)]
 pub(super) struct RolloutReconstruction {
     pub(super) history: Vec<ResponseItem>,
-<<<<<<< HEAD
     pub(super) previous_model: Option<String>,
-=======
     pub(super) previous_turn_settings: Option<PreviousTurnSettings>,
->>>>>>> upstream_main
     pub(super) reference_context_item: Option<TurnContextItem>,
 }
 
@@ -37,11 +31,8 @@ enum TurnReferenceContextItem {
 struct ActiveReplaySegment<'a> {
     turn_id: Option<String>,
     counts_as_user_turn: bool,
-<<<<<<< HEAD
     previous_model: Option<String>,
-=======
     previous_turn_settings: Option<PreviousTurnSettings>,
->>>>>>> upstream_main
     reference_context_item: TurnReferenceContextItem,
     base_replacement_history: Option<&'a [ResponseItem]>,
 }
@@ -54,11 +45,8 @@ fn turn_ids_are_compatible(active_turn_id: Option<&str>, item_turn_id: Option<&s
 fn finalize_active_segment<'a>(
     active_segment: ActiveReplaySegment<'a>,
     base_replacement_history: &mut Option<&'a [ResponseItem]>,
-<<<<<<< HEAD
     previous_model: &mut Option<String>,
-=======
     previous_turn_settings: &mut Option<PreviousTurnSettings>,
->>>>>>> upstream_main
     reference_context_item: &mut TurnReferenceContextItem,
     pending_rollback_turns: &mut usize,
 ) {
@@ -80,15 +68,12 @@ fn finalize_active_segment<'a>(
         *base_replacement_history = Some(segment_base_replacement_history);
     }
 
-<<<<<<< HEAD
     // `previous_model` comes from the newest surviving user turn that established one.
     if previous_model.is_none() && active_segment.counts_as_user_turn {
         *previous_model = active_segment.previous_model;
-=======
     // `previous_turn_settings` come from the newest surviving user turn that established them.
     if previous_turn_settings.is_none() && active_segment.counts_as_user_turn {
         *previous_turn_settings = active_segment.previous_turn_settings;
->>>>>>> upstream_main
     }
 
     // `reference_context_item` comes from the newest surviving user turn baseline, or
@@ -116,11 +101,8 @@ impl Session {
         // are both known; then replay only the buffered surviving tail forward to preserve exact
         // history semantics.
         let mut base_replacement_history: Option<&[ResponseItem]> = None;
-<<<<<<< HEAD
         let mut previous_model = None;
-=======
         let mut previous_turn_settings = None;
->>>>>>> upstream_main
         let mut reference_context_item = TurnReferenceContextItem::NeverSet;
         // Rollback is "drop the newest N user turns". While scanning in reverse, that becomes
         // "skip the next N user-turn segments we finalize".
@@ -196,14 +178,11 @@ impl Session {
                         active_segment.turn_id.as_deref(),
                         ctx.turn_id.as_deref(),
                     ) {
-<<<<<<< HEAD
                         active_segment.previous_model = Some(ctx.model.clone());
-=======
                         active_segment.previous_turn_settings = Some(PreviousTurnSettings {
                             model: ctx.model.clone(),
                             realtime_active: ctx.realtime_active,
                         });
->>>>>>> upstream_main
                         if matches!(
                             active_segment.reference_context_item,
                             TurnReferenceContextItem::NeverSet
@@ -225,17 +204,13 @@ impl Session {
                         finalize_active_segment(
                             active_segment,
                             &mut base_replacement_history,
-<<<<<<< HEAD
                             &mut previous_model,
-=======
                             &mut previous_turn_settings,
->>>>>>> upstream_main
                             &mut reference_context_item,
                             &mut pending_rollback_turns,
                         );
                     }
                 }
-<<<<<<< HEAD
                 RolloutItem::ResponseItem(_)
                 | RolloutItem::EventMsg(_)
                 | RolloutItem::SessionMeta(_) => {}
@@ -243,7 +218,6 @@ impl Session {
 
             if base_replacement_history.is_some()
                 && previous_model.is_some()
-=======
                 RolloutItem::ResponseItem(response_item) => {
                     let active_segment =
                         active_segment.get_or_insert_with(ActiveReplaySegment::default);
@@ -254,7 +228,6 @@ impl Session {
 
             if base_replacement_history.is_some()
                 && previous_turn_settings.is_some()
->>>>>>> upstream_main
                 && !matches!(reference_context_item, TurnReferenceContextItem::NeverSet)
             {
                 // At this point we have both eager resume metadata values and the replacement-
@@ -268,11 +241,8 @@ impl Session {
             finalize_active_segment(
                 active_segment,
                 &mut base_replacement_history,
-<<<<<<< HEAD
                 &mut previous_model,
-=======
                 &mut previous_turn_settings,
->>>>>>> upstream_main
                 &mut reference_context_item,
                 &mut pending_rollback_turns,
             );
@@ -341,11 +311,8 @@ impl Session {
 
         RolloutReconstruction {
             history: history.raw_items().to_vec(),
-<<<<<<< HEAD
             previous_model,
-=======
             previous_turn_settings,
->>>>>>> upstream_main
             reference_context_item,
         }
     }

--- a/codex-rs/core/src/codex/rollout_reconstruction_tests.rs
+++ b/codex-rs/core/src/codex/rollout_reconstruction_tests.rs
@@ -3,17 +3,14 @@ use super::*;
 use crate::protocol::CompactedItem;
 use crate::protocol::InitialHistory;
 use crate::protocol::ResumedHistory;
-<<<<<<< HEAD
 use codex_protocol::ThreadId;
 use codex_protocol::models::ContentItem;
 use codex_protocol::models::ResponseItem;
-=======
 use codex_protocol::AgentPath;
 use codex_protocol::ThreadId;
 use codex_protocol::models::ContentItem;
 use codex_protocol::models::ResponseItem;
 use codex_protocol::protocol::InterAgentCommunication;
->>>>>>> upstream_main
 use pretty_assertions::assert_eq;
 use std::path::PathBuf;
 
@@ -41,10 +38,8 @@ fn assistant_message(text: &str) -> ResponseItem {
     }
 }
 
-<<<<<<< HEAD
 #[tokio::test]
 async fn record_initial_history_resumed_bare_turn_context_does_not_hydrate_previous_model() {
-=======
 fn inter_agent_assistant_message(text: &str) -> ResponseItem {
     let communication = InterAgentCommunication::new(
         AgentPath::root(),
@@ -67,15 +62,11 @@ fn inter_agent_assistant_message(text: &str) -> ResponseItem {
 #[tokio::test]
 async fn record_initial_history_resumed_bare_turn_context_does_not_hydrate_previous_turn_settings()
 {
->>>>>>> upstream_main
     let (session, turn_context) = make_session_and_context().await;
     let previous_model = "previous-rollout-model";
     let previous_context_item = TurnContextItem {
         turn_id: Some(turn_context.sub_id.clone()),
-<<<<<<< HEAD
-=======
         trace_id: turn_context.trace_id.clone(),
->>>>>>> upstream_main
         cwd: turn_context.cwd.clone(),
         current_date: turn_context.current_date.clone(),
         timezone: turn_context.timezone.clone(),
@@ -85,20 +76,14 @@ async fn record_initial_history_resumed_bare_turn_context_does_not_hydrate_previ
         model: previous_model.to_string(),
         personality: turn_context.personality,
         collaboration_mode: Some(turn_context.collaboration_mode.clone()),
-<<<<<<< HEAD
-=======
         realtime_active: Some(turn_context.realtime_active),
->>>>>>> upstream_main
         effort: turn_context.reasoning_effort,
         summary: turn_context.reasoning_summary,
         user_instructions: None,
         developer_instructions: None,
         final_output_json_schema: None,
-<<<<<<< HEAD
         truncation_policy: Some(turn_context.truncation_policy.into()),
-=======
         truncation_policy: Some(turn_context.truncation_policy),
->>>>>>> upstream_main
     };
     let rollout_items = vec![RolloutItem::TurnContext(previous_context_item)];
 
@@ -110,29 +95,20 @@ async fn record_initial_history_resumed_bare_turn_context_does_not_hydrate_previ
         }))
         .await;
 
-<<<<<<< HEAD
     assert_eq!(session.previous_model().await, None);
-=======
     assert_eq!(session.previous_turn_settings().await, None);
->>>>>>> upstream_main
     assert!(session.reference_context_item().await.is_none());
 }
 
 #[tokio::test]
-<<<<<<< HEAD
 async fn record_initial_history_resumed_hydrates_previous_model_from_lifecycle_turn_with_missing_turn_context_id()
-=======
 async fn record_initial_history_resumed_hydrates_previous_turn_settings_from_lifecycle_turn_with_missing_turn_context_id()
->>>>>>> upstream_main
  {
     let (session, turn_context) = make_session_and_context().await;
     let previous_model = "previous-rollout-model";
     let mut previous_context_item = TurnContextItem {
         turn_id: Some(turn_context.sub_id.clone()),
-<<<<<<< HEAD
-=======
         trace_id: turn_context.trace_id.clone(),
->>>>>>> upstream_main
         cwd: turn_context.cwd.clone(),
         current_date: turn_context.current_date.clone(),
         timezone: turn_context.timezone.clone(),
@@ -142,20 +118,14 @@ async fn record_initial_history_resumed_hydrates_previous_turn_settings_from_lif
         model: previous_model.to_string(),
         personality: turn_context.personality,
         collaboration_mode: Some(turn_context.collaboration_mode.clone()),
-<<<<<<< HEAD
-=======
         realtime_active: Some(turn_context.realtime_active),
->>>>>>> upstream_main
         effort: turn_context.reasoning_effort,
         summary: turn_context.reasoning_summary,
         user_instructions: None,
         developer_instructions: None,
         final_output_json_schema: None,
-<<<<<<< HEAD
         truncation_policy: Some(turn_context.truncation_policy.into()),
-=======
         truncation_policy: Some(turn_context.truncation_policy),
->>>>>>> upstream_main
     };
     let turn_id = previous_context_item
         .turn_id
@@ -197,16 +167,13 @@ async fn record_initial_history_resumed_hydrates_previous_turn_settings_from_lif
         .await;
 
     assert_eq!(
-<<<<<<< HEAD
         session.previous_model().await,
         Some(previous_model.to_string())
-=======
         session.previous_turn_settings().await,
         Some(PreviousTurnSettings {
             model: previous_model.to_string(),
             realtime_active: Some(turn_context.realtime_active),
         })
->>>>>>> upstream_main
     );
 }
 
@@ -293,16 +260,13 @@ async fn reconstruct_history_rollback_keeps_history_and_metadata_in_sync_for_com
         vec![turn_one_user, turn_one_assistant]
     );
     assert_eq!(
-<<<<<<< HEAD
         reconstructed.previous_model,
         Some(turn_context.model_info.slug.clone())
-=======
         reconstructed.previous_turn_settings,
         Some(PreviousTurnSettings {
             model: turn_context.model_info.slug.clone(),
             realtime_active: Some(turn_context.realtime_active),
         })
->>>>>>> upstream_main
     );
     assert_eq!(
         serde_json::to_value(reconstructed.reference_context_item)
@@ -380,16 +344,13 @@ async fn reconstruct_history_rollback_keeps_history_and_metadata_in_sync_for_inc
         vec![turn_one_user, turn_one_assistant]
     );
     assert_eq!(
-<<<<<<< HEAD
         reconstructed.previous_model,
         Some(turn_context.model_info.slug.clone())
-=======
         reconstructed.previous_turn_settings,
         Some(PreviousTurnSettings {
             model: turn_context.model_info.slug.clone(),
             realtime_active: Some(turn_context.realtime_active),
         })
->>>>>>> upstream_main
     );
     assert_eq!(
         serde_json::to_value(reconstructed.reference_context_item)
@@ -491,10 +452,8 @@ async fn reconstruct_history_rollback_skips_non_user_turns_for_history_and_metad
         vec![turn_one_user, turn_one_assistant]
     );
     assert_eq!(
-<<<<<<< HEAD
         reconstructed.previous_model,
         Some(turn_context.model_info.slug.clone())
-=======
         reconstructed.previous_turn_settings,
         Some(PreviousTurnSettings {
             model: turn_context.model_info.slug.clone(),
@@ -588,7 +547,6 @@ async fn reconstruct_history_rollback_counts_inter_agent_assistant_turns() {
             model: turn_context.model_info.slug.clone(),
             realtime_active: Some(turn_context.realtime_active),
         })
->>>>>>> upstream_main
     );
     assert_eq!(
         serde_json::to_value(reconstructed.reference_context_item)
@@ -641,11 +599,8 @@ async fn reconstruct_history_rollback_clears_history_and_metadata_when_exceeding
         .await;
 
     assert_eq!(reconstructed.history, Vec::new());
-<<<<<<< HEAD
     assert_eq!(reconstructed.previous_model, None);
-=======
     assert_eq!(reconstructed.previous_turn_settings, None);
->>>>>>> upstream_main
     assert!(reconstructed.reference_context_item.is_none());
 }
 
@@ -708,11 +663,8 @@ async fn record_initial_history_resumed_rollback_skips_only_user_turns() {
         }))
         .await;
 
-<<<<<<< HEAD
     assert_eq!(session.previous_model().await, None);
-=======
     assert_eq!(session.previous_turn_settings().await, None);
->>>>>>> upstream_main
     assert!(session.reference_context_item().await.is_none());
 }
 
@@ -782,16 +734,13 @@ async fn record_initial_history_resumed_rollback_drops_incomplete_user_turn_comp
         .await;
 
     assert_eq!(
-<<<<<<< HEAD
         session.previous_model().await,
         Some(turn_context.model_info.slug.clone())
-=======
         session.previous_turn_settings().await,
         Some(PreviousTurnSettings {
             model: turn_context.model_info.slug.clone(),
             realtime_active: Some(turn_context.realtime_active),
         })
->>>>>>> upstream_main
     );
     assert_eq!(
         serde_json::to_value(session.reference_context_item().await)
@@ -838,11 +787,8 @@ async fn record_initial_history_resumed_does_not_seed_reference_context_item_aft
         }))
         .await;
 
-<<<<<<< HEAD
     assert_eq!(session.previous_model().await, None);
-=======
     assert_eq!(session.previous_turn_settings().await, None);
->>>>>>> upstream_main
     assert!(session.reference_context_item().await.is_none());
 }
 
@@ -926,10 +872,7 @@ async fn record_initial_history_resumed_turn_context_after_compaction_reestablis
     let previous_model = "previous-rollout-model";
     let previous_context_item = TurnContextItem {
         turn_id: Some(turn_context.sub_id.clone()),
-<<<<<<< HEAD
-=======
         trace_id: turn_context.trace_id.clone(),
->>>>>>> upstream_main
         cwd: turn_context.cwd.clone(),
         current_date: turn_context.current_date.clone(),
         timezone: turn_context.timezone.clone(),
@@ -939,20 +882,14 @@ async fn record_initial_history_resumed_turn_context_after_compaction_reestablis
         model: previous_model.to_string(),
         personality: turn_context.personality,
         collaboration_mode: Some(turn_context.collaboration_mode.clone()),
-<<<<<<< HEAD
-=======
         realtime_active: Some(turn_context.realtime_active),
->>>>>>> upstream_main
         effort: turn_context.reasoning_effort,
         summary: turn_context.reasoning_summary,
         user_instructions: None,
         developer_instructions: None,
         final_output_json_schema: None,
-<<<<<<< HEAD
         truncation_policy: Some(turn_context.truncation_policy.into()),
-=======
         truncation_policy: Some(turn_context.truncation_policy),
->>>>>>> upstream_main
     };
     let previous_turn_id = previous_context_item
         .turn_id
@@ -997,26 +934,20 @@ async fn record_initial_history_resumed_turn_context_after_compaction_reestablis
         .await;
 
     assert_eq!(
-<<<<<<< HEAD
         session.previous_model().await,
         Some(previous_model.to_string())
-=======
         session.previous_turn_settings().await,
         Some(PreviousTurnSettings {
             model: previous_model.to_string(),
             realtime_active: Some(turn_context.realtime_active),
         })
->>>>>>> upstream_main
     );
     assert_eq!(
         serde_json::to_value(session.reference_context_item().await)
             .expect("serialize seeded reference context item"),
         serde_json::to_value(Some(TurnContextItem {
             turn_id: Some(turn_context.sub_id.clone()),
-<<<<<<< HEAD
-=======
             trace_id: turn_context.trace_id.clone(),
->>>>>>> upstream_main
             cwd: turn_context.cwd.clone(),
             current_date: turn_context.current_date.clone(),
             timezone: turn_context.timezone.clone(),
@@ -1026,20 +957,14 @@ async fn record_initial_history_resumed_turn_context_after_compaction_reestablis
             model: previous_model.to_string(),
             personality: turn_context.personality,
             collaboration_mode: Some(turn_context.collaboration_mode.clone()),
-<<<<<<< HEAD
-=======
             realtime_active: Some(turn_context.realtime_active),
->>>>>>> upstream_main
             effort: turn_context.reasoning_effort,
             summary: turn_context.reasoning_summary,
             user_instructions: None,
             developer_instructions: None,
             final_output_json_schema: None,
-<<<<<<< HEAD
             truncation_policy: Some(turn_context.truncation_policy.into()),
-=======
             truncation_policy: Some(turn_context.truncation_policy),
->>>>>>> upstream_main
         }))
         .expect("serialize expected reference context item")
     );
@@ -1052,10 +977,7 @@ async fn record_initial_history_resumed_aborted_turn_without_id_clears_active_tu
     let previous_model = "previous-rollout-model";
     let previous_context_item = TurnContextItem {
         turn_id: Some(turn_context.sub_id.clone()),
-<<<<<<< HEAD
-=======
         trace_id: turn_context.trace_id.clone(),
->>>>>>> upstream_main
         cwd: turn_context.cwd.clone(),
         current_date: turn_context.current_date.clone(),
         timezone: turn_context.timezone.clone(),
@@ -1065,20 +987,14 @@ async fn record_initial_history_resumed_aborted_turn_without_id_clears_active_tu
         model: previous_model.to_string(),
         personality: turn_context.personality,
         collaboration_mode: Some(turn_context.collaboration_mode.clone()),
-<<<<<<< HEAD
-=======
         realtime_active: Some(turn_context.realtime_active),
->>>>>>> upstream_main
         effort: turn_context.reasoning_effort,
         summary: turn_context.reasoning_summary,
         user_instructions: None,
         developer_instructions: None,
         final_output_json_schema: None,
-<<<<<<< HEAD
         truncation_policy: Some(turn_context.truncation_policy.into()),
-=======
         truncation_policy: Some(turn_context.truncation_policy),
->>>>>>> upstream_main
     };
     let previous_turn_id = previous_context_item
         .turn_id
@@ -1145,16 +1061,13 @@ async fn record_initial_history_resumed_aborted_turn_without_id_clears_active_tu
         .await;
 
     assert_eq!(
-<<<<<<< HEAD
         session.previous_model().await,
         Some(previous_model.to_string())
-=======
         session.previous_turn_settings().await,
         Some(PreviousTurnSettings {
             model: previous_model.to_string(),
             realtime_active: Some(turn_context.realtime_active),
         })
->>>>>>> upstream_main
     );
     assert!(session.reference_context_item().await.is_none());
 }
@@ -1173,10 +1086,7 @@ async fn record_initial_history_resumed_unmatched_abort_preserves_active_turn_fo
     let unmatched_abort_turn_id = "other-turn".to_string();
     let current_context_item = TurnContextItem {
         turn_id: Some(current_turn_id.clone()),
-<<<<<<< HEAD
-=======
         trace_id: turn_context.trace_id.clone(),
->>>>>>> upstream_main
         cwd: turn_context.cwd.clone(),
         current_date: turn_context.current_date.clone(),
         timezone: turn_context.timezone.clone(),
@@ -1186,20 +1096,14 @@ async fn record_initial_history_resumed_unmatched_abort_preserves_active_turn_fo
         model: current_model.to_string(),
         personality: turn_context.personality,
         collaboration_mode: Some(turn_context.collaboration_mode.clone()),
-<<<<<<< HEAD
-=======
         realtime_active: Some(turn_context.realtime_active),
->>>>>>> upstream_main
         effort: turn_context.reasoning_effort,
         summary: turn_context.reasoning_summary,
         user_instructions: None,
         developer_instructions: None,
         final_output_json_schema: None,
-<<<<<<< HEAD
         truncation_policy: Some(turn_context.truncation_policy.into()),
-=======
         truncation_policy: Some(turn_context.truncation_policy),
->>>>>>> upstream_main
     };
 
     let rollout_items = vec![
@@ -1264,16 +1168,13 @@ async fn record_initial_history_resumed_unmatched_abort_preserves_active_turn_fo
         .await;
 
     assert_eq!(
-<<<<<<< HEAD
         session.previous_model().await,
         Some(current_model.to_string())
-=======
         session.previous_turn_settings().await,
         Some(PreviousTurnSettings {
             model: current_model.to_string(),
             realtime_active: Some(turn_context.realtime_active),
         })
->>>>>>> upstream_main
     );
     assert_eq!(
         serde_json::to_value(session.reference_context_item().await)
@@ -1290,10 +1191,7 @@ async fn record_initial_history_resumed_trailing_incomplete_turn_compaction_clea
     let previous_model = "previous-rollout-model";
     let previous_context_item = TurnContextItem {
         turn_id: Some(turn_context.sub_id.clone()),
-<<<<<<< HEAD
-=======
         trace_id: turn_context.trace_id.clone(),
->>>>>>> upstream_main
         cwd: turn_context.cwd.clone(),
         current_date: turn_context.current_date.clone(),
         timezone: turn_context.timezone.clone(),
@@ -1303,20 +1201,14 @@ async fn record_initial_history_resumed_trailing_incomplete_turn_compaction_clea
         model: previous_model.to_string(),
         personality: turn_context.personality,
         collaboration_mode: Some(turn_context.collaboration_mode.clone()),
-<<<<<<< HEAD
-=======
         realtime_active: Some(turn_context.realtime_active),
->>>>>>> upstream_main
         effort: turn_context.reasoning_effort,
         summary: turn_context.reasoning_summary,
         user_instructions: None,
         developer_instructions: None,
         final_output_json_schema: None,
-<<<<<<< HEAD
         truncation_policy: Some(turn_context.truncation_policy.into()),
-=======
         truncation_policy: Some(turn_context.truncation_policy),
->>>>>>> upstream_main
     };
     let previous_turn_id = previous_context_item
         .turn_id
@@ -1377,16 +1269,13 @@ async fn record_initial_history_resumed_trailing_incomplete_turn_compaction_clea
         .await;
 
     assert_eq!(
-<<<<<<< HEAD
         session.previous_model().await,
         Some(previous_model.to_string())
-=======
         session.previous_turn_settings().await,
         Some(PreviousTurnSettings {
             model: previous_model.to_string(),
             realtime_active: Some(turn_context.realtime_active),
         })
->>>>>>> upstream_main
     );
     assert!(session.reference_context_item().await.is_none());
 }
@@ -1428,16 +1317,13 @@ async fn record_initial_history_resumed_trailing_incomplete_turn_preserves_turn_
         .await;
 
     assert_eq!(
-<<<<<<< HEAD
         session.previous_model().await,
         Some(turn_context.model_info.slug.clone())
-=======
         session.previous_turn_settings().await,
         Some(PreviousTurnSettings {
             model: turn_context.model_info.slug.clone(),
             realtime_active: Some(turn_context.realtime_active),
         })
->>>>>>> upstream_main
     );
     assert_eq!(
         serde_json::to_value(session.reference_context_item().await)
@@ -1454,10 +1340,7 @@ async fn record_initial_history_resumed_replaced_incomplete_compacted_turn_clear
     let previous_model = "previous-rollout-model";
     let previous_context_item = TurnContextItem {
         turn_id: Some(turn_context.sub_id.clone()),
-<<<<<<< HEAD
-=======
         trace_id: turn_context.trace_id.clone(),
->>>>>>> upstream_main
         cwd: turn_context.cwd.clone(),
         current_date: turn_context.current_date.clone(),
         timezone: turn_context.timezone.clone(),
@@ -1467,20 +1350,14 @@ async fn record_initial_history_resumed_replaced_incomplete_compacted_turn_clear
         model: previous_model.to_string(),
         personality: turn_context.personality,
         collaboration_mode: Some(turn_context.collaboration_mode.clone()),
-<<<<<<< HEAD
-=======
         realtime_active: Some(turn_context.realtime_active),
->>>>>>> upstream_main
         effort: turn_context.reasoning_effort,
         summary: turn_context.reasoning_summary,
         user_instructions: None,
         developer_instructions: None,
         final_output_json_schema: None,
-<<<<<<< HEAD
         truncation_policy: Some(turn_context.truncation_policy.into()),
-=======
         truncation_policy: Some(turn_context.truncation_policy),
->>>>>>> upstream_main
     };
     let previous_turn_id = previous_context_item
         .turn_id
@@ -1551,16 +1428,13 @@ async fn record_initial_history_resumed_replaced_incomplete_compacted_turn_clear
         .await;
 
     assert_eq!(
-<<<<<<< HEAD
         session.previous_model().await,
         Some(previous_model.to_string())
-=======
         session.previous_turn_settings().await,
         Some(PreviousTurnSettings {
             model: previous_model.to_string(),
             realtime_active: Some(turn_context.realtime_active),
         })
->>>>>>> upstream_main
     );
     assert!(session.reference_context_item().await.is_none());
 }

--- a/codex-rs/core/src/codex_delegate.rs
+++ b/codex-rs/core/src/codex_delegate.rs
@@ -77,7 +77,6 @@ pub(crate) async fn run_codex_thread_interactive(
         config,
         auth_manager,
         models_manager,
-<<<<<<< HEAD
         Arc::clone(&parent_session.services.skills_manager),
         Arc::clone(&parent_session.services.file_watcher),
         initial_history.unwrap_or(InitialHistory::New),
@@ -87,7 +86,6 @@ pub(crate) async fn run_codex_thread_interactive(
         false,
         None,
     )
-=======
         skills_manager: Arc::clone(&parent_session.services.skills_manager),
         plugins_manager: Arc::clone(&parent_session.services.plugins_manager),
         mcp_manager: Arc::clone(&parent_session.services.mcp_manager),
@@ -103,7 +101,6 @@ pub(crate) async fn run_codex_thread_interactive(
         inherited_exec_policy: Some(Arc::clone(&parent_session.services.exec_policy)),
         parent_trace: None,
     })
->>>>>>> upstream_main
     .await?;
     let codex = Arc::new(codex);
 
@@ -445,7 +442,6 @@ async fn handle_exec_approval(
         network_approval_context,
         proposed_execpolicy_amendment,
         additional_permissions,
-<<<<<<< HEAD
         available_decisions,
         ..
     } = event;
@@ -469,7 +465,6 @@ async fn handle_exec_approval(
         cancel_token,
     )
     .await;
-=======
         skill_metadata,
         available_decisions,
         ..
@@ -524,7 +519,6 @@ async fn handle_exec_approval(
         )
         .await
     };
->>>>>>> upstream_main
 
     let _ = codex
         .submit(Op::ExecApproval {

--- a/codex-rs/core/src/codex_thread.rs
+++ b/codex-rs/core/src/codex_thread.rs
@@ -2,10 +2,7 @@ use crate::agent::AgentStatus;
 use crate::codex::Codex;
 use crate::codex::SteerInputError;
 use crate::config::ConstraintResult;
-<<<<<<< HEAD
-=======
 use crate::error::CodexErr;
->>>>>>> upstream_main
 use crate::error::Result as CodexResult;
 use crate::file_watcher::WatchRegistration;
 use crate::protocol::Event;

--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -450,7 +450,6 @@ async fn drain_to_completed(
 }
 
 #[cfg(test)]
-<<<<<<< HEAD
 mod tests {
 
     use super::*;
@@ -1015,7 +1014,5 @@ keep me updated
         assert_eq!(refreshed, expected);
     }
 }
-=======
 #[path = "compact_tests.rs"]
 mod tests;
->>>>>>> upstream_main

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -231,11 +231,8 @@ fn should_keep_compacted_history_item(item: &ResponseItem) -> bool {
         ResponseItem::Message { role, .. } if role == "user" => {
             matches!(
                 crate::event_mapping::parse_turn_item(item),
-<<<<<<< HEAD
                 Some(TurnItem::UserMessage(_))
-=======
                 Some(TurnItem::UserMessage(_) | TurnItem::HookPrompt(_))
->>>>>>> upstream_main
             )
         }
         ResponseItem::Message { role, .. } if role == "assistant" => true,

--- a/codex-rs/core/src/config/edit.rs
+++ b/codex-rs/core/src/config/edit.rs
@@ -89,8 +89,6 @@ pub fn status_line_items_edit(items: &[String]) -> ConfigEdit {
     }
 }
 
-<<<<<<< HEAD
-=======
 /// Produces a config edit that sets `[tui].terminal_title` to an explicit ordered list.
 ///
 /// The array is written even when it is empty so "disabled title updates" stays
@@ -104,7 +102,6 @@ pub fn terminal_title_items_edit(items: &[String]) -> ConfigEdit {
     }
 }
 
->>>>>>> upstream_main
 pub fn model_availability_nux_count_edits(shown_count: &HashMap<String, u32>) -> Vec<ConfigEdit> {
     let mut shown_count_entries: Vec<_> = shown_count.iter().collect();
     shown_count_entries.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
@@ -1041,7 +1038,6 @@ impl ConfigEditsBuilder {
 }
 
 #[cfg(test)]
-<<<<<<< HEAD
 mod tests {
     use super::*;
     use crate::config::types::McpServerTransportConfig;
@@ -2055,7 +2051,5 @@ model_reasoning_effort = "high"
         assert!(!contents.contains("mcp_servers"));
     }
 }
-=======
 #[path = "edit_tests.rs"]
 mod tests;
->>>>>>> upstream_main

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -96,13 +96,10 @@ use std::collections::HashMap;
 use std::io::ErrorKind;
 use std::path::Path;
 use std::path::PathBuf;
-<<<<<<< HEAD
 #[cfg(test)]
 use tempfile::tempdir;
-=======
 #[cfg(target_os = "linux")]
 use std::process::Command;
->>>>>>> upstream_main
 
 use crate::config::permissions::compile_permission_profile;
 use crate::config::permissions::get_readable_roots_required_for_codex_runtime;
@@ -159,8 +156,6 @@ const RESERVED_MODEL_PROVIDER_IDS: [&str; 3] = [
     LMSTUDIO_OSS_PROVIDER_ID,
 ];
 
-<<<<<<< HEAD
-=======
 #[cfg(target_os = "linux")]
 pub fn system_bwrap_warning() -> Option<String> {
     system_bwrap_warning_for_path(Path::new(SYSTEM_BWRAP_PATH))
@@ -202,7 +197,6 @@ fn system_bwrap_supports_argv0(system_bwrap_path: &Path) -> bool {
     stdout.contains("--argv0") || stderr.contains("--argv0")
 }
 
->>>>>>> upstream_main
 fn resolve_sqlite_home_env(resolved_cwd: &Path) -> Option<PathBuf> {
     let raw = std::env::var(codex_state::SQLITE_HOME_ENV).ok()?;
     let trimmed = raw.trim();
@@ -534,13 +528,10 @@ pub struct Config {
     /// Base URL for requests to ChatGPT (as opposed to the OpenAI API).
     pub chatgpt_base_url: String,
 
-<<<<<<< HEAD
-=======
     /// Experimental / do not use. Overrides the URL used when connecting to
     /// a remote exec server.
     pub experimental_exec_server_url: Option<String>,
 
->>>>>>> upstream_main
     /// Machine-local realtime audio device preferences used by realtime voice.
     pub realtime_audio: RealtimeAudioConfig,
 
@@ -1327,8 +1318,6 @@ pub struct ConfigToml {
     /// Base URL for requests to ChatGPT (as opposed to the OpenAI API).
     pub chatgpt_base_url: Option<String>,
 
-<<<<<<< HEAD
-=======
     /// Base URL override for the built-in `openai` model provider.
     pub openai_base_url: Option<String>,
 
@@ -1336,7 +1325,6 @@ pub struct ConfigToml {
     /// a remote exec server.
     pub experimental_exec_server_url: Option<String>,
 
->>>>>>> upstream_main
     /// Machine-local realtime audio device preferences used by realtime voice.
     #[serde(default)]
     pub audio: Option<RealtimeAudioToml>,
@@ -1501,8 +1489,6 @@ pub struct RealtimeAudioConfig {
     pub speaker: Option<String>,
 }
 
-<<<<<<< HEAD
-=======
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, Default, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum RealtimeWsMode {
@@ -1529,7 +1515,6 @@ pub struct RealtimeToml {
     pub session_type: Option<RealtimeWsMode>,
 }
 
->>>>>>> upstream_main
 #[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq, JsonSchema)]
 #[schemars(deny_unknown_fields)]
 pub struct RealtimeAudioToml {
@@ -2361,7 +2346,6 @@ impl Config {
                 "agents.max_depth must be at least 1",
             ));
         }
-<<<<<<< HEAD
         let agent_roles = cfg
             .agents
             .as_ref()
@@ -2385,8 +2369,6 @@ impl Config {
             })
             .transpose()?
             .unwrap_or_default();
-=======
->>>>>>> upstream_main
         let agent_job_max_runtime_seconds = cfg
             .agents
             .as_ref()
@@ -2548,7 +2530,6 @@ impl Config {
             .map(AbsolutePathBuf::to_path_buf)
             .or_else(|| resolve_sqlite_home_env(&resolved_cwd))
             .unwrap_or_else(|| codex_home.to_path_buf());
-<<<<<<< HEAD
 
         // Ensure that every field of ConfigRequirements is applied to the final
         // Config.
@@ -2561,9 +2542,7 @@ impl Config {
             enforce_residency,
             network: network_requirements,
         } = requirements;
-=======
         let original_sandbox_policy = sandbox_policy.clone();
->>>>>>> upstream_main
 
         apply_requirement_constrained_value(
             "approval_policy",
@@ -2731,10 +2710,7 @@ impl Config {
                 .chatgpt_base_url
                 .or(cfg.chatgpt_base_url)
                 .unwrap_or("https://chatgpt.com/backend-api/".to_string()),
-<<<<<<< HEAD
-=======
             experimental_exec_server_url: cfg.experimental_exec_server_url,
->>>>>>> upstream_main
             realtime_audio: cfg
                 .audio
                 .map_or_else(RealtimeAudioConfig::default, |audio| RealtimeAudioConfig {
@@ -2964,7 +2940,6 @@ pub fn log_dir(cfg: &Config) -> std::io::Result<PathBuf> {
 }
 
 #[cfg(test)]
-<<<<<<< HEAD
 mod tests {
     use crate::config::edit::ConfigEdit;
     use crate::config::edit::ConfigEditsBuilder;
@@ -6780,7 +6755,5 @@ mod notifications_tests {
         assert_eq!(parsed.tui.notification_method, NotificationMethod::Bel);
     }
 }
-=======
 #[path = "config_tests.rs"]
 mod tests;
->>>>>>> upstream_main

--- a/codex-rs/core/src/config/network_proxy_spec.rs
+++ b/codex-rs/core/src/config/network_proxy_spec.rs
@@ -154,8 +154,6 @@ impl NetworkProxySpec {
         Ok(StartedNetworkProxy::new(proxy, handle))
     }
 
-<<<<<<< HEAD
-=======
     pub(crate) fn with_exec_policy_network_rules(
         &self,
         exec_policy: &Policy,
@@ -171,7 +169,6 @@ impl NetworkProxySpec {
         Ok(spec)
     }
 
->>>>>>> upstream_main
     fn build_state_with_audit_metadata(
         &self,
         audit_metadata: NetworkProxyAuditMetadata,
@@ -300,7 +297,6 @@ impl NetworkProxySpec {
     }
 }
 
-<<<<<<< HEAD
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -325,7 +321,6 @@ mod tests {
         assert_eq!(state.audit_metadata(), &metadata);
     }
 }
-=======
 fn apply_exec_policy_network_rules(config: &mut NetworkProxyConfig, exec_policy: &Policy) {
     let (allowed_domains, denied_domains) = exec_policy.compiled_network_domains();
     upsert_network_domains(
@@ -364,4 +359,3 @@ fn upsert_network_domains(
 #[cfg(test)]
 #[path = "network_proxy_spec_tests.rs"]
 mod tests;
->>>>>>> upstream_main

--- a/codex-rs/core/src/config/types.rs
+++ b/codex-rs/core/src/config/types.rs
@@ -28,11 +28,8 @@ pub const DEFAULT_OTEL_ENVIRONMENT: &str = "dev";
 pub const DEFAULT_MEMORIES_MAX_ROLLOUTS_PER_STARTUP: usize = 16;
 pub const DEFAULT_MEMORIES_MAX_ROLLOUT_AGE_DAYS: i64 = 30;
 pub const DEFAULT_MEMORIES_MIN_ROLLOUT_IDLE_HOURS: i64 = 6;
-<<<<<<< HEAD
 pub const DEFAULT_MEMORIES_MAX_RAW_MEMORIES_FOR_GLOBAL: usize = 256;
-=======
 pub const DEFAULT_MEMORIES_MAX_RAW_MEMORIES_FOR_CONSOLIDATION: usize = 256;
->>>>>>> upstream_main
 pub const DEFAULT_MEMORIES_MAX_UNUSED_DAYS: i64 = 30;
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, JsonSchema)]
@@ -402,21 +399,15 @@ pub struct ToolSuggestConfig {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default, JsonSchema)]
 #[schemars(deny_unknown_fields)]
 pub struct MemoriesToml {
-<<<<<<< HEAD
-=======
     /// When `true`, web searches and MCP tool calls mark the thread `memory_mode` as `"polluted"`.
     pub no_memories_if_mcp_or_web_search: Option<bool>,
->>>>>>> upstream_main
     /// When `false`, newly created threads are stored with `memory_mode = "disabled"` in the state DB.
     pub generate_memories: Option<bool>,
     /// When `false`, skip injecting memory usage instructions into developer prompts.
     pub use_memories: Option<bool>,
     /// Maximum number of recent raw memories retained for global consolidation.
-<<<<<<< HEAD
     pub max_raw_memories_for_global: Option<usize>,
-=======
     pub max_raw_memories_for_consolidation: Option<usize>,
->>>>>>> upstream_main
     /// Maximum number of days since a memory was last used before it becomes ineligible for phase 2 selection.
     pub max_unused_days: Option<i64>,
     /// Maximum age of the threads used for memories.
@@ -434,16 +425,13 @@ pub struct MemoriesToml {
 /// Effective memories settings after defaults are applied.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MemoriesConfig {
-<<<<<<< HEAD
     pub generate_memories: bool,
     pub use_memories: bool,
     pub max_raw_memories_for_global: usize,
-=======
     pub no_memories_if_mcp_or_web_search: bool,
     pub generate_memories: bool,
     pub use_memories: bool,
     pub max_raw_memories_for_consolidation: usize,
->>>>>>> upstream_main
     pub max_unused_days: i64,
     pub max_rollout_age_days: i64,
     pub max_rollouts_per_startup: usize,
@@ -455,16 +443,13 @@ pub struct MemoriesConfig {
 impl Default for MemoriesConfig {
     fn default() -> Self {
         Self {
-<<<<<<< HEAD
             generate_memories: true,
             use_memories: true,
             max_raw_memories_for_global: DEFAULT_MEMORIES_MAX_RAW_MEMORIES_FOR_GLOBAL,
-=======
             no_memories_if_mcp_or_web_search: false,
             generate_memories: true,
             use_memories: true,
             max_raw_memories_for_consolidation: DEFAULT_MEMORIES_MAX_RAW_MEMORIES_FOR_CONSOLIDATION,
->>>>>>> upstream_main
             max_unused_days: DEFAULT_MEMORIES_MAX_UNUSED_DAYS,
             max_rollout_age_days: DEFAULT_MEMORIES_MAX_ROLLOUT_AGE_DAYS,
             max_rollouts_per_startup: DEFAULT_MEMORIES_MAX_ROLLOUTS_PER_STARTUP,
@@ -479,13 +464,11 @@ impl From<MemoriesToml> for MemoriesConfig {
     fn from(toml: MemoriesToml) -> Self {
         let defaults = Self::default();
         Self {
-<<<<<<< HEAD
             generate_memories: toml.generate_memories.unwrap_or(defaults.generate_memories),
             use_memories: toml.use_memories.unwrap_or(defaults.use_memories),
             max_raw_memories_for_global: toml
                 .max_raw_memories_for_global
                 .unwrap_or(defaults.max_raw_memories_for_global)
-=======
             no_memories_if_mcp_or_web_search: toml
                 .no_memories_if_mcp_or_web_search
                 .unwrap_or(defaults.no_memories_if_mcp_or_web_search),
@@ -494,7 +477,6 @@ impl From<MemoriesToml> for MemoriesConfig {
             max_raw_memories_for_consolidation: toml
                 .max_raw_memories_for_consolidation
                 .unwrap_or(defaults.max_raw_memories_for_consolidation)
->>>>>>> upstream_main
                 .min(4096),
             max_unused_days: toml
                 .max_unused_days
@@ -1009,7 +991,6 @@ impl Default for ShellEnvironmentPolicy {
 }
 
 #[cfg(test)]
-<<<<<<< HEAD
 mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
@@ -1327,7 +1308,5 @@ mod tests {
         );
     }
 }
-=======
 #[path = "types_tests.rs"]
 mod tests;
->>>>>>> upstream_main

--- a/codex-rs/core/src/config_loader/mod.rs
+++ b/codex-rs/core/src/config_loader/mod.rs
@@ -24,14 +24,11 @@ use std::path::Path;
 use std::path::PathBuf;
 use toml::Value as TomlValue;
 
-<<<<<<< HEAD
 pub use codex_config::CloudRequirementsLoadError;
-=======
 pub use codex_config::AppRequirementToml;
 pub use codex_config::AppsRequirementsToml;
 pub use codex_config::CloudRequirementsLoadError;
 pub use codex_config::CloudRequirementsLoadErrorCode;
->>>>>>> upstream_main
 pub use codex_config::CloudRequirementsLoader;
 pub use codex_config::ConfigError;
 pub use codex_config::ConfigLayerEntry;

--- a/codex-rs/core/src/config_loader/tests.rs
+++ b/codex-rs/core/src/config_loader/tests.rs
@@ -657,10 +657,7 @@ allowed_approval_policies = ["on-request"]
                 rules: None,
                 enforce_residency: None,
                 network: None,
-<<<<<<< HEAD
-=======
                 guardian_developer_instructions: None,
->>>>>>> upstream_main
             }))
         }),
     )
@@ -798,15 +795,12 @@ async fn load_config_layers_fails_when_cloud_requirements_loader_fails() -> anyh
         &[] as &[(String, TomlValue)],
         LoaderOverrides::default(),
         CloudRequirementsLoader::new(async {
-<<<<<<< HEAD
             Err(CloudRequirementsLoadError::new("cloud requirements failed"))
-=======
             Err(CloudRequirementsLoadError::new(
                 codex_config::CloudRequirementsLoadErrorCode::RequestFailed,
                 None,
                 "cloud requirements failed",
             ))
->>>>>>> upstream_main
         }),
     )
     .await

--- a/codex-rs/core/src/context_manager/history.rs
+++ b/codex-rs/core/src/context_manager/history.rs
@@ -1,19 +1,16 @@
 use crate::codex::TurnContext;
 use crate::context_manager::normalize;
-<<<<<<< HEAD
 use crate::event_mapping::is_contextual_user_message_content;
 use crate::truncate::TruncationPolicy;
 use crate::truncate::approx_token_count;
 use crate::truncate::approx_tokens_from_byte_count_i64;
 use crate::truncate::truncate_function_output_items_with_policy;
 use crate::truncate::truncate_text;
-=======
 use crate::event_mapping::has_non_contextual_dev_message_content;
 use crate::event_mapping::is_contextual_dev_message_content;
 use crate::event_mapping::is_contextual_user_message_content;
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
->>>>>>> upstream_main
 use codex_protocol::models::BaseInstructions;
 use codex_protocol::models::ContentItem;
 use codex_protocol::models::FunctionCallOutputBody;
@@ -379,7 +376,6 @@ impl ContextManager {
                         output,
                         policy_with_serialization_budget,
                     ),
-<<<<<<< HEAD
                 }
             }
             ResponseItem::CustomToolCallOutput { call_id, output } => {
@@ -389,8 +385,6 @@ impl ContextManager {
                         output,
                         policy_with_serialization_budget,
                     ),
-=======
->>>>>>> upstream_main
                 }
             }
             ResponseItem::CustomToolCallOutput {
@@ -733,16 +727,13 @@ pub(crate) fn is_user_turn_boundary(item: &ResponseItem) -> bool {
         return false;
     };
 
-<<<<<<< HEAD
     role == "user" && !is_contextual_user_message_content(content)
-=======
     (role == "user" && !is_contextual_user_message_content(content))
         || (role == "assistant" && is_inter_agent_instruction_content(content))
 }
 
 fn is_inter_agent_instruction_content(content: &[ContentItem]) -> bool {
     InterAgentCommunication::is_message_content(content)
->>>>>>> upstream_main
 }
 
 fn user_message_positions(items: &[ResponseItem]) -> Vec<usize> {

--- a/codex-rs/core/src/context_manager/history_tests.rs
+++ b/codex-rs/core/src/context_manager/history_tests.rs
@@ -149,10 +149,7 @@ fn reference_context_item() -> TurnContextItem {
 fn custom_tool_call_output(call_id: &str, output: &str) -> ResponseItem {
     ResponseItem::CustomToolCallOutput {
         call_id: call_id.to_string(),
-<<<<<<< HEAD
-=======
         name: None,
->>>>>>> upstream_main
         output: FunctionCallOutputPayload::from_text(output.to_string()),
     }
 }
@@ -500,10 +497,7 @@ fn for_prompt_strips_images_when_model_does_not_support_images() {
         },
         ResponseItem::CustomToolCallOutput {
             call_id: "tool-1".to_string(),
-<<<<<<< HEAD
-=======
             name: None,
->>>>>>> upstream_main
             output: FunctionCallOutputPayload::from_content_items(vec![
                 FunctionCallOutputContentItem::InputText {
                     text: "js repl result".to_string(),
@@ -1021,10 +1015,7 @@ fn remove_first_item_handles_custom_tool_pair() {
         },
         ResponseItem::CustomToolCallOutput {
             call_id: "tool-1".to_string(),
-<<<<<<< HEAD
-=======
             name: None,
->>>>>>> upstream_main
             output: FunctionCallOutputPayload::from_text("ok".to_string()),
         },
     ];
@@ -1104,10 +1095,7 @@ fn record_items_truncates_custom_tool_call_output_content() {
     let long_output = line.repeat(2_500);
     let item = ResponseItem::CustomToolCallOutput {
         call_id: "tool-200".to_string(),
-<<<<<<< HEAD
-=======
         name: None,
->>>>>>> upstream_main
         output: FunctionCallOutputPayload::from_text(long_output.clone()),
     };
 
@@ -1310,10 +1298,7 @@ fn normalize_adds_missing_output_for_custom_tool_call() {
             },
             ResponseItem::CustomToolCallOutput {
                 call_id: "tool-x".to_string(),
-<<<<<<< HEAD
-=======
                 name: None,
->>>>>>> upstream_main
                 output: FunctionCallOutputPayload::from_text("aborted".to_string()),
             },
         ]
@@ -1381,10 +1366,7 @@ fn normalize_removes_orphan_function_call_output() {
 fn normalize_removes_orphan_custom_tool_call_output() {
     let items = vec![ResponseItem::CustomToolCallOutput {
         call_id: "orphan-2".to_string(),
-<<<<<<< HEAD
-=======
         name: None,
->>>>>>> upstream_main
         output: FunctionCallOutputPayload::from_text("ok".to_string()),
     }];
     let mut h = create_history_with_items(items);
@@ -1460,10 +1442,7 @@ fn normalize_mixed_inserts_and_removals() {
             },
             ResponseItem::CustomToolCallOutput {
                 call_id: "t1".to_string(),
-<<<<<<< HEAD
-=======
                 name: None,
->>>>>>> upstream_main
                 output: FunctionCallOutputPayload::from_text("aborted".to_string()),
             },
             ResponseItem::LocalShellCall {
@@ -1601,10 +1580,7 @@ fn normalize_removes_orphan_function_call_output_panics_in_debug() {
 fn normalize_removes_orphan_custom_tool_call_output_panics_in_debug() {
     let items = vec![ResponseItem::CustomToolCallOutput {
         call_id: "orphan-2".to_string(),
-<<<<<<< HEAD
-=======
         name: None,
->>>>>>> upstream_main
         output: FunctionCallOutputPayload::from_text("ok".to_string()),
     }];
     let mut h = create_history_with_items(items);

--- a/codex-rs/core/src/context_manager/normalize.rs
+++ b/codex-rs/core/src/context_manager/normalize.rs
@@ -34,8 +34,6 @@ pub(crate) fn ensure_call_outputs_present(items: &mut Vec<ResponseItem>) {
                         ResponseItem::FunctionCallOutput {
                             call_id: call_id.clone(),
                             output: FunctionCallOutputPayload::from_text("aborted".to_string()),
-<<<<<<< HEAD
-=======
                         },
                     ));
                 }
@@ -61,7 +59,6 @@ pub(crate) fn ensure_call_outputs_present(items: &mut Vec<ResponseItem>) {
                             status: "completed".to_string(),
                             execution: "client".to_string(),
                             tools: Vec::new(),
->>>>>>> upstream_main
                         },
                     ));
                 }
@@ -82,10 +79,7 @@ pub(crate) fn ensure_call_outputs_present(items: &mut Vec<ResponseItem>) {
                         idx,
                         ResponseItem::CustomToolCallOutput {
                             call_id: call_id.clone(),
-<<<<<<< HEAD
-=======
                             name: None,
->>>>>>> upstream_main
                             output: FunctionCallOutputPayload::from_text("aborted".to_string()),
                         },
                     ));

--- a/codex-rs/core/src/context_manager/updates.rs
+++ b/codex-rs/core/src/context_manager/updates.rs
@@ -43,17 +43,14 @@ fn build_permissions_update_item(
     Some(DeveloperInstructions::from_policy(
         next.sandbox_policy.get(),
         next.approval_policy.value(),
-<<<<<<< HEAD
         exec_policy,
         &next.cwd,
         next.features.enabled(Feature::RequestPermissions),
-=======
         next.config.approvals_reviewer,
         exec_policy,
         &next.cwd,
         next.features.enabled(Feature::ExecPermissionApprovals),
         next.features.enabled(Feature::RequestPermissionsTool),
->>>>>>> upstream_main
     ))
 }
 
@@ -149,13 +146,10 @@ pub(crate) fn build_model_instructions_update_item(
     previous_turn_settings: Option<&PreviousTurnSettings>,
     next: &TurnContext,
 ) -> Option<DeveloperInstructions> {
-<<<<<<< HEAD
     let previous_model = previous_user_turn_model?;
     if previous_model == next.model_info.slug {
-=======
     let previous_turn_settings = previous_turn_settings?;
     if previous_turn_settings.model == next.model_info.slug {
->>>>>>> upstream_main
         return None;
     }
 
@@ -204,27 +198,21 @@ pub(crate) fn build_settings_update_items(
     exec_policy: &Policy,
     personality_feature_enabled: bool,
 ) -> Vec<ResponseItem> {
-<<<<<<< HEAD
-=======
     // TODO(ccunningham): build_settings_update_items still does not cover every
     // model-visible item emitted by build_initial_context. Persist the remaining
     // inputs or add explicit replay events so fork/resume can diff everything
     // deterministically.
->>>>>>> upstream_main
     let contextual_user_message = build_environment_update_item(previous, next, shell);
     let developer_update_sections = [
         // Keep model-switch instructions first so model-specific guidance is read before
         // any other context diffs on this turn.
-<<<<<<< HEAD
         build_model_instructions_update_item(previous_user_turn_model, next),
         build_permissions_update_item(previous, next, exec_policy),
         build_collaboration_mode_update_item(previous, next),
-=======
         build_model_instructions_update_item(previous_turn_settings, next),
         build_permissions_update_item(previous, next, exec_policy),
         build_collaboration_mode_update_item(previous, next),
         build_realtime_update_item(previous, previous_turn_settings, next),
->>>>>>> upstream_main
         build_personality_update_item(previous, next, personality_feature_enabled),
     ]
     .into_iter()

--- a/codex-rs/core/src/contextual_user_message.rs
+++ b/codex-rs/core/src/contextual_user_message.rs
@@ -1,8 +1,5 @@
-<<<<<<< HEAD
-=======
 use codex_protocol::items::HookPromptItem;
 use codex_protocol::items::parse_hook_prompt_fragment;
->>>>>>> upstream_main
 use codex_protocol::models::ContentItem;
 use codex_protocol::models::ResponseItem;
 use codex_protocol::protocol::ENVIRONMENT_CONTEXT_CLOSE_TAG;
@@ -99,20 +96,16 @@ const CONTEXTUAL_USER_FRAGMENTS: &[ContextualUserFragmentDefinition] = &[
     SUBAGENT_NOTIFICATION_FRAGMENT,
 ];
 
-<<<<<<< HEAD
 pub(crate) fn is_contextual_user_fragment(content_item: &ContentItem) -> bool {
     let ContentItem::InputText { text } = content_item else {
         return false;
     };
-=======
 fn is_standard_contextual_user_text(text: &str) -> bool {
->>>>>>> upstream_main
     CONTEXTUAL_USER_FRAGMENTS
         .iter()
         .any(|definition| definition.matches_text(text))
 }
 
-<<<<<<< HEAD
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -147,7 +140,6 @@ mod tests {
         }));
     }
 }
-=======
 /// Returns whether a contextual user fragment should be omitted from memory
 /// stage-1 inputs.
 ///
@@ -200,4 +192,3 @@ pub(crate) fn parse_visible_hook_prompt_message(
 #[cfg(test)]
 #[path = "contextual_user_message_tests.rs"]
 mod tests;
->>>>>>> upstream_main

--- a/codex-rs/core/src/environment_context.rs
+++ b/codex-rs/core/src/environment_context.rs
@@ -82,9 +82,7 @@ impl EnvironmentContext {
         } else {
             before_network
         };
-<<<<<<< HEAD
         EnvironmentContext::new(cwd, shell.clone(), current_date, timezone, network, None)
-=======
         EnvironmentContext::new(
             cwd,
             shell.clone(),
@@ -93,7 +91,6 @@ impl EnvironmentContext {
             network,
             /*subagents*/ None,
         )
->>>>>>> upstream_main
     }
 
     pub fn from_turn_context(turn_context: &TurnContext, shell: &Shell) -> Self {
@@ -103,11 +100,8 @@ impl EnvironmentContext {
             turn_context.current_date.clone(),
             turn_context.timezone.clone(),
             Self::network_from_turn_context(turn_context),
-<<<<<<< HEAD
             None,
-=======
             /*subagents*/ None,
->>>>>>> upstream_main
         )
     }
 
@@ -118,11 +112,8 @@ impl EnvironmentContext {
             turn_context_item.current_date.clone(),
             turn_context_item.timezone.clone(),
             Self::network_from_turn_context_item(turn_context_item),
-<<<<<<< HEAD
             None,
-=======
             /*subagents*/ None,
->>>>>>> upstream_main
         )
     }
 
@@ -218,7 +209,6 @@ impl From<EnvironmentContext> for ResponseItem {
 }
 
 #[cfg(test)]
-<<<<<<< HEAD
 mod tests {
     use crate::shell::ShellType;
 
@@ -495,7 +485,5 @@ mod tests {
         assert_eq!(context.serialize_to_xml(), expected);
     }
 }
-=======
 #[path = "environment_context_tests.rs"]
 mod tests;
->>>>>>> upstream_main

--- a/codex-rs/core/src/event_mapping.rs
+++ b/codex-rs/core/src/event_mapping.rs
@@ -21,10 +21,8 @@ use tracing::warn;
 use uuid::Uuid;
 
 use crate::contextual_user_message::is_contextual_user_fragment;
-<<<<<<< HEAD
 use crate::web_search::web_search_action_detail;
 
-=======
 use crate::contextual_user_message::parse_visible_hook_prompt_message;
 use crate::web_search::web_search_action_detail;
 
@@ -36,13 +34,10 @@ const CONTEXTUAL_DEVELOPER_PREFIXES: &[&str] = &[
     "<personality_spec>",
 ];
 
->>>>>>> upstream_main
 pub(crate) fn is_contextual_user_message_content(message: &[ContentItem]) -> bool {
     message.iter().any(is_contextual_user_fragment)
 }
 
-<<<<<<< HEAD
-=======
 /// Returns true when a developer message contains any rollback-trimmable contextual fragment.
 ///
 /// `build_initial_context` can bundle these fragments together with persistent developer text in a
@@ -73,7 +68,6 @@ fn is_contextual_dev_fragment(content_item: &ContentItem) -> bool {
     })
 }
 
->>>>>>> upstream_main
 fn parse_user_message(message: &[ContentItem]) -> Option<UserMessageItem> {
     if is_contextual_user_message_content(message) {
         return None;
@@ -217,7 +211,6 @@ pub fn parse_turn_item(item: &ResponseItem) -> Option<TurnItem> {
 }
 
 #[cfg(test)]
-<<<<<<< HEAD
 mod tests {
     use super::parse_turn_item;
     use codex_protocol::items::AgentMessageContent;
@@ -625,7 +618,5 @@ mod tests {
         }
     }
 }
-=======
 #[path = "event_mapping_tests.rs"]
 mod tests;
->>>>>>> upstream_main

--- a/codex-rs/core/src/exec.rs
+++ b/codex-rs/core/src/exec.rs
@@ -1226,7 +1226,6 @@ fn synthetic_exit_status(code: i32) -> ExitStatus {
 }
 
 #[cfg(test)]
-<<<<<<< HEAD
 mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
@@ -1542,7 +1541,5 @@ mod tests {
         ]
     }
 }
-=======
 #[path = "exec_tests.rs"]
 mod tests;
->>>>>>> upstream_main

--- a/codex-rs/core/src/exec_policy.rs
+++ b/codex-rs/core/src/exec_policy.rs
@@ -879,7 +879,6 @@ async fn collect_policy_files(dir: impl AsRef<Path>) -> Result<Vec<PathBuf>, Exe
 }
 
 #[cfg(test)]
-<<<<<<< HEAD
 mod tests {
     use super::*;
     use crate::config_loader::ConfigLayerEntry;
@@ -2409,7 +2408,5 @@ prefix_rule(pattern=["git"], decision="prompt")
         );
     }
 }
-=======
 #[path = "exec_policy_tests.rs"]
 mod tests;
->>>>>>> upstream_main

--- a/codex-rs/core/src/external_agent_config.rs
+++ b/codex-rs/core/src/external_agent_config.rs
@@ -7,12 +7,9 @@ use std::path::Path;
 use std::path::PathBuf;
 use toml::Value as TomlValue;
 
-<<<<<<< HEAD
-=======
 const EXTERNAL_AGENT_CONFIG_DETECT_METRIC: &str = "codex.external_agent_config.detect";
 const EXTERNAL_AGENT_CONFIG_IMPORT_METRIC: &str = "codex.external_agent_config.import";
 
->>>>>>> upstream_main
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExternalAgentConfigDetectOptions {
     pub include_home: bool,
@@ -63,11 +60,8 @@ impl ExternalAgentConfigService {
     ) -> io::Result<Vec<ExternalAgentConfigMigrationItem>> {
         let mut items = Vec::new();
         if params.include_home {
-<<<<<<< HEAD
             self.detect_migrations(None, &mut items)?;
-=======
             self.detect_migrations(/*repo_root*/ None, &mut items)?;
->>>>>>> upstream_main
         }
 
         for cwd in params.cwds.as_deref().unwrap_or(&[]) {
@@ -84,7 +78,6 @@ impl ExternalAgentConfigService {
         for migration_item in migration_items {
             match migration_item.item_type {
                 ExternalAgentConfigMigrationItemType::Config => {
-<<<<<<< HEAD
                     self.import_config(migration_item.cwd.as_deref())?
                 }
                 ExternalAgentConfigMigrationItemType::Skills => {
@@ -92,7 +85,6 @@ impl ExternalAgentConfigService {
                 }
                 ExternalAgentConfigMigrationItemType::AgentsMd => {
                     self.import_agents_md(migration_item.cwd.as_deref())?
-=======
                     self.import_config(migration_item.cwd.as_deref())?;
                     emit_migration_metric(
                         EXTERNAL_AGENT_CONFIG_IMPORT_METRIC,
@@ -115,7 +107,6 @@ impl ExternalAgentConfigService {
                         ExternalAgentConfigMigrationItemType::AgentsMd,
                         /*skills_count*/ None,
                     );
->>>>>>> upstream_main
                 }
                 ExternalAgentConfigMigrationItemType::McpServerConfig => {}
             }
@@ -161,24 +152,18 @@ impl ExternalAgentConfigService {
                     items.push(ExternalAgentConfigMigrationItem {
                         item_type: ExternalAgentConfigMigrationItemType::Config,
                         description: format!(
-<<<<<<< HEAD
                             "Migrate {} into {}.",
-=======
                             "Migrate {} into {}",
->>>>>>> upstream_main
                             source_settings.display(),
                             target_config.display()
                         ),
                         cwd: cwd.clone(),
                     });
-<<<<<<< HEAD
-=======
                     emit_migration_metric(
                         EXTERNAL_AGENT_CONFIG_DETECT_METRIC,
                         ExternalAgentConfigMigrationItemType::Config,
                         /*skills_count*/ None,
                     );
->>>>>>> upstream_main
                 }
             }
         }
@@ -191,7 +176,6 @@ impl ExternalAgentConfigService {
             || self.home_target_skills_dir(),
             |repo_root| repo_root.join(".agents").join("skills"),
         );
-<<<<<<< HEAD
         let source_skill_names = collect_subdirectory_names(&source_skills)?;
         let target_skill_names = collect_subdirectory_names(&target_skills)?;
         if source_skill_names
@@ -202,27 +186,23 @@ impl ExternalAgentConfigService {
                 item_type: ExternalAgentConfigMigrationItemType::Skills,
                 description: format!(
                     "Copy skill folders from {} to {}.",
-=======
         let skills_count = count_missing_subdirectories(&source_skills, &target_skills)?;
         if skills_count > 0 {
             items.push(ExternalAgentConfigMigrationItem {
                 item_type: ExternalAgentConfigMigrationItemType::Skills,
                 description: format!(
                     "Copy skill folders from {} to {}",
->>>>>>> upstream_main
                     source_skills.display(),
                     target_skills.display()
                 ),
                 cwd: cwd.clone(),
             });
-<<<<<<< HEAD
         }
 
         let source_agents_md = repo_root.map_or_else(
             || self.claude_home.join("CLAUDE.md"),
             |repo_root| repo_root.join("CLAUDE.md"),
         );
-=======
             emit_migration_metric(
                 EXTERNAL_AGENT_CONFIG_DETECT_METRIC,
                 ExternalAgentConfigMigrationItemType::Skills,
@@ -236,18 +216,15 @@ impl ExternalAgentConfigService {
             let path = self.claude_home.join("CLAUDE.md");
             is_non_empty_text_file(&path)?.then_some(path)
         };
->>>>>>> upstream_main
         let target_agents_md = repo_root.map_or_else(
             || self.codex_home.join("AGENTS.md"),
             |repo_root| repo_root.join("AGENTS.md"),
         );
-<<<<<<< HEAD
         if source_agents_md.is_file() && is_missing_or_empty_text_file(&target_agents_md)? {
             items.push(ExternalAgentConfigMigrationItem {
                 item_type: ExternalAgentConfigMigrationItemType::AgentsMd,
                 description: format!(
                     "Import {} to {}.",
-=======
         if let Some(source_agents_md) = source_agents_md
             && is_missing_or_empty_text_file(&target_agents_md)?
         {
@@ -255,20 +232,16 @@ impl ExternalAgentConfigService {
                 item_type: ExternalAgentConfigMigrationItemType::AgentsMd,
                 description: format!(
                     "Import {} to {}",
->>>>>>> upstream_main
                     source_agents_md.display(),
                     target_agents_md.display()
                 ),
                 cwd,
             });
-<<<<<<< HEAD
-=======
             emit_migration_metric(
                 EXTERNAL_AGENT_CONFIG_DETECT_METRIC,
                 ExternalAgentConfigMigrationItemType::AgentsMd,
                 /*skills_count*/ None,
             );
->>>>>>> upstream_main
         }
 
         Ok(())
@@ -333,22 +306,16 @@ impl ExternalAgentConfigService {
         Ok(())
     }
 
-<<<<<<< HEAD
     fn import_skills(&self, cwd: Option<&Path>) -> io::Result<()> {
-=======
     fn import_skills(&self, cwd: Option<&Path>) -> io::Result<usize> {
->>>>>>> upstream_main
         let (source_skills, target_skills) = if let Some(repo_root) = find_repo_root(cwd)? {
             (
                 repo_root.join(".claude").join("skills"),
                 repo_root.join(".agents").join("skills"),
             )
         } else if cwd.is_some_and(|cwd| !cwd.as_os_str().is_empty()) {
-<<<<<<< HEAD
             return Ok(());
-=======
             return Ok(0);
->>>>>>> upstream_main
         } else {
             (
                 self.claude_home.join("skills"),
@@ -356,18 +323,15 @@ impl ExternalAgentConfigService {
             )
         };
         if !source_skills.is_dir() {
-<<<<<<< HEAD
             return Ok(());
         }
 
         fs::create_dir_all(&target_skills)?;
-=======
             return Ok(0);
         }
 
         fs::create_dir_all(&target_skills)?;
         let mut copied_count = 0usize;
->>>>>>> upstream_main
 
         for entry in fs::read_dir(&source_skills)? {
             let entry = entry?;
@@ -382,28 +346,22 @@ impl ExternalAgentConfigService {
             }
 
             copy_dir_recursive(&entry.path(), &target)?;
-<<<<<<< HEAD
         }
 
         Ok(())
-=======
             copied_count += 1;
         }
 
         Ok(copied_count)
->>>>>>> upstream_main
     }
 
     fn import_agents_md(&self, cwd: Option<&Path>) -> io::Result<()> {
         let (source_agents_md, target_agents_md) = if let Some(repo_root) = find_repo_root(cwd)? {
-<<<<<<< HEAD
             (repo_root.join("CLAUDE.md"), repo_root.join("AGENTS.md"))
-=======
             let Some(source_agents_md) = find_repo_agents_md_source(&repo_root)? else {
                 return Ok(());
             };
             (source_agents_md, repo_root.join("AGENTS.md"))
->>>>>>> upstream_main
         } else if cwd.is_some_and(|cwd| !cwd.as_os_str().is_empty()) {
             return Ok(());
         } else {
@@ -412,13 +370,10 @@ impl ExternalAgentConfigService {
                 self.codex_home.join("AGENTS.md"),
             )
         };
-<<<<<<< HEAD
         if !source_agents_md.is_file() || !is_missing_or_empty_text_file(&target_agents_md)? {
-=======
         if !is_non_empty_text_file(&source_agents_md)?
             || !is_missing_or_empty_text_file(&target_agents_md)?
         {
->>>>>>> upstream_main
             return Ok(());
         }
 
@@ -491,8 +446,6 @@ fn collect_subdirectory_names(path: &Path) -> io::Result<HashSet<OsString>> {
     Ok(names)
 }
 
-<<<<<<< HEAD
-=======
 fn count_missing_subdirectories(source: &Path, target: &Path) -> io::Result<usize> {
     let source_names = collect_subdirectory_names(source)?;
     let target_names = collect_subdirectory_names(target)?;
@@ -502,7 +455,6 @@ fn count_missing_subdirectories(source: &Path, target: &Path) -> io::Result<usiz
         .count())
 }
 
->>>>>>> upstream_main
 fn is_missing_or_empty_text_file(path: &Path) -> io::Result<bool> {
     if !path.exists() {
         return Ok(true);
@@ -514,8 +466,6 @@ fn is_missing_or_empty_text_file(path: &Path) -> io::Result<bool> {
     Ok(fs::read_to_string(path)?.trim().is_empty())
 }
 
-<<<<<<< HEAD
-=======
 fn is_non_empty_text_file(path: &Path) -> io::Result<bool> {
     if !path.is_file() {
         return Ok(false);
@@ -537,7 +487,6 @@ fn find_repo_agents_md_source(repo_root: &Path) -> io::Result<Option<PathBuf>> {
     Ok(None)
 }
 
->>>>>>> upstream_main
 fn copy_dir_recursive(source: &Path, target: &Path) -> io::Result<()> {
     fs::create_dir_all(target)?;
 
@@ -649,11 +598,8 @@ fn build_config_from_external(settings: &JsonValue) -> io::Result<TomlValue> {
         shell_policy.insert("inherit".to_string(), TomlValue::String("core".to_string()));
         shell_policy.insert(
             "set".to_string(),
-<<<<<<< HEAD
             TomlValue::Table(json_object_to_toml_table(env)?),
-=======
             TomlValue::Table(json_object_to_env_toml_table(env)),
->>>>>>> upstream_main
         );
         root.insert(
             "shell_environment_policy".to_string(),
@@ -677,7 +623,6 @@ fn build_config_from_external(settings: &JsonValue) -> io::Result<TomlValue> {
     Ok(TomlValue::Table(root))
 }
 
-<<<<<<< HEAD
 fn json_object_to_toml_table(
     object: &serde_json::Map<String, JsonValue>,
 ) -> io::Result<toml::map::Map<String, TomlValue>> {
@@ -708,7 +653,6 @@ fn json_to_toml_value(value: &JsonValue) -> io::Result<TomlValue> {
             .collect::<io::Result<Vec<_>>>()
             .map(TomlValue::Array),
         JsonValue::Object(map) => json_object_to_toml_table(map).map(TomlValue::Table),
-=======
 fn json_object_to_env_toml_table(
     object: &serde_json::Map<String, JsonValue>,
 ) -> toml::map::Map<String, TomlValue> {
@@ -728,7 +672,6 @@ fn json_env_value_to_string(value: &JsonValue) -> Option<String> {
         JsonValue::Bool(value) => Some(value.to_string()),
         JsonValue::Number(value) => Some(value.to_string()),
         JsonValue::Array(_) | JsonValue::Object(_) => None,
->>>>>>> upstream_main
     }
 }
 
@@ -764,11 +707,8 @@ fn merge_missing_toml_values(existing: &mut TomlValue, incoming: &TomlValue) -> 
 fn write_toml_file(path: &Path, value: &TomlValue) -> io::Result<()> {
     let serialized = toml::to_string_pretty(value)
         .map_err(|err| invalid_data_error(format!("failed to serialize config.toml: {err}")))?;
-<<<<<<< HEAD
     fs::write(path, format!("{serialized}\n"))
-=======
     fs::write(path, format!("{}\n", serialized.trim_end()))
->>>>>>> upstream_main
 }
 
 fn is_empty_toml_table(value: &TomlValue) -> bool {
@@ -787,7 +727,6 @@ fn invalid_data_error(message: impl Into<String>) -> io::Error {
     io::Error::new(io::ErrorKind::InvalidData, message.into())
 }
 
-<<<<<<< HEAD
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1111,7 +1050,6 @@ mod tests {
         );
     }
 }
-=======
 fn migration_metric_tags(
     item_type: ExternalAgentConfigMigrationItemType,
     skills_count: Option<usize>,
@@ -1148,4 +1086,3 @@ fn emit_migration_metric(
 #[cfg(test)]
 #[path = "external_agent_config_tests.rs"]
 mod tests;
->>>>>>> upstream_main

--- a/codex-rs/core/src/instructions/user_instructions.rs
+++ b/codex-rs/core/src/instructions/user_instructions.rs
@@ -53,7 +53,6 @@ impl From<SkillInstructions> for ResponseItem {
 }
 
 #[cfg(test)]
-<<<<<<< HEAD
 mod tests {
     use super::*;
     use codex_protocol::models::ContentItem;
@@ -124,7 +123,5 @@ mod tests {
         assert!(!SKILL_FRAGMENT.matches_text("regular text"));
     }
 }
-=======
 #[path = "user_instructions_tests.rs"]
 mod tests;
->>>>>>> upstream_main

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -39,12 +39,8 @@ pub mod exec;
 pub mod exec_env;
 mod exec_policy;
 pub mod external_agent_config;
-<<<<<<< HEAD
 pub mod features;
 mod file_watcher;
-=======
-pub mod file_watcher;
->>>>>>> upstream_main
 mod flags;
 #[cfg(test)]
 mod git_info_tests;
@@ -73,10 +69,7 @@ mod model_provider_info;
 pub mod utils;
 pub use utils::path_utils;
 pub mod personality_migration;
-<<<<<<< HEAD
-=======
 pub mod plugins;
->>>>>>> upstream_main
 mod sandbox_tags;
 pub mod sandboxing;
 mod session_prefix;

--- a/codex-rs/core/src/mcp/skill_dependencies.rs
+++ b/codex-rs/core/src/mcp/skill_dependencies.rs
@@ -247,15 +247,12 @@ pub(crate) async fn maybe_install_mcp_dependencies(
             &name,
             &oauth_config.url,
             config.mcp_oauth_credentials_store_mode,
-<<<<<<< HEAD
             oauth_config.http_headers,
             oauth_config.env_http_headers,
             &[],
-=======
             oauth_config.http_headers.clone(),
             oauth_config.env_http_headers.clone(),
             &resolved_scopes.scopes,
->>>>>>> upstream_main
             server_config.oauth_resource.as_deref(),
             config.mcp_oauth_callback_port,
             config.mcp_oauth_callback_url.as_deref(),
@@ -466,7 +463,6 @@ fn mcp_dependency_to_server_config(
 }
 
 #[cfg(test)]
-<<<<<<< HEAD
 mod tests {
     use super::*;
     use crate::skills::model::SkillDependencies;
@@ -576,7 +572,5 @@ mod tests {
         );
     }
 }
-=======
 #[path = "skill_dependencies_tests.rs"]
 mod tests;
->>>>>>> upstream_main

--- a/codex-rs/core/src/mcp_connection_manager.rs
+++ b/codex-rs/core/src/mcp_connection_manager.rs
@@ -1711,7 +1711,6 @@ fn startup_outcome_error_message(error: StartupOutcomeError) -> String {
 mod mcp_init_error_display_tests {}
 
 #[cfg(test)]
-<<<<<<< HEAD
 mod tests {
     use super::*;
     use codex_protocol::protocol::McpAuthStatus;
@@ -2347,7 +2346,5 @@ mod tests {
         assert_eq!(transport_origin(&transport), Some("stdio".to_string()));
     }
 }
-=======
 #[path = "mcp_connection_manager_tests.rs"]
 mod tests;
->>>>>>> upstream_main

--- a/codex-rs/core/src/memories/citations.rs
+++ b/codex-rs/core/src/memories/citations.rs
@@ -1,5 +1,4 @@
 use codex_protocol::ThreadId;
-<<<<<<< HEAD
 
 pub fn get_thread_id_from_citations(citations: Vec<String>) -> Vec<ThreadId> {
     let mut result = Vec::new();
@@ -18,7 +17,6 @@ pub fn get_thread_id_from_citations(citations: Vec<String>) -> Vec<ThreadId> {
         }
 
         if let Some(ids_block) = ids_block {
-=======
 use codex_protocol::memory_citation::MemoryCitation;
 use codex_protocol::memory_citation::MemoryCitationEntry;
 use std::collections::HashSet;
@@ -40,24 +38,19 @@ pub fn parse_memory_citation(citations: Vec<String>) -> Option<MemoryCitation> {
         }
 
         if let Some(ids_block) = extract_ids_block(&citation) {
->>>>>>> upstream_main
             for id in ids_block
                 .lines()
                 .map(str::trim)
                 .filter(|line| !line.is_empty())
             {
-<<<<<<< HEAD
                 if let Ok(thread_id) = ThreadId::try_from(id) {
                     result.push(thread_id);
-=======
                 if seen_rollout_ids.insert(id.to_string()) {
                     rollout_ids.push(id.to_string());
->>>>>>> upstream_main
                 }
             }
         }
     }
-<<<<<<< HEAD
     result
 }
 
@@ -90,7 +83,6 @@ mod tests {
         assert_eq!(get_thread_id_from_citations(citations), vec![thread_id]);
     }
 }
-=======
 
     if entries.is_empty() && rollout_ids.is_empty() {
         None
@@ -147,4 +139,3 @@ fn extract_ids_block(text: &str) -> Option<&str> {
 #[cfg(test)]
 #[path = "citations_tests.rs"]
 mod tests;
->>>>>>> upstream_main

--- a/codex-rs/core/src/memories/mod.rs
+++ b/codex-rs/core/src/memories/mod.rs
@@ -5,10 +5,7 @@
 //! - Phase 2: claim a global consolidation lock, materialize consolidation inputs, and dispatch one consolidation agent.
 
 pub(crate) mod citations;
-<<<<<<< HEAD
-=======
 mod control;
->>>>>>> upstream_main
 mod phase1;
 mod phase2;
 pub(crate) mod prompts;

--- a/codex-rs/core/src/memories/phase2.rs
+++ b/codex-rs/core/src/memories/phase2.rs
@@ -52,11 +52,8 @@ pub(super) async fn run(session: &Arc<Session>, config: Arc<Config>) {
         return;
     };
     let root = memory_root(&config.codex_home);
-<<<<<<< HEAD
     let max_raw_memories = config.memories.max_raw_memories_for_global;
-=======
     let max_raw_memories = config.memories.max_raw_memories_for_consolidation;
->>>>>>> upstream_main
     let max_unused_days = config.memories.max_unused_days;
 
     // 1. Claim the job.

--- a/codex-rs/core/src/memories/prompts.rs
+++ b/codex-rs/core/src/memories/prompts.rs
@@ -1,32 +1,24 @@
 use crate::memories::memory_root;
 use crate::memories::phase_one;
 use crate::memories::storage::rollout_summary_file_stem_from_parts;
-<<<<<<< HEAD
 use crate::truncate::TruncationPolicy;
 use crate::truncate::truncate_text;
-=======
 use askama::Template;
->>>>>>> upstream_main
 use codex_protocol::openai_models::ModelInfo;
 use codex_state::Phase2InputSelection;
 use codex_state::Stage1Output;
 use codex_state::Stage1OutputRef;
-<<<<<<< HEAD
-=======
 use codex_utils_output_truncation::TruncationPolicy;
 use codex_utils_output_truncation::truncate_text;
->>>>>>> upstream_main
 use std::path::Path;
 use tokio::fs;
 use tracing::warn;
 
-<<<<<<< HEAD
 const CONSOLIDATION_PROMPT_TEMPLATE: &str =
     include_str!("../../templates/memories/consolidation.md");
 const STAGE_ONE_INPUT_TEMPLATE: &str = include_str!("../../templates/memories/stage_one_input.md");
 const MEMORY_TOOL_DEVELOPER_INSTRUCTIONS_TEMPLATE: &str =
     include_str!("../../templates/memories/read_path.md");
-=======
 #[derive(Template)]
 #[template(path = "memories/consolidation.md", escape = "none")]
 struct ConsolidationPromptTemplate<'a> {
@@ -48,7 +40,6 @@ struct MemoryToolDeveloperInstructionsTemplate<'a> {
     base_path: &'a str,
     memory_summary: &'a str,
 }
->>>>>>> upstream_main
 
 /// Builds the consolidation subagent prompt for a specific memory root.
 pub(super) fn build_consolidation_prompt(
@@ -57,7 +48,6 @@ pub(super) fn build_consolidation_prompt(
 ) -> String {
     let memory_root = memory_root.display().to_string();
     let phase2_input_selection = render_phase2_input_selection(selection);
-<<<<<<< HEAD
     render_prompt_template(
         CONSOLIDATION_PROMPT_TEMPLATE,
         &[
@@ -66,13 +56,11 @@ pub(super) fn build_consolidation_prompt(
         ],
     )
     .unwrap_or_else(|err| {
-=======
     let template = ConsolidationPromptTemplate {
         memory_root: &memory_root,
         phase2_input_selection: &phase2_input_selection,
     };
     template.render().unwrap_or_else(|err| {
->>>>>>> upstream_main
         warn!("failed to render memories consolidation prompt template: {err}");
         format!(
             "## Memory Phase 2 (Consolidation)\nConsolidate Codex memories in: {memory_root}\n\n{phase2_input_selection}"
@@ -171,7 +159,6 @@ pub(super) fn build_stage_one_input_message(
 
     let rollout_path = rollout_path.display().to_string();
     let rollout_cwd = rollout_cwd.display().to_string();
-<<<<<<< HEAD
     render_prompt_template(
         STAGE_ONE_INPUT_TEMPLATE,
         &[
@@ -180,14 +167,12 @@ pub(super) fn build_stage_one_input_message(
             ("rollout_contents", truncated_rollout_contents.as_str()),
         ],
     )
-=======
     Ok(StageOneInputTemplate {
         rollout_path: &rollout_path,
         rollout_cwd: &rollout_cwd,
         rollout_contents: &truncated_rollout_contents,
     }
     .render()?)
->>>>>>> upstream_main
 }
 
 /// Build prompt used for read path. This prompt must be added to the developer instructions. In
@@ -209,7 +194,6 @@ pub(crate) async fn build_memory_tool_developer_instructions(codex_home: &Path) 
         return None;
     }
     let base_path = base_path.display().to_string();
-<<<<<<< HEAD
     render_prompt_template(
         MEMORY_TOOL_DEVELOPER_INSTRUCTIONS_TEMPLATE,
         &[
@@ -227,13 +211,11 @@ fn render_prompt_template(template: &str, vars: &[(&str, &str)]) -> anyhow::Resu
         rendered = rendered.replace(&token, value);
     }
     Ok(rendered)
-=======
     let template = MemoryToolDeveloperInstructionsTemplate {
         base_path: &base_path,
         memory_summary: &memory_summary,
     };
     template.render().ok()
->>>>>>> upstream_main
 }
 
 #[cfg(test)]

--- a/codex-rs/core/src/memories/storage.rs
+++ b/codex-rs/core/src/memories/storage.rs
@@ -256,7 +256,6 @@ pub(super) fn rollout_summary_file_stem_from_parts(
 }
 
 #[cfg(test)]
-<<<<<<< HEAD
 mod tests {
     use super::rollout_summary_file_stem;
     use super::rollout_summary_file_stem_from_parts;
@@ -329,7 +328,5 @@ mod tests {
         assert_eq!(rollout_summary_file_stem(&memory), FIXED_PREFIX);
     }
 }
-=======
 #[path = "storage_tests.rs"]
 mod tests;
->>>>>>> upstream_main

--- a/codex-rs/core/src/models_manager/collaboration_mode_presets.rs
+++ b/codex-rs/core/src/models_manager/collaboration_mode_presets.rs
@@ -99,7 +99,6 @@ fn asking_questions_guidance_message(default_mode_request_user_input: bool) -> S
         "In Default mode, strongly prefer making reasonable assumptions and executing the user's request rather than stopping to ask questions. If you absolutely must ask a question because the answer cannot be discovered from local context and a reasonable assumption would be risky, prefer using the `request_user_input` tool rather than writing a multiple choice question as a textual assistant message. Never write a multiple choice question as a textual assistant message.".to_string()
     } else {
         "In Default mode, strongly prefer making reasonable assumptions and executing the user's request rather than stopping to ask questions. If you absolutely must ask a question because the answer cannot be discovered from local context and a reasonable assumption would be risky, ask the user directly with a concise plain-text question. Never write a multiple choice question as a textual assistant message.".to_string()
-<<<<<<< HEAD
     }
 }
 
@@ -156,8 +155,6 @@ mod tests {
             default_instructions
                 .contains("ask the user directly with a concise plain-text question")
         );
-=======
->>>>>>> upstream_main
     }
 }
 

--- a/codex-rs/core/src/models_manager/manager.rs
+++ b/codex-rs/core/src/models_manager/manager.rs
@@ -194,8 +194,6 @@ impl ModelsManager {
         auth_manager: Arc<AuthManager>,
         model_catalog: Option<ModelsResponse>,
         collaboration_modes_config: CollaborationModesConfig,
-<<<<<<< HEAD
-=======
     ) -> Self {
         Self::new_with_provider(
             codex_home,
@@ -213,7 +211,6 @@ impl ModelsManager {
         model_catalog: Option<ModelsResponse>,
         collaboration_modes_config: CollaborationModesConfig,
         provider: ModelProviderInfo,
->>>>>>> upstream_main
     ) -> Self {
         let cache_path = codex_home.join(MODEL_CACHE_FILE);
         let cache_manager = ModelsCacheManager::new(cache_path, DEFAULT_MODEL_CACHE_TTL);
@@ -546,7 +543,6 @@ impl ModelsManager {
         auth_manager: Arc<AuthManager>,
         provider: ModelProviderInfo,
     ) -> Self {
-<<<<<<< HEAD
         let cache_path = codex_home.join(MODEL_CACHE_FILE);
         let cache_manager = ModelsCacheManager::new(cache_path, DEFAULT_MODEL_CACHE_TTL);
         Self {
@@ -556,10 +552,8 @@ impl ModelsManager {
             ),
             catalog_mode: CatalogMode::Default,
             collaboration_modes_config: CollaborationModesConfig::default(),
-=======
         Self::new_with_provider(
             codex_home,
->>>>>>> upstream_main
             auth_manager,
             /*model_catalog*/ None,
             CollaborationModesConfig::default(),
@@ -598,7 +592,6 @@ impl ModelsManager {
 }
 
 #[cfg(test)]
-<<<<<<< HEAD
 mod tests {
     use super::*;
     use crate::CodexAuth;
@@ -1178,7 +1171,5 @@ mod tests {
         );
     }
 }
-=======
 #[path = "manager_tests.rs"]
 mod tests;
->>>>>>> upstream_main

--- a/codex-rs/core/src/realtime_conversation.rs
+++ b/codex-rs/core/src/realtime_conversation.rs
@@ -463,7 +463,6 @@ async fn prepare_realtime_start(
         .experimental_realtime_ws_backend_prompt
         .clone()
         .unwrap_or(params.prompt);
-<<<<<<< HEAD
 
     let requested_session_id = params
         .session_id
@@ -479,14 +478,12 @@ async fn prepare_realtime_start(
             error!("failed to start realtime conversation: {err}");
             send_conversation_error(sess, sub_id, err.to_string(), CodexErrorInfo::Other).await;
             return Ok(());
-=======
     let startup_context = match config.experimental_realtime_ws_startup_context.clone() {
         Some(startup_context) => startup_context,
         None => {
             build_realtime_startup_context(sess.as_ref(), REALTIME_STARTUP_CONTEXT_TOKEN_BUDGET)
                 .await
                 .unwrap_or_default()
->>>>>>> upstream_main
         }
     };
     let prompt = if startup_context.is_empty() {
@@ -564,9 +561,7 @@ async fn handle_start_inner(
         };
         let mut end = RealtimeConversationEnd::TransportClosed;
         while let Ok(event) = events_rx.recv().await {
-<<<<<<< HEAD
             debug!(conversation_id = %sess_clone.conversation_id, "received realtime conversation event");
-=======
             if !fanout_realtime_active.load(Ordering::Relaxed) {
                 break;
             }
@@ -580,7 +575,6 @@ async fn handle_start_inner(
             if matches!(event, RealtimeEvent::Error(_)) {
                 end = RealtimeConversationEnd::Error;
             }
->>>>>>> upstream_main
             let maybe_routed_text = match &event {
                 RealtimeEvent::HandoffRequested(handoff) => {
                     realtime_text_from_handoff_request(handoff)
@@ -603,15 +597,12 @@ async fn handle_start_inner(
                 )))
                 .await;
         }
-<<<<<<< HEAD
         if let Some(()) = sess_clone.conversation.running_state().await {
             info!("realtime conversation transport closed");
-=======
         if fanout_realtime_active.swap(false, Ordering::Relaxed) {
             if matches!(end, RealtimeConversationEnd::TransportClosed) {
                 info!("realtime conversation transport closed");
             }
->>>>>>> upstream_main
             sess_clone
                 .conversation
                 .finish_if_active(&fanout_realtime_active)
@@ -633,16 +624,13 @@ pub(crate) async fn handle_audio(
 ) {
     if let Err(err) = sess.conversation.audio_in(params.frame).await {
         error!("failed to append realtime audio: {err}");
-<<<<<<< HEAD
         send_conversation_error(sess, sub_id, err.to_string(), CodexErrorInfo::BadRequest).await;
-=======
         if sess.conversation.running_state().await.is_some() {
             warn!("realtime audio input failed while the session was already ending");
         } else {
             send_conversation_error(sess, sub_id, err.to_string(), CodexErrorInfo::BadRequest)
                 .await;
         }
->>>>>>> upstream_main
     }
 }
 
@@ -713,12 +701,10 @@ pub(crate) async fn handle_text(
     params: ConversationTextParams,
 ) {
     debug!(text = %params.text, "[realtime-text] appending realtime conversation text input");
-<<<<<<< HEAD
 
     if let Err(err) = sess.conversation.text_in(params.text).await {
         error!("failed to append realtime text: {err}");
         send_conversation_error(sess, sub_id, err.to_string(), CodexErrorInfo::BadRequest).await;
-=======
     if let Err(err) = sess.conversation.text_in(params.text).await {
         error!("failed to append realtime text: {err}");
         if sess.conversation.running_state().await.is_some() {
@@ -727,7 +713,6 @@ pub(crate) async fn handle_text(
             send_conversation_error(sess, sub_id, err.to_string(), CodexErrorInfo::BadRequest)
                 .await;
         }
->>>>>>> upstream_main
     }
 }
 

--- a/codex-rs/core/src/sandboxing/mod.rs
+++ b/codex-rs/core/src/sandboxing/mod.rs
@@ -11,7 +11,6 @@ use crate::exec::ExecCapturePolicy;
 use crate::exec::ExecExpiration;
 use crate::exec::ExecToolCallOutput;
 use crate::exec::StdoutStream;
-<<<<<<< HEAD
 use crate::exec::execute_exec_env;
 use crate::landlock::allow_network_for_proxy;
 use crate::landlock::create_linux_sandbox_command_args;
@@ -20,22 +19,17 @@ use crate::protocol::SandboxPolicy;
 use crate::seatbelt::MACOS_PATH_TO_SEATBELT_EXECUTABLE;
 #[cfg(target_os = "macos")]
 use crate::seatbelt::create_seatbelt_command_args_with_extensions;
-=======
 use crate::exec::WindowsRestrictedTokenFilesystemOverlay;
 use crate::exec::execute_exec_request;
->>>>>>> upstream_main
 #[cfg(target_os = "macos")]
 use crate::spawn::CODEX_SANDBOX_ENV_VAR;
 use crate::spawn::CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR;
 use codex_network_proxy::NetworkProxy;
 use codex_protocol::config_types::WindowsSandboxLevel;
-<<<<<<< HEAD
 use codex_protocol::models::FileSystemPermissions;
 #[cfg(target_os = "macos")]
 use codex_protocol::models::MacOsSeatbeltProfileExtensions;
 use codex_protocol::models::PermissionProfile;
-=======
->>>>>>> upstream_main
 pub use codex_protocol::models::SandboxPermissions;
 use codex_protocol::permissions::FileSystemSandboxPolicy;
 use codex_protocol::permissions::NetworkSandboxPolicy;
@@ -70,7 +64,6 @@ pub struct ExecRequest {
     pub arg0: Option<String>,
 }
 
-<<<<<<< HEAD
 /// Bundled arguments for sandbox transformation.
 ///
 /// This keeps call sites self-documenting when several fields are optional.
@@ -269,7 +262,6 @@ impl SandboxManager {
         &self,
         policy: &SandboxPolicy,
         pref: SandboxablePreference,
-=======
 impl ExecRequest {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -280,7 +272,6 @@ impl ExecRequest {
         expiration: ExecExpiration,
         capture_policy: ExecCapturePolicy,
         sandbox: SandboxType,
->>>>>>> upstream_main
         windows_sandbox_level: WindowsSandboxLevel,
         windows_sandbox_private_desktop: bool,
         sandbox_policy: SandboxPolicy,
@@ -315,15 +306,12 @@ impl ExecRequest {
             cwd,
             mut env,
             network,
-<<<<<<< HEAD
             sandbox_policy_cwd,
             #[cfg(target_os = "macos")]
             macos_seatbelt_profile_extensions,
             codex_linux_sandbox_exe,
             use_linux_sandbox_bwrap,
-=======
             sandbox,
->>>>>>> upstream_main
             windows_sandbox_level,
             windows_sandbox_private_desktop,
             sandbox_policy,
@@ -341,7 +329,6 @@ impl ExecRequest {
                 "1".to_string(),
             );
         }
-<<<<<<< HEAD
 
         let mut command = Vec::with_capacity(1 + spec.args.len());
         command.push(spec.program);
@@ -401,13 +388,11 @@ impl ExecRequest {
         env.extend(sandbox_env);
 
         Ok(ExecRequest {
-=======
         #[cfg(target_os = "macos")]
         if sandbox == SandboxType::MacosSeatbelt {
             env.insert(CODEX_SANDBOX_ENV_VAR.to_string(), "seatbelt".to_string());
         }
         Self {
->>>>>>> upstream_main
             command,
             cwd,
             env,

--- a/codex-rs/core/src/session_prefix.rs
+++ b/codex-rs/core/src/session_prefix.rs
@@ -4,15 +4,12 @@ use codex_protocol::protocol::AgentStatus;
 /// messages but are not user intent.
 use crate::contextual_user_message::SUBAGENT_NOTIFICATION_FRAGMENT;
 
-<<<<<<< HEAD
 pub(crate) fn format_subagent_notification_message(agent_id: &str, status: &AgentStatus) -> String {
-=======
 // TODO(jif) unify with structured schema
 pub(crate) fn format_subagent_notification_message(
     agent_reference: &str,
     status: &AgentStatus,
 ) -> String {
->>>>>>> upstream_main
     let payload_json = serde_json::json!({
         "agent_path": agent_reference,
         "status": status,
@@ -21,12 +18,10 @@ pub(crate) fn format_subagent_notification_message(
     SUBAGENT_NOTIFICATION_FRAGMENT.wrap(payload_json)
 }
 
-<<<<<<< HEAD
 pub(crate) fn format_subagent_context_line(agent_id: &str, agent_nickname: Option<&str>) -> String {
     match agent_nickname.filter(|nickname| !nickname.is_empty()) {
         Some(agent_nickname) => format!("- {agent_id}: {agent_nickname}"),
         None => format!("- {agent_id}"),
-=======
 pub(crate) fn format_subagent_context_line(
     agent_reference: &str,
     agent_nickname: Option<&str>,
@@ -34,6 +29,5 @@ pub(crate) fn format_subagent_context_line(
     match agent_nickname.filter(|nickname| !nickname.is_empty()) {
         Some(agent_nickname) => format!("- {agent_reference}: {agent_nickname}"),
         None => format!("- {agent_reference}"),
->>>>>>> upstream_main
     }
 }

--- a/codex-rs/core/src/shell_snapshot.rs
+++ b/codex-rs/core/src/shell_snapshot.rs
@@ -384,7 +384,6 @@ alias_count=$(alias -p | wc -l | tr -d ' ')
 echo "# aliases $alias_count"
 alias -p
 echo ''
-<<<<<<< HEAD
 export_lines=$(export -p | awk '
 /^(export|declare -x|typeset -x) / {
   line=$0
@@ -409,7 +408,6 @@ export_lines=$(export -p | awk '
     print line
   }
 }')
-=======
 export_lines=$(
   while IFS= read -r name; do
     if [[ "$name" =~ ^(EXCLUDED_EXPORTS)$ ]]; then
@@ -421,7 +419,6 @@ export_lines=$(
     declare -xp "$name" 2>/dev/null || true
   done < <(compgen -e)
 )
->>>>>>> upstream_main
 export_count=$(printf '%s\n' "$export_lines" | sed '/^$/d' | wc -l | tr -d ' ')
 echo "# exports $export_count"
 if [ -n "$export_lines" ]; then
@@ -602,7 +599,6 @@ async fn remove_snapshot_file(path: &Path) {
     }
 }
 
-<<<<<<< HEAD
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1003,7 +999,6 @@ mod tests {
             return Err(std::io::Error::last_os_error().into());
         }
         Ok(())
-=======
 fn snapshot_session_id_from_file_name(file_name: &str) -> Option<&str> {
     let (stem, extension) = file_name.rsplit_once('.')?;
     match extension {
@@ -1013,7 +1008,6 @@ fn snapshot_session_id_from_file_name(file_name: &str) -> Option<&str> {
         ),
         _ if extension.starts_with("tmp-") => Some(stem),
         _ => None,
->>>>>>> upstream_main
     }
 }
 

--- a/codex-rs/core/src/skills/injection.rs
+++ b/codex-rs/core/src/skills/injection.rs
@@ -489,7 +489,6 @@ fn is_mention_name_char(byte: u8) -> bool {
 }
 
 #[cfg(test)]
-<<<<<<< HEAD
 mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
@@ -831,7 +830,5 @@ mod tests {
         assert_eq!(selected, Vec::new());
     }
 }
-=======
 #[path = "injection_tests.rs"]
 mod tests;
->>>>>>> upstream_main

--- a/codex-rs/core/src/skills/invocation_utils.rs
+++ b/codex-rs/core/src/skills/invocation_utils.rs
@@ -231,7 +231,6 @@ fn normalize_path(path: &Path) -> PathBuf {
 }
 
 #[cfg(test)]
-<<<<<<< HEAD
 mod tests {
     use super::SkillLoadOutcome;
     use super::SkillMetadata;
@@ -356,7 +355,5 @@ mod tests {
         );
     }
 }
-=======
 #[path = "invocation_utils_tests.rs"]
 mod tests;
->>>>>>> upstream_main

--- a/codex-rs/core/src/skills/loader.rs
+++ b/codex-rs/core/src/skills/loader.rs
@@ -564,11 +564,8 @@ fn parse_skill_file(path: &Path, scope: SkillScope) -> Result<SkillMetadata, Ski
         dependencies,
         policy,
         permission_profile,
-<<<<<<< HEAD
         permissions,
-=======
         managed_network_override,
->>>>>>> upstream_main
     } = load_skill_metadata(path);
 
     validate_len(&name, MAX_NAME_LEN, "name")?;
@@ -591,18 +588,13 @@ fn parse_skill_file(path: &Path, scope: SkillScope) -> Result<SkillMetadata, Ski
         dependencies,
         policy,
         permission_profile,
-<<<<<<< HEAD
         permissions,
-=======
         managed_network_override,
->>>>>>> upstream_main
         path_to_skills_md: resolved_path,
         scope,
     })
 }
 
-<<<<<<< HEAD
-=======
 fn default_skill_name(path: &Path) -> String {
     path.parent()
         .and_then(Path::file_name)
@@ -618,7 +610,6 @@ fn namespaced_skill_name(path: &Path, base_name: &str) -> String {
         .unwrap_or_else(|| base_name.to_string())
 }
 
->>>>>>> upstream_main
 fn load_skill_metadata(skill_path: &Path) -> LoadedSkillMetadata {
     // Fail open: optional metadata should not block loading SKILL.md.
     let Some(skill_dir) = skill_path.parent() else {
@@ -664,7 +655,6 @@ fn load_skill_metadata(skill_path: &Path) -> LoadedSkillMetadata {
         policy,
         permissions,
     } = parsed;
-<<<<<<< HEAD
     let permission_profile = permissions.clone().filter(|profile| !profile.is_empty());
 
     LoadedSkillMetadata {
@@ -674,7 +664,6 @@ fn load_skill_metadata(skill_path: &Path) -> LoadedSkillMetadata {
         permission_profile,
         permissions: compile_permission_profile(skill_dir, permissions),
     }
-=======
     let (permission_profile, managed_network_override) = normalize_permissions(permissions);
     LoadedSkillMetadata {
         interface: resolve_interface(interface, skill_dir),
@@ -719,7 +708,6 @@ fn normalize_permissions(
         (!permission_profile.is_empty()).then_some(permission_profile),
         managed_network_override,
     )
->>>>>>> upstream_main
 }
 
 fn resolve_interface(interface: Option<Interface>, skill_dir: &Path) -> Option<SkillInterface> {
@@ -954,7 +942,6 @@ pub(crate) fn skill_roots_from_layer_stack(
 }
 
 #[cfg(test)]
-<<<<<<< HEAD
 mod tests {
     use super::*;
     use crate::config::ConfigBuilder;
@@ -2796,7 +2783,5 @@ permissions:
         assert_eq!(scopes, expected);
     }
 }
-=======
 #[path = "loader_tests.rs"]
 mod tests;
->>>>>>> upstream_main

--- a/codex-rs/core/src/skills/manager.rs
+++ b/codex-rs/core/src/skills/manager.rs
@@ -5,11 +5,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::RwLock;
 
-<<<<<<< HEAD
 use codex_app_server_protocol::ConfigLayerSource;
-=======
 use codex_protocol::protocol::Product;
->>>>>>> upstream_main
 use codex_protocol::protocol::SkillScope;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use toml::Value as TomlValue;
@@ -196,7 +193,6 @@ impl SkillsManager {
                     scope: SkillScope::User,
                 }),
         );
-<<<<<<< HEAD
         let mut outcome = load_skills_from_roots(roots);
         if !extra_user_roots.is_empty() {
             // When extra user roots are provided, skip system skills before caching the result.
@@ -213,14 +209,12 @@ impl SkillsManager {
             Ok(cache) => cache,
             Err(err) => err.into_inner(),
         };
-=======
         let skill_config_rules = skill_config_rules_from_stack(&config_layer_stack);
         let outcome = self.build_skill_outcome(roots, &skill_config_rules);
         let mut cache = self
             .cache_by_cwd
             .write()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
->>>>>>> upstream_main
         cache.insert(cwd.to_path_buf(), outcome.clone());
         outcome
     }
@@ -287,7 +281,6 @@ struct ConfigSkillsCacheKey {
 
 pub(crate) fn bundled_skills_enabled_from_stack(
     config_layer_stack: &crate::config_loader::ConfigLayerStack,
-<<<<<<< HEAD
 ) -> HashSet<PathBuf> {
     let mut disabled = HashSet::new();
     let mut configs = HashMap::new();
@@ -299,7 +292,6 @@ pub(crate) fn bundled_skills_enabled_from_stack(
             ConfigLayerSource::User { .. } | ConfigLayerSource::SessionFlags
         ) {
             continue;
-=======
 ) -> bool {
     let effective_config = config_layer_stack.effective_config();
     let Some(skills_value) = effective_config
@@ -314,10 +306,8 @@ pub(crate) fn bundled_skills_enabled_from_stack(
         Err(err) => {
             warn!("invalid skills config: {err}");
             return true;
->>>>>>> upstream_main
         }
 
-<<<<<<< HEAD
         let Some(skills_value) = layer.config.get("skills") else {
             continue;
         };
@@ -342,9 +332,7 @@ pub(crate) fn bundled_skills_enabled_from_stack(
     }
 
     disabled
-=======
     skills.bundled.unwrap_or_default().enabled
->>>>>>> upstream_main
 }
 
 fn config_skills_cache_key(
@@ -391,7 +379,6 @@ fn normalize_extra_user_roots(extra_user_roots: &[PathBuf]) -> Vec<PathBuf> {
 }
 
 #[cfg(test)]
-<<<<<<< HEAD
 mod tests {
     use super::*;
     use crate::config::ConfigBuilder;
@@ -663,7 +650,5 @@ enabled = false
         );
     }
 }
-=======
 #[path = "manager_tests.rs"]
 mod tests;
->>>>>>> upstream_main

--- a/codex-rs/core/src/skills/model.rs
+++ b/codex-rs/core/src/skills/model.rs
@@ -3,13 +3,10 @@ use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-<<<<<<< HEAD
 use crate::config::Permissions;
 use codex_protocol::models::PermissionProfile;
-=======
 use codex_protocol::models::PermissionProfile;
 use codex_protocol::protocol::Product;
->>>>>>> upstream_main
 use codex_protocol::protocol::SkillScope;
 use serde::Deserialize;
 
@@ -34,12 +31,9 @@ pub struct SkillMetadata {
     pub dependencies: Option<SkillDependencies>,
     pub policy: Option<SkillPolicy>,
     pub permission_profile: Option<PermissionProfile>,
-<<<<<<< HEAD
     // This is an experimental field.
     pub permissions: Option<Permissions>,
-=======
     pub managed_network_override: Option<SkillManagedNetworkOverride>,
->>>>>>> upstream_main
     /// Path to the SKILLS.md file that declares this skill.
     pub path_to_skills_md: PathBuf,
     pub scope: SkillScope,

--- a/codex-rs/core/src/state/service.rs
+++ b/codex-rs/core/src/state/service.rs
@@ -22,11 +22,8 @@ use crate::tools::sandboxing::ApprovalStore;
 use crate::unified_exec::UnifiedExecProcessManager;
 use codex_exec_server::Environment;
 use codex_hooks::Hooks;
-<<<<<<< HEAD
 use codex_otel::OtelManager;
-=======
 use codex_otel::SessionTelemetry;
->>>>>>> upstream_main
 use codex_utils_absolute_path::AbsolutePathBuf;
 use std::path::PathBuf;
 use tokio::sync::Mutex;

--- a/codex-rs/core/src/state/turn.rs
+++ b/codex-rs/core/src/state/turn.rs
@@ -13,11 +13,8 @@ use codex_protocol::dynamic_tools::DynamicToolResponse;
 use codex_protocol::models::ResponseInputItem;
 use codex_protocol::request_permissions::RequestPermissionsResponse;
 use codex_protocol::request_user_input::RequestUserInputResponse;
-<<<<<<< HEAD
-=======
 use codex_rmcp_client::ElicitationResponse;
 use rmcp::model::RequestId;
->>>>>>> upstream_main
 use tokio::sync::oneshot;
 
 use crate::codex::TurnContext;
@@ -81,10 +78,7 @@ pub(crate) struct TurnState {
     pending_approvals: HashMap<String, oneshot::Sender<ReviewDecision>>,
     pending_request_permissions: HashMap<String, oneshot::Sender<RequestPermissionsResponse>>,
     pending_user_input: HashMap<String, oneshot::Sender<RequestUserInputResponse>>,
-<<<<<<< HEAD
-=======
     pending_elicitations: HashMap<(String, RequestId), oneshot::Sender<ElicitationResponse>>,
->>>>>>> upstream_main
     pending_dynamic_tools: HashMap<String, oneshot::Sender<DynamicToolResponse>>,
     pending_input: Vec<ResponseInputItem>,
     granted_permissions: Option<PermissionProfile>,
@@ -112,10 +106,7 @@ impl TurnState {
         self.pending_approvals.clear();
         self.pending_request_permissions.clear();
         self.pending_user_input.clear();
-<<<<<<< HEAD
-=======
         self.pending_elicitations.clear();
->>>>>>> upstream_main
         self.pending_dynamic_tools.clear();
         self.pending_input.clear();
     }

--- a/codex-rs/core/src/stream_events_utils.rs
+++ b/codex-rs/core/src/stream_events_utils.rs
@@ -16,10 +16,7 @@ use crate::error::CodexErr;
 use crate::error::Result;
 use crate::function_tool::FunctionCallError;
 use crate::memories::citations::get_thread_id_from_citations;
-<<<<<<< HEAD
-=======
 use crate::memories::citations::parse_memory_citation;
->>>>>>> upstream_main
 use crate::parse_turn_item;
 use crate::state_db;
 use crate::tools::parallel::ToolCallRuntime;
@@ -34,8 +31,6 @@ use futures::Future;
 use tracing::debug;
 use tracing::instrument;
 
-<<<<<<< HEAD
-=======
 const GENERATED_IMAGE_ARTIFACTS_DIR: &str = "generated_images";
 
 pub(crate) fn image_generation_artifact_path(
@@ -66,7 +61,6 @@ pub(crate) fn image_generation_artifact_path(
         .join(format!("{}.png", sanitize(call_id)))
 }
 
->>>>>>> upstream_main
 fn strip_hidden_assistant_markup(text: &str, plan_mode: bool) -> String {
     let (without_citations, _) = strip_citations(text);
     if plan_mode {
@@ -76,8 +70,6 @@ fn strip_hidden_assistant_markup(text: &str, plan_mode: bool) -> String {
     }
 }
 
-<<<<<<< HEAD
-=======
 fn strip_hidden_assistant_markup_and_parse_memory_citation(
     text: &str,
     plan_mode: bool,
@@ -94,7 +86,6 @@ fn strip_hidden_assistant_markup_and_parse_memory_citation(
     (visible_text, parse_memory_citation(citations))
 }
 
->>>>>>> upstream_main
 pub(crate) fn raw_assistant_output_text_from_item(item: &ResponseItem) -> Option<String> {
     if let ResponseItem::Message { role, content, .. } = item
         && role == "assistant"
@@ -111,8 +102,6 @@ pub(crate) fn raw_assistant_output_text_from_item(item: &ResponseItem) -> Option
     None
 }
 
-<<<<<<< HEAD
-=======
 async fn save_image_generation_result(
     codex_home: &std::path::Path,
     session_id: &str,
@@ -132,7 +121,6 @@ async fn save_image_generation_result(
     Ok(path)
 }
 
->>>>>>> upstream_main
 /// Persist a completed model response item and record any cited memory usage.
 pub(crate) async fn record_completed_response_item(
     sess: &Session,
@@ -141,11 +129,9 @@ pub(crate) async fn record_completed_response_item(
 ) {
     sess.record_conversation_items(turn_context, std::slice::from_ref(item))
         .await;
-<<<<<<< HEAD
     record_stage1_output_usage_for_completed_item(turn_context, item).await;
 }
 
-=======
     maybe_mark_thread_memory_mode_polluted_from_web_search(sess, turn_context, item).await;
     record_stage1_output_usage_for_completed_item(turn_context, item).await;
 }
@@ -171,7 +157,6 @@ async fn maybe_mark_thread_memory_mode_polluted_from_web_search(
     .await;
 }
 
->>>>>>> upstream_main
 async fn record_stage1_output_usage_for_completed_item(
     turn_context: &TurnContext,
     item: &ResponseItem,
@@ -186,11 +171,8 @@ async fn record_stage1_output_usage_for_completed_item(
         return;
     }
 
-<<<<<<< HEAD
     if let Some(db) = state_db::get_state_db(turn_context.config.as_ref(), None).await {
-=======
     if let Some(db) = state_db::get_state_db(turn_context.config.as_ref()).await {
->>>>>>> upstream_main
         let _ = db.record_stage1_output_usage(&thread_ids).await;
     }
 }
@@ -250,9 +232,7 @@ pub(crate) async fn handle_output_item_done(
         }
         // No tool call: convert messages/reasoning into turn items and mark them as complete.
         Ok(None) => {
-<<<<<<< HEAD
             if let Some(turn_item) = handle_non_tool_response_item(&item, plan_mode) {
-=======
             if let Some(turn_item) = handle_non_tool_response_item(
                 ctx.sess.as_ref(),
                 ctx.turn_context.as_ref(),
@@ -261,7 +241,6 @@ pub(crate) async fn handle_output_item_done(
             )
             .await
             {
->>>>>>> upstream_main
                 if previously_active_item.is_none() {
                     let mut started_item = turn_item.clone();
                     if let TurnItem::ImageGeneration(item) = &mut started_item {
@@ -279,10 +258,7 @@ pub(crate) async fn handle_output_item_done(
                     .emit_turn_item_completed(&ctx.turn_context, turn_item)
                     .await;
             }
-<<<<<<< HEAD
 
-=======
->>>>>>> upstream_main
             record_completed_response_item(ctx.sess.as_ref(), ctx.turn_context.as_ref(), &item)
                 .await;
             let last_agent_message = last_assistant_message_from_item(&item, plan_mode);
@@ -348,13 +324,10 @@ pub(crate) async fn handle_output_item_done(
     Ok(output)
 }
 
-<<<<<<< HEAD
 pub(crate) fn handle_non_tool_response_item(
-=======
 pub(crate) async fn handle_non_tool_response_item(
     sess: &Session,
     turn_context: &TurnContext,
->>>>>>> upstream_main
     item: &ResponseItem,
     plan_mode: bool,
 ) -> Option<TurnItem> {
@@ -374,12 +347,9 @@ pub(crate) async fn handle_non_tool_response_item(
                         codex_protocol::items::AgentMessageContent::Text { text } => text.as_str(),
                     })
                     .collect::<String>();
-<<<<<<< HEAD
                 let stripped = strip_hidden_assistant_markup(&combined, plan_mode);
-=======
                 let (stripped, memory_citation) =
                     strip_hidden_assistant_markup_and_parse_memory_citation(&combined, plan_mode);
->>>>>>> upstream_main
                 agent_message.content =
                     vec![codex_protocol::items::AgentMessageContent::Text { text: stripped }];
                 agent_message.memory_citation = memory_citation;
@@ -504,7 +474,6 @@ pub(crate) fn response_input_to_response_item(input: &ResponseInputItem) -> Opti
 }
 
 #[cfg(test)]
-<<<<<<< HEAD
 mod tests {
     use super::handle_non_tool_response_item;
     use super::last_assistant_message_from_item;
@@ -571,7 +540,5 @@ mod tests {
         assert_eq!(last_assistant_message_from_item(&item, true), None);
     }
 }
-=======
 #[path = "stream_events_utils_tests.rs"]
 mod tests;
->>>>>>> upstream_main

--- a/codex-rs/core/src/tasks/mod.rs
+++ b/codex-rs/core/src/tasks/mod.rs
@@ -22,16 +22,13 @@ use tracing::warn;
 use crate::AuthManager;
 use crate::codex::Session;
 use crate::codex::TurnContext;
-<<<<<<< HEAD
 use crate::contextual_user_message::TURN_ABORTED_OPEN_TAG;
-=======
 use crate::contextual_user_message::TURN_ABORTED_CLOSE_TAG;
 use crate::contextual_user_message::TURN_ABORTED_OPEN_TAG;
 use crate::hook_runtime::PendingInputHookDisposition;
 use crate::hook_runtime::inspect_pending_input;
 use crate::hook_runtime::record_additional_contexts;
 use crate::hook_runtime::record_pending_input;
->>>>>>> upstream_main
 use crate::models_manager::manager::ModelsManager;
 use crate::protocol::EventMsg;
 use crate::protocol::TurnAbortReason;

--- a/codex-rs/core/src/tasks/regular.rs
+++ b/codex-rs/core/src/tasks/regular.rs
@@ -20,7 +20,6 @@ use super::SessionTaskContext;
 pub(crate) struct RegularTask;
 
 impl RegularTask {
-<<<<<<< HEAD
     #[allow(dead_code)]
     pub(crate) async fn with_startup_prewarm(
         model_client: ModelClient,
@@ -50,10 +49,8 @@ impl RegularTask {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .take()
-=======
     pub(crate) fn new() -> Self {
         Self
->>>>>>> upstream_main
     }
 }
 

--- a/codex-rs/core/src/tasks/review.rs
+++ b/codex-rs/core/src/tasks/review.rs
@@ -20,11 +20,8 @@ use crate::codex::Session;
 use crate::codex::TurnContext;
 use crate::codex_delegate::run_codex_thread_one_shot;
 use crate::config::Constrained;
-<<<<<<< HEAD
 use crate::features::Feature;
 use crate::protocol::SandboxPolicy;
-=======
->>>>>>> upstream_main
 use crate::review_format::format_review_findings_block;
 use crate::review_format::render_review_output_text;
 use crate::state::TaskKind;

--- a/codex-rs/core/src/thread_manager.rs
+++ b/codex-rs/core/src/thread_manager.rs
@@ -12,11 +12,8 @@ use crate::config::Config;
 use crate::error::CodexErr;
 use crate::error::Result as CodexResult;
 use crate::file_watcher::FileWatcher;
-<<<<<<< HEAD
 use crate::file_watcher::FileWatcherEvent;
-=======
 use crate::mcp::McpManager;
->>>>>>> upstream_main
 use crate::models_manager::collaboration_mode_presets::CollaborationModesConfig;
 use crate::models_manager::manager::ModelsManager;
 use crate::plugins::PluginsManager;
@@ -218,10 +215,7 @@ impl ThreadManager {
         config: &Config,
         auth_manager: Arc<AuthManager>,
         session_source: SessionSource,
-<<<<<<< HEAD
         model_catalog: Option<ModelsResponse>,
-=======
->>>>>>> upstream_main
         collaboration_modes_config: CollaborationModesConfig,
     ) -> Self {
         let codex_home = config.codex_home.clone();
@@ -251,14 +245,11 @@ impl ThreadManager {
                 models_manager: Arc::new(ModelsManager::new_with_provider(
                     codex_home,
                     auth_manager.clone(),
-<<<<<<< HEAD
                     model_catalog,
                     collaboration_modes_config,
-=======
                     config.model_catalog.clone(),
                     collaboration_modes_config,
                     openai_models_provider,
->>>>>>> upstream_main
                 )),
                 skills_manager,
                 plugins_manager,
@@ -425,14 +416,12 @@ impl ThreadManager {
         dynamic_tools: Vec<codex_protocol::dynamic_tools::DynamicToolSpec>,
         persist_extended_history: bool,
     ) -> CodexResult<NewThread> {
-<<<<<<< HEAD
         self.start_thread_with_tools_and_service_name(
             config,
             dynamic_tools,
             persist_extended_history,
             None,
         )
-=======
         Box::pin(self.start_thread_with_tools_and_service_name(
             config,
             dynamic_tools,
@@ -440,7 +429,6 @@ impl ThreadManager {
             /*metrics_service_name*/ None,
             /*parent_trace*/ None,
         ))
->>>>>>> upstream_main
         .await
     }
 
@@ -450,7 +438,6 @@ impl ThreadManager {
         dynamic_tools: Vec<codex_protocol::dynamic_tools::DynamicToolSpec>,
         persist_extended_history: bool,
         metrics_service_name: Option<String>,
-<<<<<<< HEAD
     ) -> CodexResult<NewThread> {
         self.state
             .spawn_thread(
@@ -463,7 +450,6 @@ impl ThreadManager {
                 metrics_service_name,
             )
             .await
-=======
         parent_trace: Option<W3cTraceContext>,
     ) -> CodexResult<NewThread> {
         Box::pin(self.state.spawn_thread(
@@ -478,7 +464,6 @@ impl ThreadManager {
             /*user_shell_override*/ None,
         ))
         .await
->>>>>>> upstream_main
     }
 
     pub async fn resume_thread_from_rollout(
@@ -507,7 +492,6 @@ impl ThreadManager {
         persist_extended_history: bool,
         parent_trace: Option<W3cTraceContext>,
     ) -> CodexResult<NewThread> {
-<<<<<<< HEAD
         self.state
             .spawn_thread(
                 config,
@@ -519,7 +503,6 @@ impl ThreadManager {
                 None,
             )
             .await
-=======
         Box::pin(self.state.spawn_thread(
             config,
             initial_history,
@@ -573,7 +556,6 @@ impl ThreadManager {
             /*user_shell_override*/ Some(user_shell_override),
         ))
         .await
->>>>>>> upstream_main
     }
 
     /// Removes the thread from the manager's internal map, though the thread is stored
@@ -651,7 +633,6 @@ impl ThreadManager {
     {
         let snapshot = snapshot.into();
         let history = RolloutRecorder::get_rollout_history(&path).await?;
-<<<<<<< HEAD
         let history = truncate_before_nth_user_message(history, nth_user_message);
         self.state
             .spawn_thread(
@@ -664,7 +645,6 @@ impl ThreadManager {
                 None,
             )
             .await
-=======
         let snapshot_state = snapshot_turn_state(&history);
         let history = match snapshot {
             ForkSnapshot::TruncateBeforeNthUserMessage(nth_user_message) => {
@@ -695,7 +675,6 @@ impl ThreadManager {
             /*user_shell_override*/ None,
         ))
         .await
->>>>>>> upstream_main
     }
 
     pub(crate) fn agent_control(&self) -> AgentControl {
@@ -759,7 +738,6 @@ impl ThreadManagerState {
         config: Config,
         agent_control: AgentControl,
     ) -> CodexResult<NewThread> {
-<<<<<<< HEAD
         self.spawn_new_thread_with_source(
             config,
             agent_control,
@@ -767,7 +745,6 @@ impl ThreadManagerState {
             false,
             None,
         )
-=======
         Box::pin(self.spawn_new_thread_with_source(
             config,
             agent_control,
@@ -777,7 +754,6 @@ impl ThreadManagerState {
             /*inherited_shell_snapshot*/ None,
             /*inherited_exec_policy*/ None,
         ))
->>>>>>> upstream_main
         .await
     }
 
@@ -789,11 +765,8 @@ impl ThreadManagerState {
         session_source: SessionSource,
         persist_extended_history: bool,
         metrics_service_name: Option<String>,
-<<<<<<< HEAD
-=======
         inherited_shell_snapshot: Option<Arc<ShellSnapshot>>,
         inherited_exec_policy: Option<Arc<crate::exec_policy::ExecPolicyManager>>,
->>>>>>> upstream_main
     ) -> CodexResult<NewThread> {
         Box::pin(self.spawn_thread_with_source(
             config,
@@ -804,15 +777,12 @@ impl ThreadManagerState {
             Vec::new(),
             persist_extended_history,
             metrics_service_name,
-<<<<<<< HEAD
         )
-=======
             inherited_shell_snapshot,
             inherited_exec_policy,
             /*parent_trace*/ None,
             /*user_shell_override*/ None,
         ))
->>>>>>> upstream_main
         .await
     }
 
@@ -833,14 +803,12 @@ impl ThreadManagerState {
             agent_control,
             session_source,
             Vec::new(),
-<<<<<<< HEAD
             false,
             None,
         )
         .await
     }
 
-=======
             /*persist_extended_history*/ false,
             /*metrics_service_name*/ None,
             inherited_shell_snapshot,
@@ -852,7 +820,6 @@ impl ThreadManagerState {
     }
 
     #[allow(clippy::too_many_arguments)]
->>>>>>> upstream_main
     pub(crate) async fn fork_thread_with_source(
         &self,
         config: Config,
@@ -860,15 +827,12 @@ impl ThreadManagerState {
         agent_control: AgentControl,
         session_source: SessionSource,
         persist_extended_history: bool,
-<<<<<<< HEAD
     ) -> CodexResult<NewThread> {
         self.spawn_thread_with_source(
-=======
         inherited_shell_snapshot: Option<Arc<ShellSnapshot>>,
         inherited_exec_policy: Option<Arc<crate::exec_policy::ExecPolicyManager>>,
     ) -> CodexResult<NewThread> {
         Box::pin(self.spawn_thread_with_source(
->>>>>>> upstream_main
             config,
             initial_history,
             Arc::clone(&self.auth_manager),
@@ -876,17 +840,14 @@ impl ThreadManagerState {
             session_source,
             Vec::new(),
             persist_extended_history,
-<<<<<<< HEAD
             None,
         )
-=======
             /*metrics_service_name*/ None,
             inherited_shell_snapshot,
             inherited_exec_policy,
             /*parent_trace*/ None,
             /*user_shell_override*/ None,
         ))
->>>>>>> upstream_main
         .await
     }
 
@@ -901,11 +862,8 @@ impl ThreadManagerState {
         dynamic_tools: Vec<codex_protocol::dynamic_tools::DynamicToolSpec>,
         persist_extended_history: bool,
         metrics_service_name: Option<String>,
-<<<<<<< HEAD
-=======
         parent_trace: Option<W3cTraceContext>,
         user_shell_override: Option<crate::shell::Shell>,
->>>>>>> upstream_main
     ) -> CodexResult<NewThread> {
         Box::pin(self.spawn_thread_with_source(
             config,
@@ -916,15 +874,12 @@ impl ThreadManagerState {
             dynamic_tools,
             persist_extended_history,
             metrics_service_name,
-<<<<<<< HEAD
         )
-=======
             /*inherited_shell_snapshot*/ None,
             /*inherited_exec_policy*/ None,
             parent_trace,
             user_shell_override,
         ))
->>>>>>> upstream_main
         .await
     }
 
@@ -939,13 +894,10 @@ impl ThreadManagerState {
         dynamic_tools: Vec<codex_protocol::dynamic_tools::DynamicToolSpec>,
         persist_extended_history: bool,
         metrics_service_name: Option<String>,
-<<<<<<< HEAD
-=======
         inherited_shell_snapshot: Option<Arc<ShellSnapshot>>,
         inherited_exec_policy: Option<Arc<crate::exec_policy::ExecPolicyManager>>,
         parent_trace: Option<W3cTraceContext>,
         user_shell_override: Option<crate::shell::Shell>,
->>>>>>> upstream_main
     ) -> CodexResult<NewThread> {
         let watch_registration = self
             .skills_watcher
@@ -966,15 +918,12 @@ impl ThreadManagerState {
             dynamic_tools,
             persist_extended_history,
             metrics_service_name,
-<<<<<<< HEAD
         )
-=======
             inherited_shell_snapshot,
             inherited_exec_policy,
             user_shell_override,
             parent_trace,
         })
->>>>>>> upstream_main
         .await?;
         self.finalize_thread_spawn(codex, thread_id, watch_registration)
             .await
@@ -1095,7 +1044,6 @@ fn snapshot_turn_state(history: &InitialHistory) -> SnapshotTurnState {
         };
     };
 
-<<<<<<< HEAD
         let initial: Vec<RolloutItem> = items
             .iter()
             .cloned()
@@ -1151,7 +1099,6 @@ fn snapshot_turn_state(history: &InitialHistory) -> SnapshotTurnState {
             serde_json::to_value(&got_items).unwrap(),
             serde_json::to_value(&expected).unwrap()
         );
-=======
     // Synthetic fork/resume histories can contain user/assistant response items
     // without explicit turn lifecycle events. If the persisted snapshot has no
     // terminating boundary after its last user message, treat it as mid-turn.
@@ -1164,7 +1111,6 @@ fn snapshot_turn_state(history: &InitialHistory) -> SnapshotTurnState {
         }),
         active_turn_id: None,
         active_turn_start_index: None,
->>>>>>> upstream_main
     }
 }
 

--- a/codex-rs/core/src/tools/context.rs
+++ b/codex-rs/core/src/tools/context.rs
@@ -168,7 +168,6 @@ impl FunctionToolOutput {
         }
     }
 
-<<<<<<< HEAD
     pub fn into_response(self, call_id: &str, payload: &ToolPayload) -> ResponseInputItem {
         match self {
             ToolOutput::Function { body, success } => {
@@ -181,7 +180,6 @@ impl FunctionToolOutput {
                         output: FunctionCallOutputPayload { body, success },
                     };
                 }
-=======
     pub fn from_content(
         content: Vec<FunctionCallOutputContentItem>,
         success: Option<bool>,
@@ -191,7 +189,6 @@ impl FunctionToolOutput {
             success,
         }
     }
->>>>>>> upstream_main
 
     pub fn into_text(self) -> String {
         function_call_output_content_items_to_text(&self.body).unwrap_or_default()
@@ -519,7 +516,6 @@ fn telemetry_preview(content: &str) -> String {
 }
 
 #[cfg(test)]
-<<<<<<< HEAD
 mod tests {
     use super::*;
     use codex_protocol::models::FunctionCallOutputContentItem;
@@ -658,7 +654,5 @@ mod tests {
         assert_eq!(lines.last(), Some(&TELEMETRY_PREVIEW_TRUNCATION_NOTICE));
     }
 }
-=======
 #[path = "context_tests.rs"]
 mod tests;
->>>>>>> upstream_main

--- a/codex-rs/core/src/tools/handlers/js_repl.rs
+++ b/codex-rs/core/src/tools/handlers/js_repl.rs
@@ -174,7 +174,6 @@ impl ToolHandler for JsReplHandler {
         )
         .await;
 
-<<<<<<< HEAD
         Ok(ToolOutput::Function {
             body: if items.is_empty() {
                 FunctionCallOutputBody::Text(content)
@@ -183,13 +182,11 @@ impl ToolHandler for JsReplHandler {
             },
             success: Some(true),
         })
-=======
         if items.is_empty() {
             Ok(FunctionToolOutput::from_text(content, Some(true)))
         } else {
             Ok(FunctionToolOutput::from_content(items, Some(true)))
         }
->>>>>>> upstream_main
     }
 }
 

--- a/codex-rs/core/src/tools/handlers/mod.rs
+++ b/codex-rs/core/src/tools/handlers/mod.rs
@@ -21,12 +21,9 @@ mod tool_suggest;
 pub(crate) mod unified_exec;
 mod view_image;
 
-<<<<<<< HEAD
-=======
 use codex_sandboxing::policy_transforms::intersect_permission_profiles;
 use codex_sandboxing::policy_transforms::merge_permission_profiles;
 use codex_sandboxing::policy_transforms::normalize_additional_permissions;
->>>>>>> upstream_main
 use codex_utils_absolute_path::AbsolutePathBufGuard;
 pub use plan::PLAN_TOOL;
 use serde::Deserialize;
@@ -110,10 +107,7 @@ pub(crate) fn normalize_and_validate_additional_permissions(
     approval_policy: AskForApproval,
     sandbox_permissions: SandboxPermissions,
     additional_permissions: Option<PermissionProfile>,
-<<<<<<< HEAD
-=======
     permissions_preapproved: bool,
->>>>>>> upstream_main
     _cwd: &Path,
 ) -> Result<Option<PermissionProfile>, String> {
     let uses_additional_permissions = matches!(
@@ -143,13 +137,10 @@ pub(crate) fn normalize_and_validate_additional_permissions(
                     .to_string(),
             );
         };
-<<<<<<< HEAD
-=======
         #[cfg(not(target_os = "macos"))]
         if additional_permissions.macos.is_some() {
             return Err("`additional_permissions.macos` is only supported on macOS".to_string());
         }
->>>>>>> upstream_main
         let normalized = normalize_additional_permissions(additional_permissions)?;
         if normalized.is_empty() {
             return Err(

--- a/codex-rs/core/src/tools/handlers/multi_agents.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents.rs
@@ -11,12 +11,9 @@ use crate::agent::agent_resolver::resolve_agent_targets;
 use crate::agent::exceeds_thread_spawn_depth_limit;
 use crate::codex::Session;
 use crate::codex::TurnContext;
-<<<<<<< HEAD
 use crate::config::Config;
 use crate::error::CodexErr;
 use crate::features::Feature;
-=======
->>>>>>> upstream_main
 use crate::function_tool::FunctionCallError;
 use crate::tools::context::ToolInvocation;
 use crate::tools::context::ToolOutput;
@@ -27,13 +24,10 @@ use crate::tools::registry::ToolHandler;
 use crate::tools::registry::ToolKind;
 use async_trait::async_trait;
 use codex_protocol::ThreadId;
-<<<<<<< HEAD
 use codex_protocol::models::BaseInstructions;
 use codex_protocol::models::FunctionCallOutputBody;
-=======
 use codex_protocol::models::ResponseInputItem;
 use codex_protocol::openai_models::ReasoningEffort;
->>>>>>> upstream_main
 use codex_protocol::protocol::CollabAgentInteractionBeginEvent;
 use codex_protocol::protocol::CollabAgentInteractionEndEvent;
 use codex_protocol::protocol::CollabAgentRef;
@@ -48,7 +42,6 @@ use codex_protocol::protocol::CollabWaitingEndEvent;
 use codex_protocol::user_input::UserInput;
 use serde::Deserialize;
 use serde::Serialize;
-<<<<<<< HEAD
 use std::collections::HashMap;
 
 pub struct MultiAgentHandler;
@@ -2139,7 +2132,6 @@ mod tests {
         assert_eq!(config, expected);
     }
 }
-=======
 use serde_json::Value as JsonValue;
 
 pub(crate) use close_agent::Handler as CloseAgentHandler;
@@ -2157,4 +2149,3 @@ pub(crate) mod wait;
 #[cfg(test)]
 #[path = "multi_agents_tests.rs"]
 mod tests;
->>>>>>> upstream_main

--- a/codex-rs/core/src/tools/handlers/request_user_input.rs
+++ b/codex-rs/core/src/tools/handlers/request_user_input.rs
@@ -121,7 +121,6 @@ impl ToolHandler for RequestUserInputHandler {
 }
 
 #[cfg(test)]
-<<<<<<< HEAD
 mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
@@ -170,7 +169,5 @@ mod tests {
         );
     }
 }
-=======
 #[path = "request_user_input_tests.rs"]
 mod tests;
->>>>>>> upstream_main

--- a/codex-rs/core/src/tools/handlers/unified_exec.rs
+++ b/codex-rs/core/src/tools/handlers/unified_exec.rs
@@ -209,7 +209,6 @@ impl ToolHandler for UnifiedExecHandler {
 
                 let workdir = workdir.map(|dir| context.turn.resolve_path(Some(dir)));
                 let cwd = workdir.clone().unwrap_or(cwd);
-<<<<<<< HEAD
                 let normalized_additional_permissions =
                     match normalize_and_validate_additional_permissions(
                         request_permission_enabled,
@@ -224,7 +223,6 @@ impl ToolHandler for UnifiedExecHandler {
                             return Err(FunctionCallError::RespondToModel(err));
                         }
                     };
-=======
                 let normalized_additional_permissions = match implicit_granted_permissions(
                     sandbox_permissions,
                     requested_additional_permissions.as_ref(),
@@ -249,7 +247,6 @@ impl ToolHandler for UnifiedExecHandler {
                         return Err(FunctionCallError::RespondToModel(err));
                     }
                 };
->>>>>>> upstream_main
 
                 if let Some(output) = intercept_apply_patch(
                     &command,
@@ -375,7 +372,6 @@ pub(crate) fn get_command(
 }
 
 #[cfg(test)]
-<<<<<<< HEAD
 mod tests {
     use super::*;
     use crate::shell::default_user_shell;
@@ -504,7 +500,5 @@ mod tests {
         Ok(())
     }
 }
-=======
 #[path = "unified_exec_tests.rs"]
 mod tests;
->>>>>>> upstream_main

--- a/codex-rs/core/src/tools/js_repl/mod.rs
+++ b/codex-rs/core/src/tools/js_repl/mod.rs
@@ -12,10 +12,7 @@ use codex_protocol::ThreadId;
 use codex_protocol::models::ContentItem;
 use codex_protocol::models::FunctionCallOutputContentItem;
 use codex_protocol::models::FunctionCallOutputPayload;
-<<<<<<< HEAD
-=======
 use codex_protocol::models::ImageDetail;
->>>>>>> upstream_main
 use codex_protocol::models::ResponseInputItem;
 use serde::Deserialize;
 use serde::Serialize;
@@ -45,18 +42,15 @@ use crate::original_image_detail::normalize_output_image_detail;
 use crate::sandboxing::ExecOptions;
 use crate::tools::ToolRouter;
 use crate::tools::context::SharedTurnDiffTracker;
-<<<<<<< HEAD
 use crate::tools::sandboxing::SandboxablePreference;
 use crate::truncate::TruncationPolicy;
 use crate::truncate::truncate_text;
-=======
 use codex_sandboxing::SandboxCommand;
 use codex_sandboxing::SandboxManager;
 use codex_sandboxing::SandboxTransformRequest;
 use codex_sandboxing::SandboxablePreference;
 use codex_utils_output_truncation::TruncationPolicy;
 use codex_utils_output_truncation::truncate_text;
->>>>>>> upstream_main
 
 pub(crate) const JS_REPL_PRAGMA_PREFIX: &str = "// codex-js-repl:";
 const KERNEL_SOURCE: &str = include_str!("kernel.js");
@@ -438,7 +432,6 @@ impl JsReplManager {
         Some(state.cancel.clone())
     }
 
-<<<<<<< HEAD
     async fn record_exec_tool_call_content_items(
         exec_tool_calls: &Arc<Mutex<HashMap<String, ExecToolCalls>>>,
         exec_id: &str,
@@ -451,7 +444,6 @@ impl JsReplManager {
         let mut calls = exec_tool_calls.lock().await;
         if let Some(state) = calls.get_mut(exec_id) {
             state.content_items.extend(content_items);
-=======
     async fn record_exec_content_item(
         exec_tool_calls: &Arc<Mutex<HashMap<String, ExecToolCalls>>>,
         exec_id: &str,
@@ -460,7 +452,6 @@ impl JsReplManager {
         let mut calls = exec_tool_calls.lock().await;
         if let Some(state) = calls.get_mut(exec_id) {
             state.content_items.push(content_item);
->>>>>>> upstream_main
         }
     }
 
@@ -530,8 +521,6 @@ impl JsReplManager {
         }
     }
 
-<<<<<<< HEAD
-=======
     async fn register_top_level_exec(&self, exec_id: String, turn_id: String) {
         let mut kernel = self.kernel.lock().await;
         let Some(state) = kernel.as_mut() else {
@@ -620,7 +609,6 @@ impl JsReplManager {
         })
     }
 
->>>>>>> upstream_main
     fn log_tool_call_response(
         req: &RunToolRequest,
         ok: bool,
@@ -790,7 +778,6 @@ impl JsReplManager {
                     output,
                 )
             }
-<<<<<<< HEAD
             ResponseInputItem::McpToolCallOutput { result, .. } => match result {
                 Ok(result) => {
                     let output = FunctionCallOutputPayload::from(result);
@@ -813,7 +800,6 @@ impl JsReplManager {
                     summary.result_is_error = Some(true);
                     summary
                 }
-=======
             ResponseInputItem::McpToolCallOutput { output, .. } => {
                 let function_output = output.as_function_call_output_payload();
                 let payload_kind = if output.success() {
@@ -840,21 +826,17 @@ impl JsReplManager {
                 ),
                 payload_item_count: Some(tools.len()),
                 ..Default::default()
->>>>>>> upstream_main
             },
         }
     }
 
     fn summarize_tool_call_error(error: &str) -> JsReplToolCallResponseSummary {
-<<<<<<< HEAD
         Self::summarize_text_payload(None, JsReplToolCallPayloadKind::Error, error)
-=======
         Self::summarize_text_payload(
             /*response_type*/ None,
             JsReplToolCallPayloadKind::Error,
             error,
         )
->>>>>>> upstream_main
     }
 
     pub async fn reset(&self) -> Result<(), FunctionCallError> {
@@ -1374,17 +1356,14 @@ impl JsReplManager {
                             .map(|state| state.content_items.clone())
                             .unwrap_or_default()
                     };
-<<<<<<< HEAD
                     let mut pending = pending_execs.lock().await;
                     if let Some(tx) = pending.remove(&id) {
-=======
                     let tx = {
                         let mut pending = pending_execs.lock().await;
                         pending.remove(&id)
                     };
                     if let Some(tx) = tx {
                         Self::clear_top_level_exec_if_matches_map(&manager_kernel, &id).await;
->>>>>>> upstream_main
                         let payload = if ok {
                             ExecResultMessage::Ok {
                                 content_items: build_exec_result_content_items(
@@ -1609,9 +1588,7 @@ impl JsReplManager {
         if is_js_repl_internal_tool(&req.tool_name) {
             let error = "js_repl cannot invoke itself".to_string();
             let summary = Self::summarize_tool_call_error(&error);
-<<<<<<< HEAD
             Self::log_tool_call_response(&req, false, &summary, None, Some(&error));
-=======
             Self::log_tool_call_response(
                 &req,
                 /*ok*/ false,
@@ -1619,7 +1596,6 @@ impl JsReplManager {
                 /*response*/ None,
                 Some(&error),
             );
->>>>>>> upstream_main
             return RunToolResult {
                 id: req.id,
                 ok: false,
@@ -1694,7 +1670,6 @@ impl JsReplManager {
             )
             .await
         {
-<<<<<<< HEAD
             Ok(response) => {
                 if let Some(items) = response_content_items(&response) {
                     Self::record_exec_tool_call_content_items(
@@ -1709,7 +1684,6 @@ impl JsReplManager {
                 match serde_json::to_value(response) {
                     Ok(value) => {
                         Self::log_tool_call_response(&req, true, &summary, Some(&value), None);
-=======
             Ok(result) => {
                 let response = result.into_response();
                 let summary = Self::summarize_tool_call_response(&response);
@@ -1722,7 +1696,6 @@ impl JsReplManager {
                             Some(&value),
                             /*error*/ None,
                         );
->>>>>>> upstream_main
                         RunToolResult {
                             id: req.id,
                             ok: true,
@@ -1733,9 +1706,7 @@ impl JsReplManager {
                     Err(err) => {
                         let error = format!("failed to serialize tool output: {err}");
                         let summary = Self::summarize_tool_call_error(&error);
-<<<<<<< HEAD
                         Self::log_tool_call_response(&req, false, &summary, None, Some(&error));
-=======
                         Self::log_tool_call_response(
                             &req,
                             /*ok*/ false,
@@ -1743,7 +1714,6 @@ impl JsReplManager {
                             /*response*/ None,
                             Some(&error),
                         );
->>>>>>> upstream_main
                         RunToolResult {
                             id: req.id,
                             ok: false,
@@ -1756,9 +1726,7 @@ impl JsReplManager {
             Err(err) => {
                 let error = err.to_string();
                 let summary = Self::summarize_tool_call_error(&error);
-<<<<<<< HEAD
                 Self::log_tool_call_response(&req, false, &summary, None, Some(&error));
-=======
                 Self::log_tool_call_response(
                     &req,
                     /*ok*/ false,
@@ -1766,7 +1734,6 @@ impl JsReplManager {
                     /*response*/ None,
                     Some(&error),
                 );
->>>>>>> upstream_main
                 RunToolResult {
                     id: req.id,
                     ok: false,
@@ -1811,7 +1778,6 @@ impl JsReplManager {
     }
 }
 
-<<<<<<< HEAD
 fn response_content_items(
     response: &ResponseInputItem,
 ) -> Option<Vec<FunctionCallOutputContentItem>> {
@@ -1827,7 +1793,6 @@ fn response_content_items(
             Err(_) => None,
         },
         ResponseInputItem::Message { .. } => None,
-=======
 fn emitted_image_content_item(
     turn: &TurnContext,
     image_url: String,
@@ -1847,7 +1812,6 @@ fn validate_emitted_image_url(image_url: &str) -> Result<(), String> {
         Ok(())
     } else {
         Err("codex.emitImage only accepts data URLs".to_string())
->>>>>>> upstream_main
     }
 }
 
@@ -2083,7 +2047,6 @@ pub(crate) fn resolve_node(config_path: Option<&Path>) -> Option<PathBuf> {
 }
 
 #[cfg(test)]
-<<<<<<< HEAD
 mod tests {
     use super::*;
     use crate::codex::make_session_and_context;
@@ -3144,7 +3107,5 @@ console.log(out.type);
         Ok(())
     }
 }
-=======
 #[path = "mod_tests.rs"]
 mod tests;
->>>>>>> upstream_main

--- a/codex-rs/core/src/tools/network_approval.rs
+++ b/codex-rs/core/src/tools/network_approval.rs
@@ -350,7 +350,6 @@ impl NetworkApprovalService {
             host: request.host.clone(),
             protocol,
         };
-<<<<<<< HEAD
 
         let available_decisions = None;
         let approval_decision = session
@@ -365,7 +364,6 @@ impl NetworkApprovalService {
                 None,
                 None,
                 available_decisions,
-=======
         let owner_call = self.resolve_single_active_call().await;
         let approval_decision = if routes_approval_to_guardian(&turn_context) {
             // TODO(ccunningham): Attach guardian network reviews to the reviewed tool item
@@ -384,7 +382,6 @@ impl NetworkApprovalService {
                     port: key.port,
                 },
                 Some(policy_denial_message.clone()),
->>>>>>> upstream_main
             )
             .await
         } else {

--- a/codex-rs/core/src/tools/parallel.rs
+++ b/codex-rs/core/src/tools/parallel.rs
@@ -143,7 +143,6 @@ impl ToolCallRuntime {
                 tools: Vec::new(),
             },
             ToolPayload::Custom { .. } => ResponseInputItem::CustomToolCallOutput {
-<<<<<<< HEAD
                 call_id: call.call_id.clone(),
                 output: FunctionCallOutputPayload {
                     body: FunctionCallOutputBody::Text(Self::abort_message(call, secs)),
@@ -159,13 +158,11 @@ impl ToolCallRuntime {
                 output: FunctionCallOutputPayload {
                     body: FunctionCallOutputBody::Text(Self::abort_message(call, secs)),
                     ..Default::default()
-=======
                 call_id: call.call_id,
                 name: None,
                 output: codex_protocol::models::FunctionCallOutputPayload {
                     body: codex_protocol::models::FunctionCallOutputBody::Text(message),
                     success: Some(false),
->>>>>>> upstream_main
                 },
             },
             _ => ResponseInputItem::FunctionCallOutput {

--- a/codex-rs/core/src/tools/router.rs
+++ b/codex-rs/core/src/tools/router.rs
@@ -246,7 +246,6 @@ impl ToolRouter {
             payload,
         };
 
-<<<<<<< HEAD
         match self.registry.dispatch(invocation).await {
             Ok(response) => Ok(response),
             Err(FunctionCallError::Fatal(message)) => Err(FunctionCallError::Fatal(message)),
@@ -281,9 +280,7 @@ impl ToolRouter {
                 },
             }
         }
-=======
         self.registry.dispatch_any(invocation).await
->>>>>>> upstream_main
     }
 }
 #[cfg(test)]

--- a/codex-rs/core/src/tools/runtimes/mod.rs
+++ b/codex-rs/core/src/tools/runtimes/mod.rs
@@ -25,11 +25,8 @@ pub(crate) struct ExecveSessionApproval {
     pub skill: Option<SkillMetadata>,
 }
 
-<<<<<<< HEAD
 /// Shared helper to construct a CommandSpec from a tokenized command line.
-=======
 /// Shared helper to construct sandbox transform inputs from a tokenized command line.
->>>>>>> upstream_main
 /// Validates that at least a program is present.
 pub(crate) fn build_sandbox_command(
     command: &[String],

--- a/codex-rs/core/src/tools/runtimes/shell.rs
+++ b/codex-rs/core/src/tools/runtimes/shell.rs
@@ -184,10 +184,7 @@ impl Approvable<ShellRequest> for ShellRuntime {
                             .proposed_execpolicy_amendment()
                             .cloned(),
                         req.additional_permissions.clone(),
-<<<<<<< HEAD
-=======
                         /*skill_metadata*/ None,
->>>>>>> upstream_main
                         available_decisions,
                     )
                     .await

--- a/codex-rs/core/src/tools/runtimes/shell/unix_escalation.rs
+++ b/codex-rs/core/src/tools/runtimes/shell/unix_escalation.rs
@@ -14,11 +14,8 @@ use crate::sandboxing::SandboxPermissions;
 use crate::shell::ShellType;
 use crate::skills::SkillMetadata;
 use crate::tools::runtimes::ExecveSessionApproval;
-<<<<<<< HEAD
 use crate::tools::runtimes::build_command_spec;
-=======
 use crate::tools::runtimes::build_sandbox_command;
->>>>>>> upstream_main
 use crate::tools::sandboxing::SandboxAttempt;
 use crate::tools::sandboxing::SandboxablePreference;
 use crate::tools::sandboxing::ToolCtx;
@@ -32,11 +29,8 @@ use codex_features::Feature;
 use codex_protocol::config_types::WindowsSandboxLevel;
 use codex_protocol::models::MacOsSeatbeltProfileExtensions;
 use codex_protocol::models::PermissionProfile;
-<<<<<<< HEAD
-=======
 use codex_protocol::permissions::FileSystemSandboxPolicy;
 use codex_protocol::permissions::NetworkSandboxPolicy;
->>>>>>> upstream_main
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::ExecApprovalRequestSkillMetadata;
 use codex_protocol::protocol::NetworkPolicyRuleAction;
@@ -148,11 +142,8 @@ pub(super) async fn try_run_zsh_fork(
         windows_restricted_token_filesystem_overlay: _windows_restricted_token_filesystem_overlay,
         arg0,
     } = sandbox_exec_request;
-<<<<<<< HEAD
     let ParsedShellCommand { script, login } = extract_shell_script(&command)?;
-=======
     let ParsedShellCommand { script, login, .. } = extract_shell_script(&command)?;
->>>>>>> upstream_main
     let effective_timeout = Duration::from_millis(
         req.timeout_ms
             .unwrap_or(crate::exec::DEFAULT_EXEC_COMMAND_TIMEOUT_MS),
@@ -179,11 +170,8 @@ pub(super) async fn try_run_zsh_fork(
             .macos_seatbelt_profile_extensions
             .clone(),
         codex_linux_sandbox_exe: ctx.turn.codex_linux_sandbox_exe.clone(),
-<<<<<<< HEAD
         use_linux_sandbox_bwrap: ctx.turn.features.enabled(Feature::UseLinuxSandboxBwrap),
-=======
         use_legacy_landlock: ctx.turn.features.use_legacy_landlock(),
->>>>>>> upstream_main
     };
     let main_execve_wrapper_exe = ctx
         .session
@@ -222,10 +210,7 @@ pub(super) async fn try_run_zsh_fork(
         file_system_sandbox_policy: command_executor.file_system_sandbox_policy.clone(),
         network_sandbox_policy: command_executor.network_sandbox_policy,
         sandbox_permissions: req.sandbox_permissions,
-<<<<<<< HEAD
-=======
         approval_sandbox_permissions,
->>>>>>> upstream_main
         prompt_permissions: req.additional_permissions.clone(),
         stopwatch: stopwatch.clone(),
     };
@@ -338,10 +323,7 @@ struct CoreShellActionProvider {
     file_system_sandbox_policy: FileSystemSandboxPolicy,
     network_sandbox_policy: NetworkSandboxPolicy,
     sandbox_permissions: SandboxPermissions,
-<<<<<<< HEAD
-=======
     approval_sandbox_permissions: SandboxPermissions,
->>>>>>> upstream_main
     prompt_permissions: Option<PermissionProfile>,
     stopwatch: Stopwatch,
 }
@@ -356,8 +338,6 @@ enum DecisionSource {
     UnmatchedCommandFallback,
 }
 
-<<<<<<< HEAD
-=======
 fn execve_prompt_is_rejected_by_policy(
     approval_policy: AskForApproval,
     decision_source: &DecisionSource,
@@ -383,7 +363,6 @@ fn execve_prompt_is_rejected_by_policy(
     }
 }
 
->>>>>>> upstream_main
 impl CoreShellActionProvider {
     fn decision_driven_by_policy(matched_rules: &[RuleMatch], decision: Decision) -> bool {
         matched_rules.iter().any(|rule_match| {
@@ -395,11 +374,8 @@ impl CoreShellActionProvider {
     fn shell_request_escalation_execution(
         sandbox_permissions: SandboxPermissions,
         sandbox_policy: &SandboxPolicy,
-<<<<<<< HEAD
-=======
         file_system_sandbox_policy: &FileSystemSandboxPolicy,
         network_sandbox_policy: NetworkSandboxPolicy,
->>>>>>> upstream_main
         additional_permissions: Option<&PermissionProfile>,
         macos_seatbelt_profile_extensions: Option<&MacOsSeatbeltProfileExtensions>,
     ) -> EscalationExecution {
@@ -413,11 +389,8 @@ impl CoreShellActionProvider {
                     EscalationExecution::Permissions(EscalationPermissions::Permissions(
                         EscalatedPermissions {
                             sandbox_policy: sandbox_policy.clone(),
-<<<<<<< HEAD
-=======
                             file_system_sandbox_policy: file_system_sandbox_policy.clone(),
                             network_sandbox_policy,
->>>>>>> upstream_main
                             macos_seatbelt_profile_extensions: macos_seatbelt_profile_extensions
                                 .cloned(),
                         },
@@ -428,7 +401,6 @@ impl CoreShellActionProvider {
     }
 
     fn skill_escalation_execution(skill: &SkillMetadata) -> EscalationExecution {
-<<<<<<< HEAD
         skill
             .permissions
             .as_ref()
@@ -450,7 +422,6 @@ impl CoreShellActionProvider {
                     .map(EscalationExecution::Permissions)
             })
             .unwrap_or(EscalationExecution::TurnDefault)
-=======
         let permission_profile = skill.permission_profile.clone().unwrap_or_default();
         if permission_profile.is_empty() {
             EscalationExecution::TurnDefault
@@ -459,7 +430,6 @@ impl CoreShellActionProvider {
                 permission_profile,
             ))
         }
->>>>>>> upstream_main
     }
 
     async fn prompt(
@@ -480,8 +450,6 @@ impl CoreShellActionProvider {
         let tool_name = self.tool_name;
         Ok(stopwatch
             .pause_for(async move {
-<<<<<<< HEAD
-=======
                 if routes_approval_to_guardian(&turn) {
                     return review_approval_request(
                         &session,
@@ -498,7 +466,6 @@ impl CoreShellActionProvider {
                     )
                     .await;
                 }
->>>>>>> upstream_main
                 let available_decisions = vec![
                     Some(ReviewDecision::Approved),
                     // Currently, ApprovedForSession is only honored for skills,
@@ -513,8 +480,6 @@ impl CoreShellActionProvider {
                 .into_iter()
                 .flatten()
                 .collect();
-<<<<<<< HEAD
-=======
                 let skill_metadata = match decision_source {
                     DecisionSource::SkillScript { skill } => {
                         Some(ExecApprovalRequestSkillMetadata {
@@ -523,7 +488,6 @@ impl CoreShellActionProvider {
                     }
                     DecisionSource::PrefixRule | DecisionSource::UnmatchedCommandFallback => None,
                 };
->>>>>>> upstream_main
                 session
                     .request_command_approval(
                         &turn,
@@ -531,18 +495,15 @@ impl CoreShellActionProvider {
                         approval_id,
                         command,
                         workdir,
-<<<<<<< HEAD
                         None,
                         None,
                         None,
                         additional_permissions,
-=======
                         /*reason*/ None,
                         /*network_approval_context*/ None,
                         /*proposed_execpolicy_amendment*/ None,
                         additional_permissions,
                         skill_metadata,
->>>>>>> upstream_main
                         Some(available_decisions),
                     )
                     .await
@@ -559,11 +520,8 @@ impl CoreShellActionProvider {
             .session
             .services
             .skills_manager
-<<<<<<< HEAD
             .skills_for_cwd(&self.turn.cwd, force_reload)
-=======
             .skills_for_cwd(&self.turn.cwd, self.turn.config.as_ref(), force_reload)
->>>>>>> upstream_main
             .await;
 
         let program_path = program.as_path();
@@ -597,17 +555,14 @@ impl CoreShellActionProvider {
                 EscalationDecision::deny(Some("Execution forbidden by policy".to_string()))
             }
             Decision::Prompt => {
-<<<<<<< HEAD
                 if matches!(
                     self.approval_policy,
                     AskForApproval::Never
                         | AskForApproval::Reject(RejectConfig { rules: true, .. })
                 ) {
-=======
                 if execve_prompt_is_rejected_by_policy(self.approval_policy, &decision_source)
                     .is_some()
                 {
->>>>>>> upstream_main
                     EscalationDecision::deny(Some("Execution forbidden by policy".to_string()))
                 } else {
                     match self
@@ -740,11 +695,9 @@ impl EscalationPolicy for CoreShellActionProvider {
         // In the usual case, the execve wrapper reports the command being
         // executed in `program`, so a direct skill lookup is sufficient.
         if let Some(skill) = self.find_skill(program).await {
-<<<<<<< HEAD
             // For now, we always prompt for scripts that look like they belong
             // to skills, which means we ignore exec policy rules for those
             // scripts.
-=======
             // For now, scripts that look like they belong to skills bypass
             // general exec policy evaluation. Permissionless skills inherit the
             // turn sandbox directly; skills with declared permissions still
@@ -761,7 +714,6 @@ impl EscalationPolicy for CoreShellActionProvider {
                     EscalationExecution::TurnDefault,
                 ));
             }
->>>>>>> upstream_main
             tracing::debug!("Matched {program:?} to skill {skill:?}, prompting for approval");
             let needs_escalation = true;
             let decision_source = DecisionSource::SkillScript {
@@ -774,11 +726,8 @@ impl EscalationPolicy for CoreShellActionProvider {
                     program,
                     argv,
                     workdir,
-<<<<<<< HEAD
                     skill.permission_profile.clone(),
-=======
                     prompt_permissions,
->>>>>>> upstream_main
                     Self::skill_escalation_execution(&skill),
                     decision_source,
                 )
@@ -791,12 +740,10 @@ impl EscalationPolicy for CoreShellActionProvider {
                 &policy,
                 program,
                 argv,
-<<<<<<< HEAD
                 self.approval_policy,
                 &self.sandbox_policy,
                 self.sandbox_permissions,
                 ENABLE_INTERCEPTED_EXEC_POLICY_SHELL_WRAPPER_PARSING,
-=======
                 InterceptedExecPolicyContext {
                     approval_policy: self.approval_policy,
                     sandbox_policy: &self.sandbox_policy,
@@ -805,7 +752,6 @@ impl EscalationPolicy for CoreShellActionProvider {
                     enable_shell_wrapper_parsing:
                         ENABLE_INTERCEPTED_EXEC_POLICY_SHELL_WRAPPER_PARSING,
                 },
->>>>>>> upstream_main
             )
         };
         // When true, means the Evaluation was due to *.rules, not the
@@ -825,11 +771,8 @@ impl EscalationPolicy for CoreShellActionProvider {
             DecisionSource::UnmatchedCommandFallback => Self::shell_request_escalation_execution(
                 self.sandbox_permissions,
                 &self.sandbox_policy,
-<<<<<<< HEAD
-=======
                 &self.file_system_sandbox_policy,
                 self.network_sandbox_policy,
->>>>>>> upstream_main
                 self.prompt_permissions.as_ref(),
                 self.turn
                     .config
@@ -857,7 +800,6 @@ fn evaluate_intercepted_exec_policy(
     policy: &Policy,
     program: &AbsolutePathBuf,
     argv: &[String],
-<<<<<<< HEAD
     approval_policy: AskForApproval,
     sandbox_policy: &SandboxPolicy,
     sandbox_permissions: SandboxPermissions,
@@ -867,7 +809,6 @@ fn evaluate_intercepted_exec_policy(
         commands,
         used_complex_parsing,
     } = if enable_intercepted_exec_policy_shell_wrapper_parsing {
-=======
     context: InterceptedExecPolicyContext<'_>,
 ) -> Evaluation {
     let InterceptedExecPolicyContext {
@@ -881,7 +822,6 @@ fn evaluate_intercepted_exec_policy(
         commands,
         used_complex_parsing,
     } = if enable_shell_wrapper_parsing {
->>>>>>> upstream_main
         // In this codepath, the first argument in `commands` could be a bare
         // name like `find` instead of an absolute path like `/usr/bin/find`.
         // It could also be a shell built-in like `echo`.
@@ -899,10 +839,7 @@ fn evaluate_intercepted_exec_policy(
         crate::exec_policy::render_decision_for_unmatched_command(
             approval_policy,
             sandbox_policy,
-<<<<<<< HEAD
-=======
             file_system_sandbox_policy,
->>>>>>> upstream_main
             cmd,
             sandbox_permissions,
             used_complex_parsing,
@@ -918,8 +855,6 @@ fn evaluate_intercepted_exec_policy(
     )
 }
 
-<<<<<<< HEAD
-=======
 #[derive(Clone, Copy)]
 struct InterceptedExecPolicyContext<'a> {
     approval_policy: AskForApproval,
@@ -929,7 +864,6 @@ struct InterceptedExecPolicyContext<'a> {
     enable_shell_wrapper_parsing: bool,
 }
 
->>>>>>> upstream_main
 struct CandidateCommands {
     commands: Vec<Vec<String>>,
     used_complex_parsing: bool,
@@ -977,11 +911,9 @@ struct CoreShellCommandExecutor {
     windows_sandbox_level: WindowsSandboxLevel,
     arg0: Option<String>,
     sandbox_policy_cwd: PathBuf,
-<<<<<<< HEAD
     macos_seatbelt_profile_extensions: Option<MacOsSeatbeltProfileExtensions>,
     codex_linux_sandbox_exe: Option<PathBuf>,
     use_linux_sandbox_bwrap: bool,
-=======
     #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
     macos_seatbelt_profile_extensions: Option<MacOsSeatbeltProfileExtensions>,
     codex_linux_sandbox_exe: Option<PathBuf>,
@@ -998,7 +930,6 @@ struct PrepareSandboxedExecParams<'a> {
     additional_permissions: Option<PermissionProfile>,
     #[cfg(target_os = "macos")]
     macos_seatbelt_profile_extensions: Option<&'a MacOsSeatbeltProfileExtensions>,
->>>>>>> upstream_main
 }
 
 #[async_trait::async_trait]
@@ -1007,11 +938,8 @@ impl ShellCommandExecutor for CoreShellCommandExecutor {
         &self,
         _command: Vec<String>,
         _cwd: PathBuf,
-<<<<<<< HEAD
         env: HashMap<String, String>,
-=======
         env_overlay: HashMap<String, String>,
->>>>>>> upstream_main
         cancel_rx: CancellationToken,
         after_spawn: Option<Box<dyn FnOnce() + Send>>,
     ) -> anyhow::Result<ExecResult> {
@@ -1078,7 +1006,6 @@ impl ShellCommandExecutor for CoreShellCommandExecutor {
                 env,
                 arg0: Some(first_arg.clone()),
             },
-<<<<<<< HEAD
             EscalationExecution::TurnDefault => self.prepare_sandboxed_exec(
                 command,
                 workdir,
@@ -1106,7 +1033,6 @@ impl ShellCommandExecutor for CoreShellCommandExecutor {
                     None,
                     permissions.macos_seatbelt_profile_extensions.as_ref(),
                 )?
-=======
             EscalationExecution::TurnDefault => {
                 self.prepare_sandboxed_exec(PrepareSandboxedExecParams {
                     command,
@@ -1156,7 +1082,6 @@ impl ShellCommandExecutor for CoreShellCommandExecutor {
                         .macos_seatbelt_profile_extensions
                         .as_ref(),
                 })?
->>>>>>> upstream_main
             }
         };
 
@@ -1165,7 +1090,6 @@ impl ShellCommandExecutor for CoreShellCommandExecutor {
 }
 
 impl CoreShellCommandExecutor {
-<<<<<<< HEAD
     fn prepare_sandboxed_exec(
         &self,
         command: Vec<String>,
@@ -1186,7 +1110,6 @@ impl CoreShellCommandExecutor {
         let sandbox_manager = crate::sandboxing::SandboxManager::new();
         let sandbox = sandbox_manager.select_initial(
             sandbox_policy,
-=======
     #[allow(clippy::too_many_arguments)]
     fn prepare_sandboxed_exec(
         &self,
@@ -1210,12 +1133,10 @@ impl CoreShellCommandExecutor {
         let sandbox = sandbox_manager.select_initial(
             file_system_sandbox_policy,
             network_sandbox_policy,
->>>>>>> upstream_main
             SandboxablePreference::Auto,
             self.windows_sandbox_level,
             self.network.is_some(),
         );
-<<<<<<< HEAD
         let mut exec_request =
             sandbox_manager.transform(crate::sandboxing::SandboxTransformRequest {
                 spec: crate::sandboxing::CommandSpec {
@@ -1243,7 +1164,6 @@ impl CoreShellCommandExecutor {
                 use_linux_sandbox_bwrap: self.use_linux_sandbox_bwrap,
                 windows_sandbox_level: self.windows_sandbox_level,
             })?;
-=======
         let command = SandboxCommand {
             program: program.clone(),
             args: args.to_vec(),
@@ -1273,7 +1193,6 @@ impl CoreShellCommandExecutor {
         })?;
         let mut exec_request =
             crate::sandboxing::ExecRequest::from_sandbox_exec_request(exec_request, options);
->>>>>>> upstream_main
         if let Some(network) = exec_request.network.as_ref() {
             network.apply_to_env(&mut exec_request.env);
         }
@@ -1298,14 +1217,12 @@ fn extract_shell_script(command: &[String]) -> Result<ParsedShellCommand, ToolEr
     // Commands reaching zsh-fork can be wrapped by environment/sandbox helpers, so
     // we search for the first `-c`/`-lc` triple anywhere in the argv rather
     // than assuming it is the first positional form.
-<<<<<<< HEAD
     if let Some((script, login)) = command.windows(3).find_map(|parts| match parts {
         [_, flag, script] if flag == "-c" => Some((script.to_owned(), false)),
         [_, flag, script] if flag == "-lc" => Some((script.to_owned(), true)),
         _ => None,
     }) {
         return Ok(ParsedShellCommand { script, login });
-=======
     if let Some((program, script, login)) = command.windows(3).find_map(|parts| match parts {
         [program, flag, script] if flag == "-c" => {
             Some((program.to_owned(), script.to_owned(), false))
@@ -1320,7 +1237,6 @@ fn extract_shell_script(command: &[String]) -> Result<ParsedShellCommand, ToolEr
             script,
             login,
         });
->>>>>>> upstream_main
     }
 
     Err(ToolError::Rejected(

--- a/codex-rs/core/src/tools/runtimes/shell/unix_escalation_tests.rs
+++ b/codex-rs/core/src/tools/runtimes/shell/unix_escalation_tests.rs
@@ -1,10 +1,7 @@
 use super::CoreShellActionProvider;
 #[cfg(target_os = "macos")]
 use super::CoreShellCommandExecutor;
-<<<<<<< HEAD
-=======
 use super::InterceptedExecPolicyContext;
->>>>>>> upstream_main
 use super::ParsedShellCommand;
 use super::commands_for_intercepted_exec_policy;
 use super::evaluate_intercepted_exec_policy;
@@ -17,7 +14,6 @@ use crate::config::Constrained;
 use crate::config::Permissions;
 #[cfg(target_os = "macos")]
 use crate::config::types::ShellEnvironmentPolicy;
-<<<<<<< HEAD
 use crate::exec::SandboxType;
 use crate::protocol::AskForApproval;
 use crate::protocol::ReadOnlyAccess;
@@ -25,14 +21,12 @@ use crate::protocol::SandboxPolicy;
 use crate::sandboxing::SandboxPermissions;
 #[cfg(target_os = "macos")]
 use crate::seatbelt::MACOS_PATH_TO_SEATBELT_EXECUTABLE;
-=======
 use crate::protocol::AskForApproval;
 use crate::protocol::GranularApprovalConfig;
 use crate::protocol::ReadOnlyAccess;
 use crate::protocol::SandboxPolicy;
 use crate::sandboxing::SandboxPermissions;
 use crate::skills::SkillMetadata;
->>>>>>> upstream_main
 use codex_execpolicy::Decision;
 use codex_execpolicy::Evaluation;
 use codex_execpolicy::PolicyParser;
@@ -43,8 +37,6 @@ use codex_protocol::models::FileSystemPermissions;
 use codex_protocol::models::MacOsPreferencesPermission;
 use codex_protocol::models::MacOsSeatbeltProfileExtensions;
 use codex_protocol::models::PermissionProfile;
-<<<<<<< HEAD
-=======
 use codex_protocol::permissions::FileSystemAccessMode;
 use codex_protocol::permissions::FileSystemPath;
 use codex_protocol::permissions::FileSystemSandboxEntry;
@@ -55,7 +47,6 @@ use codex_protocol::protocol::SkillScope;
 use codex_sandboxing::SandboxType;
 #[cfg(target_os = "macos")]
 use codex_sandboxing::seatbelt::MACOS_PATH_TO_SEATBELT_EXECUTABLE;
->>>>>>> upstream_main
 use codex_shell_escalation::EscalationExecution;
 use codex_shell_escalation::EscalationPermissions;
 use codex_shell_escalation::ExecResult;
@@ -85,8 +76,6 @@ fn starlark_string(value: &str) -> String {
     value.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
-<<<<<<< HEAD
-=======
 fn read_only_file_system_sandbox_policy() -> FileSystemSandboxPolicy {
     FileSystemSandboxPolicy::restricted(vec![FileSystemSandboxEntry {
         path: FileSystemPath::Special {
@@ -200,16 +189,12 @@ fn approval_sandbox_permissions_only_downgrades_preapproved_additional_permissio
     );
 }
 
->>>>>>> upstream_main
 #[test]
 fn extract_shell_script_preserves_login_flag() {
     assert_eq!(
         extract_shell_script(&["/bin/zsh".into(), "-lc".into(), "echo hi".into()]).unwrap(),
         ParsedShellCommand {
-<<<<<<< HEAD
-=======
             program: "/bin/zsh".to_string(),
->>>>>>> upstream_main
             script: "echo hi".to_string(),
             login: true,
         }
@@ -217,10 +202,7 @@ fn extract_shell_script_preserves_login_flag() {
     assert_eq!(
         extract_shell_script(&["/bin/zsh".into(), "-c".into(), "echo hi".into()]).unwrap(),
         ParsedShellCommand {
-<<<<<<< HEAD
-=======
             program: "/bin/zsh".to_string(),
->>>>>>> upstream_main
             script: "echo hi".to_string(),
             login: false,
         }
@@ -239,10 +221,7 @@ fn extract_shell_script_supports_wrapped_command_prefixes() {
         ])
         .unwrap(),
         ParsedShellCommand {
-<<<<<<< HEAD
-=======
             program: "/bin/zsh".to_string(),
->>>>>>> upstream_main
             script: "echo hello".to_string(),
             login: true,
         }
@@ -259,10 +238,7 @@ fn extract_shell_script_supports_wrapped_command_prefixes() {
         ])
         .unwrap(),
         ParsedShellCommand {
-<<<<<<< HEAD
-=======
             program: "/bin/zsh".to_string(),
->>>>>>> upstream_main
             script: "pwd".to_string(),
             login: false,
         }
@@ -361,8 +337,6 @@ fn shell_request_escalation_execution_is_explicit() {
         exclude_tmpdir_env_var: false,
         exclude_slash_tmp: false,
     };
-<<<<<<< HEAD
-=======
     let file_system_sandbox_policy = FileSystemSandboxPolicy::restricted(vec![
         FileSystemSandboxEntry {
             path: FileSystemPath::Path {
@@ -378,7 +352,6 @@ fn shell_request_escalation_execution_is_explicit() {
         },
     ]);
     let network_sandbox_policy = NetworkSandboxPolicy::Restricted;
->>>>>>> upstream_main
     let macos_seatbelt_profile_extensions = MacOsSeatbeltProfileExtensions {
         macos_preferences: MacOsPreferencesPermission::ReadWrite,
         ..Default::default()
@@ -388,11 +361,8 @@ fn shell_request_escalation_execution_is_explicit() {
         CoreShellActionProvider::shell_request_escalation_execution(
             crate::sandboxing::SandboxPermissions::UseDefault,
             &sandbox_policy,
-<<<<<<< HEAD
-=======
             &file_system_sandbox_policy,
             network_sandbox_policy,
->>>>>>> upstream_main
             None,
             Some(&macos_seatbelt_profile_extensions),
         ),
@@ -402,11 +372,8 @@ fn shell_request_escalation_execution_is_explicit() {
         CoreShellActionProvider::shell_request_escalation_execution(
             crate::sandboxing::SandboxPermissions::RequireEscalated,
             &sandbox_policy,
-<<<<<<< HEAD
-=======
             &file_system_sandbox_policy,
             network_sandbox_policy,
->>>>>>> upstream_main
             None,
             Some(&macos_seatbelt_profile_extensions),
         ),
@@ -416,22 +383,16 @@ fn shell_request_escalation_execution_is_explicit() {
         CoreShellActionProvider::shell_request_escalation_execution(
             crate::sandboxing::SandboxPermissions::WithAdditionalPermissions,
             &sandbox_policy,
-<<<<<<< HEAD
-=======
             &file_system_sandbox_policy,
             network_sandbox_policy,
->>>>>>> upstream_main
             Some(&requested_permissions),
             Some(&macos_seatbelt_profile_extensions),
         ),
         EscalationExecution::Permissions(EscalationPermissions::Permissions(
             EscalatedPermissions {
                 sandbox_policy,
-<<<<<<< HEAD
-=======
                 file_system_sandbox_policy,
                 network_sandbox_policy,
->>>>>>> upstream_main
                 macos_seatbelt_profile_extensions: Some(macos_seatbelt_profile_extensions),
             },
         )),
@@ -439,8 +400,6 @@ fn shell_request_escalation_execution_is_explicit() {
 }
 
 #[test]
-<<<<<<< HEAD
-=======
 fn skill_escalation_execution_uses_additional_permissions() {
     let requested_permissions = PermissionProfile {
         file_system: Some(FileSystemPermissions {
@@ -477,7 +436,6 @@ fn skill_escalation_execution_ignores_empty_permissions() {
 }
 
 #[test]
->>>>>>> upstream_main
 fn evaluate_intercepted_exec_policy_uses_wrapper_command_when_shell_wrapper_parsing_disabled() {
     let policy_src = r#"prefix_rule(pattern = ["npm", "publish"], decision = "prompt")"#;
     let mut parser = PolicyParser::new();
@@ -494,12 +452,10 @@ fn evaluate_intercepted_exec_policy_uses_wrapper_command_when_shell_wrapper_pars
             "-lc".to_string(),
             "npm publish".to_string(),
         ],
-<<<<<<< HEAD
         AskForApproval::OnRequest,
         &SandboxPolicy::new_read_only_policy(),
         SandboxPermissions::UseDefault,
         enable_intercepted_exec_policy_shell_wrapper_parsing,
-=======
         InterceptedExecPolicyContext {
             approval_policy: AskForApproval::OnRequest,
             sandbox_policy: &SandboxPolicy::new_read_only_policy(),
@@ -507,7 +463,6 @@ fn evaluate_intercepted_exec_policy_uses_wrapper_command_when_shell_wrapper_pars
             sandbox_permissions: SandboxPermissions::UseDefault,
             enable_shell_wrapper_parsing: enable_intercepted_exec_policy_shell_wrapper_parsing,
         },
->>>>>>> upstream_main
     );
 
     assert!(
@@ -552,12 +507,10 @@ fn evaluate_intercepted_exec_policy_matches_inner_shell_commands_when_enabled() 
             "-lc".to_string(),
             "npm publish".to_string(),
         ],
-<<<<<<< HEAD
         AskForApproval::OnRequest,
         &SandboxPolicy::new_read_only_policy(),
         SandboxPermissions::UseDefault,
         enable_intercepted_exec_policy_shell_wrapper_parsing,
-=======
         InterceptedExecPolicyContext {
             approval_policy: AskForApproval::OnRequest,
             sandbox_policy: &SandboxPolicy::new_read_only_policy(),
@@ -565,7 +518,6 @@ fn evaluate_intercepted_exec_policy_matches_inner_shell_commands_when_enabled() 
             sandbox_permissions: SandboxPermissions::UseDefault,
             enable_shell_wrapper_parsing: enable_intercepted_exec_policy_shell_wrapper_parsing,
         },
->>>>>>> upstream_main
     );
 
     assert_eq!(
@@ -601,12 +553,10 @@ host_executable(name = "git", paths = ["{git_path_literal}"])
         &policy,
         &program,
         &["git".to_string(), "status".to_string()],
-<<<<<<< HEAD
         AskForApproval::OnRequest,
         &SandboxPolicy::new_read_only_policy(),
         SandboxPermissions::UseDefault,
         false,
-=======
         InterceptedExecPolicyContext {
             approval_policy: AskForApproval::OnRequest,
             sandbox_policy: &SandboxPolicy::new_read_only_policy(),
@@ -614,7 +564,6 @@ host_executable(name = "git", paths = ["{git_path_literal}"])
             sandbox_permissions: SandboxPermissions::UseDefault,
             enable_shell_wrapper_parsing: false,
         },
->>>>>>> upstream_main
     );
 
     assert_eq!(
@@ -636,8 +585,6 @@ host_executable(name = "git", paths = ["{git_path_literal}"])
 }
 
 #[test]
-<<<<<<< HEAD
-=======
 fn intercepted_exec_policy_treats_preapproved_additional_permissions_as_default() {
     let policy = PolicyParser::new().build();
     let program = AbsolutePathBuf::try_from(host_absolute_path(&["usr", "bin", "printf"])).unwrap();
@@ -679,7 +626,6 @@ fn intercepted_exec_policy_treats_preapproved_additional_permissions_as_default(
 }
 
 #[test]
->>>>>>> upstream_main
 fn intercepted_exec_policy_rejects_disallowed_host_executable_mapping() {
     let allowed_git = host_absolute_path(&["usr", "bin", "git"]);
     let other_git = host_absolute_path(&["opt", "homebrew", "bin", "git"]);
@@ -699,12 +645,10 @@ host_executable(name = "git", paths = ["{allowed_git_literal}"])
         &policy,
         &program,
         &["git".to_string(), "status".to_string()],
-<<<<<<< HEAD
         AskForApproval::OnRequest,
         &SandboxPolicy::new_read_only_policy(),
         SandboxPermissions::UseDefault,
         false,
-=======
         InterceptedExecPolicyContext {
             approval_policy: AskForApproval::OnRequest,
             sandbox_policy: &SandboxPolicy::new_read_only_policy(),
@@ -712,7 +656,6 @@ host_executable(name = "git", paths = ["{allowed_git_literal}"])
             sandbox_permissions: SandboxPermissions::UseDefault,
             enable_shell_wrapper_parsing: false,
         },
->>>>>>> upstream_main
     );
 
     assert!(matches!(
@@ -737,15 +680,12 @@ async fn prepare_escalated_exec_turn_default_preserves_macos_seatbelt_extensions
         network: None,
         sandbox: SandboxType::None,
         sandbox_policy: SandboxPolicy::new_read_only_policy(),
-<<<<<<< HEAD
         windows_sandbox_level: WindowsSandboxLevel::Disabled,
         sandbox_permissions: SandboxPermissions::UseDefault,
         justification: None,
-=======
         file_system_sandbox_policy: read_only_file_system_sandbox_policy(),
         network_sandbox_policy: NetworkSandboxPolicy::Restricted,
         windows_sandbox_level: WindowsSandboxLevel::Disabled,
->>>>>>> upstream_main
         arg0: None,
         sandbox_policy_cwd: cwd.to_path_buf(),
         macos_seatbelt_profile_extensions: Some(MacOsSeatbeltProfileExtensions {
@@ -753,11 +693,8 @@ async fn prepare_escalated_exec_turn_default_preserves_macos_seatbelt_extensions
             ..Default::default()
         }),
         codex_linux_sandbox_exe: None,
-<<<<<<< HEAD
         use_linux_sandbox_bwrap: false,
-=======
         use_legacy_landlock: false,
->>>>>>> upstream_main
     };
 
     let prepared = executor
@@ -797,42 +734,30 @@ async fn prepare_escalated_exec_permissions_preserve_macos_seatbelt_extensions()
         network: None,
         sandbox: SandboxType::None,
         sandbox_policy: SandboxPolicy::DangerFullAccess,
-<<<<<<< HEAD
         windows_sandbox_level: WindowsSandboxLevel::Disabled,
         sandbox_permissions: SandboxPermissions::UseDefault,
         justification: None,
-=======
         file_system_sandbox_policy: unrestricted_file_system_sandbox_policy(),
         network_sandbox_policy: NetworkSandboxPolicy::Enabled,
         windows_sandbox_level: WindowsSandboxLevel::Disabled,
->>>>>>> upstream_main
         arg0: None,
         sandbox_policy_cwd: cwd.to_path_buf(),
         macos_seatbelt_profile_extensions: None,
         codex_linux_sandbox_exe: None,
-<<<<<<< HEAD
         use_linux_sandbox_bwrap: false,
-=======
         use_legacy_landlock: false,
->>>>>>> upstream_main
     };
 
     let permissions = Permissions {
         approval_policy: Constrained::allow_any(AskForApproval::Never),
         sandbox_policy: Constrained::allow_any(SandboxPolicy::new_read_only_policy()),
-<<<<<<< HEAD
-=======
         file_system_sandbox_policy: read_only_file_system_sandbox_policy(),
         network_sandbox_policy: codex_protocol::permissions::NetworkSandboxPolicy::Restricted,
->>>>>>> upstream_main
         network: None,
         allow_login_shell: true,
         shell_environment_policy: ShellEnvironmentPolicy::default(),
         windows_sandbox_mode: None,
-<<<<<<< HEAD
-=======
         windows_sandbox_private_desktop: false,
->>>>>>> upstream_main
         macos_seatbelt_profile_extensions: Some(MacOsSeatbeltProfileExtensions {
             macos_preferences: MacOsPreferencesPermission::ReadWrite,
             ..Default::default()
@@ -848,11 +773,8 @@ async fn prepare_escalated_exec_permissions_preserve_macos_seatbelt_extensions()
             EscalationExecution::Permissions(EscalationPermissions::Permissions(
                 EscalatedPermissions {
                     sandbox_policy: permissions.sandbox_policy.get().clone(),
-<<<<<<< HEAD
-=======
                     file_system_sandbox_policy: permissions.file_system_sandbox_policy.clone(),
                     network_sandbox_policy: permissions.network_sandbox_policy,
->>>>>>> upstream_main
                     macos_seatbelt_profile_extensions: permissions
                         .macos_seatbelt_profile_extensions
                         .clone(),
@@ -876,8 +798,6 @@ async fn prepare_escalated_exec_permissions_preserve_macos_seatbelt_extensions()
         prepared.command
     );
 }
-<<<<<<< HEAD
-=======
 
 #[cfg(target_os = "macos")]
 #[tokio::test]
@@ -944,4 +864,3 @@ async fn prepare_escalated_exec_permission_profile_unions_turn_and_requested_mac
         prepared.command
     );
 }
->>>>>>> upstream_main

--- a/codex-rs/core/src/tools/runtimes/unified_exec.rs
+++ b/codex-rs/core/src/tools/runtimes/unified_exec.rs
@@ -153,10 +153,7 @@ impl Approvable<UnifiedExecRequest> for UnifiedExecRuntime<'_> {
                             .proposed_execpolicy_amendment()
                             .cloned(),
                         req.additional_permissions.clone(),
-<<<<<<< HEAD
-=======
                         /*skill_metadata*/ None,
->>>>>>> upstream_main
                         available_decisions,
                     )
                     .await

--- a/codex-rs/core/src/tools/spec.rs
+++ b/codex-rs/core/src/tools/spec.rs
@@ -6,8 +6,6 @@ use crate::config::AgentRoleConfig;
 use crate::mcp::CODEX_APPS_MCP_SERVER_NAME;
 use crate::mcp_connection_manager::ToolInfo;
 use crate::models_manager::collaboration_mode_presets::CollaborationModesConfig;
-<<<<<<< HEAD
-=======
 use crate::original_image_detail::can_request_original_image_detail;
 use crate::shell::Shell;
 use crate::shell::ShellType;
@@ -18,7 +16,6 @@ use crate::tools::discoverable::DiscoverablePluginInfo;
 use crate::tools::discoverable::DiscoverableTool;
 use crate::tools::discoverable::DiscoverableToolAction;
 use crate::tools::discoverable::DiscoverableToolType;
->>>>>>> upstream_main
 use crate::tools::handlers::PLAN_TOOL;
 use crate::tools::handlers::TOOL_SEARCH_DEFAULT_LIMIT;
 use crate::tools::handlers::TOOL_SEARCH_TOOL_NAME;
@@ -336,12 +333,9 @@ pub(crate) struct ToolsConfig {
     pub js_repl_tools_only: bool,
     pub can_request_original_image_detail: bool,
     pub collab_tools: bool,
-<<<<<<< HEAD
-=======
     pub multi_agent_v2: bool,
     pub artifact_tools: bool,
     pub request_user_input: bool,
->>>>>>> upstream_main
     pub default_mode_request_user_input: bool,
     pub experimental_supported_tools: Vec<String>,
     pub agent_jobs_tools: bool,
@@ -389,13 +383,11 @@ impl ToolsConfig {
         let include_js_repl_tools_only =
             include_js_repl && features.enabled(Feature::JsReplToolsOnly);
         let include_collab_tools = features.enabled(Feature::Collab);
-<<<<<<< HEAD
         let include_default_mode_request_user_input =
             features.enabled(Feature::DefaultModeRequestUserInput);
         let include_search_tool = features.enabled(Feature::Apps);
         let include_agent_jobs = include_collab_tools && features.enabled(Feature::Sqlite);
         let request_permission_enabled = features.enabled(Feature::RequestPermissions);
-=======
         let include_multi_agent_v2 = features.enabled(Feature::MultiAgentV2);
         let include_agent_jobs = features.enabled(Feature::SpawnCsv);
         let include_request_user_input = !matches!(session_source, SessionSource::SubAgent(_));
@@ -413,7 +405,6 @@ impl ToolsConfig {
             features.enabled(Feature::ImageGeneration) && supports_image_generation(model_info);
         let exec_permission_approvals_enabled = features.enabled(Feature::ExecPermissionApprovals);
         let request_permissions_tool_enabled = features.enabled(Feature::RequestPermissionsTool);
->>>>>>> upstream_main
         let shell_command_backend =
             if features.enabled(Feature::ShellTool) && features.enabled(Feature::ShellZshFork) {
                 ShellCommandBackendConfig::ZshFork
@@ -484,12 +475,9 @@ impl ToolsConfig {
             js_repl_tools_only: include_js_repl_tools_only,
             can_request_original_image_detail: include_original_image_detail,
             collab_tools: include_collab_tools,
-<<<<<<< HEAD
-=======
             multi_agent_v2: include_multi_agent_v2,
             artifact_tools: include_artifact_tools,
             request_user_input: include_request_user_input,
->>>>>>> upstream_main
             default_mode_request_user_input: include_default_mode_request_user_input,
             experimental_supported_tools: model_info.experimental_supported_tools.clone(),
             agent_jobs_tools: include_agent_jobs,
@@ -1185,8 +1173,6 @@ fn create_spawn_agent_tool(config: &ToolsConfig) -> ToolSpec {
                 ),
             },
         ),
-<<<<<<< HEAD
-=======
         (
             "model".to_string(),
             JsonSchema::String {
@@ -1205,7 +1191,6 @@ fn create_spawn_agent_tool(config: &ToolsConfig) -> ToolSpec {
                 ),
             },
         ),
->>>>>>> upstream_main
     ]);
     properties.insert(
         "task_name".to_string(),
@@ -1610,8 +1595,6 @@ fn create_wait_agent_tool_v1() -> ToolSpec {
     })
 }
 
-<<<<<<< HEAD
-=======
 fn create_wait_agent_tool_v2() -> ToolSpec {
     ToolSpec::Function(ResponsesApiTool {
         name: "wait_agent".to_string(),
@@ -1650,7 +1633,6 @@ fn create_list_agents_tool() -> ToolSpec {
     })
 }
 
->>>>>>> upstream_main
 fn create_request_user_input_tool(
     collaboration_modes_config: CollaborationModesConfig,
 ) -> ToolSpec {
@@ -2813,12 +2795,10 @@ pub(crate) fn build_specs_with_discoverable_tools(
     let mcp_handler = Arc::new(McpHandler);
     let mcp_resource_handler = Arc::new(McpResourceHandler);
     let shell_command_handler = Arc::new(ShellCommandHandler::from(config.shell_command_backend));
-<<<<<<< HEAD
     let request_user_input_handler = Arc::new(RequestUserInputHandler {
         default_mode_request_user_input: config.default_mode_request_user_input,
     });
     let search_tool_handler = Arc::new(SearchToolBm25Handler);
-=======
     let request_permissions_handler = Arc::new(RequestPermissionsHandler);
     let request_user_input_handler = Arc::new(RequestUserInputHandler {
         default_mode_request_user_input: config.default_mode_request_user_input,
@@ -2826,7 +2806,6 @@ pub(crate) fn build_specs_with_discoverable_tools(
     let tool_suggest_handler = Arc::new(ToolSuggestHandler);
     let code_mode_handler = Arc::new(CodeModeExecuteHandler);
     let code_mode_wait_handler = Arc::new(CodeModeWaitHandler);
->>>>>>> upstream_main
     let js_repl_handler = Arc::new(JsReplHandler);
     let js_repl_reset_handler = Arc::new(JsReplResetHandler);
     let artifacts_handler = Arc::new(ArtifactsHandler);
@@ -2982,12 +2961,10 @@ pub(crate) fn build_specs_with_discoverable_tools(
         builder.register_handler("js_repl_reset", js_repl_reset_handler);
     }
 
-<<<<<<< HEAD
     builder.push_spec(create_request_user_input_tool(CollaborationModesConfig {
         default_mode_request_user_input: config.default_mode_request_user_input,
     }));
     builder.register_handler("request_user_input", request_user_input_handler);
-=======
     if config.request_user_input {
         push_tool_spec(
             &mut builder,
@@ -2999,7 +2976,6 @@ pub(crate) fn build_specs_with_discoverable_tools(
         );
         builder.register_handler("request_user_input", request_user_input_handler);
     }
->>>>>>> upstream_main
 
     if config.request_permissions_tool_enabled {
         push_tool_spec(
@@ -3329,7 +3305,6 @@ pub(crate) fn build_specs_with_discoverable_tools(
 }
 
 #[cfg(test)]
-<<<<<<< HEAD
 mod tests {
     use crate::client_common::tools::FreeformTool;
     use crate::config::test_config;
@@ -4744,7 +4719,5 @@ Examples of valid command strings:
         );
     }
 }
-=======
 #[path = "spec_tests.rs"]
 mod tests;
->>>>>>> upstream_main

--- a/codex-rs/core/src/user_shell_command.rs
+++ b/codex-rs/core/src/user_shell_command.rs
@@ -55,7 +55,6 @@ pub fn user_shell_command_record_item(
 }
 
 #[cfg(test)]
-<<<<<<< HEAD
 mod tests {
     use super::*;
     use crate::codex::make_session_and_context;
@@ -114,7 +113,5 @@ mod tests {
         );
     }
 }
-=======
 #[path = "user_shell_command_tests.rs"]
 mod tests;
->>>>>>> upstream_main

--- a/codex-rs/core/tests/common/context_snapshot.rs
+++ b/codex-rs/core/tests/common/context_snapshot.rs
@@ -411,8 +411,6 @@ mod tests {
     }
 
     #[test]
-<<<<<<< HEAD
-=======
     fn redacted_text_mode_keeps_capability_instruction_placeholders() {
         let items = vec![json!({
             "type": "message",
@@ -494,7 +492,6 @@ mod tests {
     }
 
     #[test]
->>>>>>> upstream_main
     fn redacted_text_mode_normalizes_environment_context_with_subagents() {
         let items = vec![json!({
             "type": "message",
@@ -517,8 +514,6 @@ mod tests {
     }
 
     #[test]
-<<<<<<< HEAD
-=======
     fn kind_with_text_prefix_mode_normalizes_crlf_line_endings() {
         let items = vec![json!({
             "type": "message",
@@ -542,7 +537,6 @@ mod tests {
     }
 
     #[test]
->>>>>>> upstream_main
     fn image_only_message_is_rendered_as_non_text_span() {
         let items = vec![json!({
             "type": "message",
@@ -584,8 +578,6 @@ mod tests {
         assert_eq!(
             rendered,
             "00:message/user[3]:\n    [01] <image>\n    [02] <input_image:image_url>\n    [03] </image>"
-<<<<<<< HEAD
-=======
         );
     }
 
@@ -605,7 +597,6 @@ mod tests {
         assert_eq!(
             rendered,
             "00:message/developer:## Skills\\n- openai-docs: helper (file: <SYSTEM_SKILLS_ROOT>/openai-docs/SKILL.md)"
->>>>>>> upstream_main
         );
     }
 }

--- a/codex-rs/core/tests/common/lib.rs
+++ b/codex-rs/core/tests/common/lib.rs
@@ -23,14 +23,11 @@ pub mod responses;
 pub mod streaming_sse;
 pub mod test_codex;
 pub mod test_codex_exec;
-<<<<<<< HEAD
 pub mod zsh_fork;
-=======
 pub mod tracing;
 pub mod zsh_fork;
 
 static TEST_ARG0_PATH_ENTRY: OnceLock<Option<Arg0PathEntryGuard>> = OnceLock::new();
->>>>>>> upstream_main
 
 #[ctor]
 fn enable_deterministic_unified_exec_process_ids_for_tests() {

--- a/codex-rs/core/tests/common/test_codex.rs
+++ b/codex-rs/core/tests/common/test_codex.rs
@@ -17,9 +17,7 @@ use codex_core::ModelProviderInfo;
 use codex_core::ThreadManager;
 use codex_core::built_in_model_providers;
 use codex_core::config::Config;
-<<<<<<< HEAD
 use codex_core::features::Feature;
-=======
 use codex_core::models_manager::collaboration_mode_presets::CollaborationModesConfig;
 use codex_core::shell::Shell;
 use codex_core::shell::get_shell_by_model_provided_path;
@@ -28,7 +26,6 @@ use codex_exec_server::ExecutorFileSystem;
 use codex_features::Feature;
 use codex_protocol::config_types::ServiceTier;
 use codex_protocol::openai_models::ModelsResponse;
->>>>>>> upstream_main
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::Op;
@@ -732,10 +729,7 @@ impl TestCodex {
                 model: session_model,
                 effort: None,
                 summary: None,
-<<<<<<< HEAD
-=======
                 service_tier,
->>>>>>> upstream_main
                 collaboration_mode: None,
                 personality: None,
             })

--- a/codex-rs/core/tests/common/zsh_fork.rs
+++ b/codex-rs/core/tests/common/zsh_fork.rs
@@ -4,11 +4,8 @@ use std::path::PathBuf;
 use anyhow::Result;
 use codex_core::config::Config;
 use codex_core::config::Constrained;
-<<<<<<< HEAD
 use codex_core::features::Feature;
-=======
 use codex_features::Feature;
->>>>>>> upstream_main
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::SandboxPolicy;
 
@@ -28,10 +25,8 @@ impl ZshForkRuntime {
         approval_policy: AskForApproval,
         sandbox_policy: SandboxPolicy,
     ) {
-<<<<<<< HEAD
         config.features.enable(Feature::ShellTool);
         config.features.enable(Feature::ShellZshFork);
-=======
         config
             .features
             .enable(Feature::ShellTool)
@@ -40,7 +35,6 @@ impl ZshForkRuntime {
             .features
             .enable(Feature::ShellZshFork)
             .expect("test config should allow feature update");
->>>>>>> upstream_main
         config.zsh_path = Some(self.zsh_path.clone());
         config.main_execve_wrapper_exe = Some(self.main_execve_wrapper_exe.clone());
         config.permissions.allow_login_shell = false;
@@ -111,11 +105,8 @@ fn find_test_zsh_path() -> Result<Option<PathBuf>> {
         return Ok(None);
     }
 
-<<<<<<< HEAD
     match crate::fetch_dotslash_file(&dotslash_zsh, None) {
-=======
     match crate::fetch_dotslash_file(&dotslash_zsh, /*dotslash_cache*/ None) {
->>>>>>> upstream_main
         Ok(path) => Ok(Some(path)),
         Err(error) => {
             eprintln!("skipping zsh-fork test: failed to fetch zsh via dotslash: {error:#}");

--- a/codex-rs/core/tests/responses_headers.rs
+++ b/codex-rs/core/tests/responses_headers.rs
@@ -113,18 +113,15 @@ async fn responses_stream_includes_subagent_header_on_review() {
         .stream(
             &prompt,
             &model_info,
-<<<<<<< HEAD
             &otel_manager,
             effort,
             summary.unwrap_or(model_info.default_reasoning_summary),
             None,
-=======
             &session_telemetry,
             effort,
             summary.unwrap_or(model_info.default_reasoning_summary),
             None,
             None,
->>>>>>> upstream_main
         )
         .await
         .expect("stream failed");
@@ -233,18 +230,15 @@ async fn responses_stream_includes_subagent_header_on_other() {
         .stream(
             &prompt,
             &model_info,
-<<<<<<< HEAD
             &otel_manager,
             effort,
             summary.unwrap_or(model_info.default_reasoning_summary),
             None,
-=======
             &session_telemetry,
             effort,
             summary.unwrap_or(model_info.default_reasoning_summary),
             None,
             None,
->>>>>>> upstream_main
         )
         .await
         .expect("stream failed");
@@ -352,18 +346,15 @@ async fn responses_respects_model_info_overrides_from_config() {
         .stream(
             &prompt,
             &model_info,
-<<<<<<< HEAD
             &otel_manager,
             effort,
             summary.unwrap_or(model_info.default_reasoning_summary),
             None,
-=======
             &session_telemetry,
             effort,
             summary.unwrap_or(model_info.default_reasoning_summary),
             None,
             None,
->>>>>>> upstream_main
         )
         .await
         .expect("stream failed");

--- a/codex-rs/core/tests/suite/apply_patch_cli.rs
+++ b/codex-rs/core/tests/suite/apply_patch_cli.rs
@@ -1,11 +1,8 @@
 #![allow(clippy::expect_used)]
 
 use anyhow::Result;
-<<<<<<< HEAD
-=======
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
->>>>>>> upstream_main
 use codex_test_macros::large_stack_test;
 use core_test_support::responses::ev_apply_patch_call;
 use core_test_support::responses::ev_apply_patch_custom_tool_call;
@@ -16,11 +13,8 @@ use std::fs;
 use std::sync::atomic::AtomicI32;
 use std::sync::atomic::Ordering;
 
-<<<<<<< HEAD
 use codex_core::features::Feature;
-=======
 use codex_features::Feature;
->>>>>>> upstream_main
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::Op;
@@ -322,10 +316,7 @@ async fn apply_patch_cli_move_without_content_change_has_no_turn_diff(
             model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -935,10 +926,7 @@ async fn apply_patch_shell_command_heredoc_with_cd_emits_turn_diff() -> Result<(
             model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -1020,10 +1008,7 @@ async fn apply_patch_shell_command_failure_propagates_error_and_skips_diff() -> 
             model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -1175,10 +1160,7 @@ async fn apply_patch_emits_turn_diff_event_with_unified_diff(
             model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -1243,10 +1225,7 @@ async fn apply_patch_turn_diff_for_rename_with_content_change(
             model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -1319,10 +1298,7 @@ async fn apply_patch_aggregates_diff_across_multiple_tool_calls() -> Result<()> 
             model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -1395,10 +1371,7 @@ async fn apply_patch_aggregates_diff_preserves_success_after_failure() -> Result
             model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })

--- a/codex-rs/core/tests/suite/approvals.rs
+++ b/codex-rs/core/tests/suite/approvals.rs
@@ -563,10 +563,7 @@ async fn submit_turn(
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -2046,8 +2043,6 @@ async fn approving_execpolicy_amendment_persists_policy_and_skips_future_prompts
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-<<<<<<< HEAD
-=======
 async fn spawned_subagent_execpolicy_amendment_propagates_to_parent_session() -> Result<()> {
     skip_if_no_network!(Ok(()));
 
@@ -2230,7 +2225,6 @@ async fn spawned_subagent_execpolicy_amendment_propagates_to_parent_session() ->
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
->>>>>>> upstream_main
 #[cfg(unix)]
 async fn matched_prefix_rule_runs_unsandboxed_under_zsh_fork() -> Result<()> {
     skip_if_no_network!(Ok(()));

--- a/codex-rs/core/tests/suite/client.rs
+++ b/codex-rs/core/tests/suite/client.rs
@@ -10,15 +10,12 @@ use codex_core::auth::AuthCredentialsStoreMode;
 use codex_core::built_in_model_providers;
 use codex_core::default_client::originator;
 use codex_core::error::CodexErr;
-<<<<<<< HEAD
 use codex_core::features::Feature;
 use codex_core::models_manager::collaboration_mode_presets::CollaborationModesConfig;
 use codex_otel::OtelManager;
-=======
 use codex_core::models_manager::collaboration_mode_presets::CollaborationModesConfig;
 use codex_features::Feature;
 use codex_otel::SessionTelemetry;
->>>>>>> upstream_main
 use codex_otel::TelemetryAuthMode;
 use codex_protocol::ThreadId;
 use codex_protocol::config_types::CollaborationMode;
@@ -395,10 +392,7 @@ async fn resume_replays_legacy_js_repl_image_rollout_shapes() {
             timestamp: "2024-01-01T00:00:02.000Z".to_string(),
             item: RolloutItem::ResponseItem(ResponseItem::CustomToolCallOutput {
                 call_id: "legacy-js-call".to_string(),
-<<<<<<< HEAD
-=======
                 name: None,
->>>>>>> upstream_main
                 output: FunctionCallOutputPayload::from_text("legacy js_repl stdout".to_string()),
             }),
         },
@@ -498,8 +492,6 @@ async fn resume_replays_legacy_js_repl_image_rollout_shapes() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-<<<<<<< HEAD
-=======
 async fn resume_replays_image_tool_outputs_with_detail() {
     skip_if_no_network!();
 
@@ -623,7 +615,6 @@ async fn resume_replays_image_tool_outputs_with_detail() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
->>>>>>> upstream_main
 async fn includes_conversation_id_and_model_headers_in_request() {
     skip_if_no_network!();
 
@@ -835,10 +826,7 @@ async fn prefers_apikey_when_config_prefers_apikey_even_with_chatgpt_tokens() {
         &config,
         auth_manager,
         SessionSource::Exec,
-<<<<<<< HEAD
         config.model_catalog.clone(),
-=======
->>>>>>> upstream_main
         CollaborationModesConfig {
             default_mode_request_user_input: config
                 .features
@@ -1335,10 +1323,7 @@ async fn user_turn_collaboration_mode_overrides_model_and_effort() -> anyhow::Re
                     .model_reasoning_summary
                     .unwrap_or(ReasoningSummary::Auto),
             ),
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: Some(collaboration_mode),
             final_output_json_schema: None,
             personality: None,
@@ -1447,18 +1432,12 @@ async fn user_turn_explicit_reasoning_summary_overrides_model_catalog_default() 
             }],
             cwd: config.cwd.clone(),
             approval_policy: config.permissions.approval_policy.value(),
-<<<<<<< HEAD
-=======
             approvals_reviewer: None,
->>>>>>> upstream_main
             sandbox_policy: config.permissions.sandbox_policy.get().clone(),
             model: session_configured.model,
             effort: None,
             summary: Some(ReasoningSummary::Concise),
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             final_output_json_schema: None,
             personality: None,
@@ -1927,10 +1906,7 @@ async fn azure_responses_request_includes_store_and_reasoning_ids() {
     });
     prompt.input.push(ResponseItem::CustomToolCallOutput {
         call_id: "custom-tool-call-id".into(),
-<<<<<<< HEAD
-=======
         name: None,
->>>>>>> upstream_main
         output: FunctionCallOutputPayload::from_text("ok".into()),
     });
 
@@ -1938,18 +1914,15 @@ async fn azure_responses_request_includes_store_and_reasoning_ids() {
         .stream(
             &prompt,
             &model_info,
-<<<<<<< HEAD
             &otel_manager,
             effort,
             summary.unwrap_or(ReasoningSummary::Auto),
             None,
-=======
             &session_telemetry,
             effort,
             summary.unwrap_or(ReasoningSummary::Auto),
             None,
             None,
->>>>>>> upstream_main
         )
         .await
         .expect("responses stream to start");

--- a/codex-rs/core/tests/suite/client_websockets.rs
+++ b/codex-rs/core/tests/suite/client_websockets.rs
@@ -467,11 +467,8 @@ async fn responses_websocket_request_prewarm_is_reused_even_with_header_changes(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-<<<<<<< HEAD
 async fn responses_websocket_prewarm_uses_v2_when_model_prefers_websockets_and_feature_disabled() {
-=======
 async fn responses_websocket_prewarm_uses_v2_when_provider_supports_websockets() {
->>>>>>> upstream_main
     skip_if_no_network!();
 
     let server = start_websocket_server(vec![vec![vec![
@@ -499,7 +496,6 @@ async fn responses_websocket_prewarm_uses_v2_when_provider_supports_websockets()
     // V2 prewarm issues a request on the websocket connection.
     assert_eq!(server.handshakes().len(), 1);
     assert_eq!(server.single_connection().len(), 1);
-<<<<<<< HEAD
 
     let handshake = server.single_handshake();
     let openai_beta_header = handshake
@@ -517,8 +513,6 @@ async fn responses_websocket_prewarm_uses_v2_when_provider_supports_websockets()
             .map(str::trim)
             .any(|value| value == OPENAI_BETA_RESPONSES_WEBSOCKETS)
     );
-=======
->>>>>>> upstream_main
 
     let handshake = server.single_handshake();
     let openai_beta_header = handshake
@@ -1164,11 +1158,8 @@ async fn responses_websocket_connection_limit_error_reconnects_and_completes() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-<<<<<<< HEAD
 async fn responses_websocket_appends_on_prefix() {
-=======
 async fn responses_websocket_uses_incremental_create_on_prefix() {
->>>>>>> upstream_main
     skip_if_no_network!();
 
     let server = start_websocket_server(vec![vec![

--- a/codex-rs/core/tests/suite/collaboration_instructions.rs
+++ b/codex-rs/core/tests/suite/collaboration_instructions.rs
@@ -187,10 +187,7 @@ async fn collaboration_instructions_added_on_user_turn() -> Result<()> {
                     .model_reasoning_summary
                     .unwrap_or(codex_protocol::config_types::ReasoningSummary::Auto),
             ),
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: Some(collaboration_mode),
             final_output_json_schema: None,
             personality: None,
@@ -306,10 +303,7 @@ async fn user_turn_overrides_collaboration_instructions_after_override() -> Resu
                     .model_reasoning_summary
                     .unwrap_or(codex_protocol::config_types::ReasoningSummary::Auto),
             ),
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: Some(turn_mode),
             final_output_json_schema: None,
             personality: None,

--- a/codex-rs/core/tests/suite/compact.rs
+++ b/codex-rs/core/tests/suite/compact.rs
@@ -5,10 +5,7 @@ use codex_core::built_in_model_providers;
 use codex_core::compact::SUMMARIZATION_PROMPT;
 use codex_core::compact::SUMMARY_PREFIX;
 use codex_core::config::Config;
-<<<<<<< HEAD
-=======
 use codex_features::Feature;
->>>>>>> upstream_main
 use codex_protocol::items::TurnItem;
 use codex_protocol::openai_models::ModelInfo;
 use codex_protocol::openai_models::ModelsResponse;
@@ -1666,10 +1663,7 @@ async fn auto_compact_runs_after_resume_when_token_usage_is_over_limit() {
             model: resumed.session_configured.model.clone(),
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -1760,10 +1754,7 @@ async fn pre_sampling_compact_runs_on_switch_to_smaller_context_model() {
             model: previous_model.to_string(),
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -1788,10 +1779,7 @@ async fn pre_sampling_compact_runs_on_switch_to_smaller_context_model() {
             model: next_model.to_string(),
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -1902,10 +1890,7 @@ async fn pre_sampling_compact_runs_after_resume_and_switch_to_smaller_model() {
             model: previous_model.to_string(),
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -1954,10 +1939,7 @@ async fn pre_sampling_compact_runs_after_resume_and_switch_to_smaller_model() {
             model: next_model.to_string(),
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -3160,10 +3142,7 @@ async fn snapshot_request_shape_pre_turn_compaction_strips_incoming_model_switch
             model: previous_model.to_string(),
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -3188,10 +3167,7 @@ async fn snapshot_request_shape_pre_turn_compaction_strips_incoming_model_switch
             model: next_model.to_string(),
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })

--- a/codex-rs/core/tests/suite/compact_resume_fork.rs
+++ b/codex-rs/core/tests/suite/compact_resume_fork.rs
@@ -23,13 +23,10 @@ use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::Op;
 use codex_protocol::protocol::WarningEvent;
 use codex_protocol::user_input::UserInput;
-<<<<<<< HEAD
 use codex_test_macros::large_stack_test;
-=======
 use core_test_support::context_snapshot;
 use core_test_support::context_snapshot::ContextSnapshotOptions;
 use core_test_support::context_snapshot::ContextSnapshotRenderMode;
->>>>>>> upstream_main
 use core_test_support::responses::ResponseMock;
 use core_test_support::responses::ResponsesRequest;
 use core_test_support::responses::ev_assistant_message;
@@ -381,7 +378,6 @@ async fn compact_resume_after_second_compaction_preserves_history() -> Result<()
         compact_filtered.as_slice(),
         &resume_filtered[..compact_filtered.len()]
     );
-<<<<<<< HEAD
     let previous_compact_user_texts =
         json_message_input_texts(&requests[requests.len() - 2], "user")
             .into_iter()
@@ -391,7 +387,6 @@ async fn compact_resume_after_second_compaction_preserves_history() -> Result<()
         .into_iter()
         .filter(|text| !text.trim_start().starts_with("<ghost_snapshot>"))
         .collect::<Vec<_>>();
-=======
     let first_request_user_texts = json_message_input_texts(&requests[0], "user");
     let first_turn_user_index = first_request_user_texts
         .len()
@@ -418,17 +413,14 @@ async fn compact_resume_after_second_compaction_preserves_history() -> Result<()
     expected_fork_local_user_texts.extend_from_slice(seeded_user_prefix);
     expected_fork_local_user_texts.push("AFTER_COMPACT_2".to_string());
     let final_user_texts = json_message_input_texts(&requests[requests.len() - 1], "user");
->>>>>>> upstream_main
     let (final_last, final_prefix) = final_user_texts
         .split_last()
         .unwrap_or_else(|| panic!("after-second-resume request missing user messages"));
     assert_eq!(final_last, AFTER_SECOND_RESUME);
-<<<<<<< HEAD
     assert!(
         final_prefix.starts_with(&previous_compact_user_texts),
         "after-second-resume user texts should preserve the prior compact request user history",
     );
-=======
     let matched_prefix_len = if let Some(start) = final_prefix
         .windows(expected_after_second_compact_user_texts.len())
         .position(|window| window == expected_after_second_compact_user_texts)
@@ -684,7 +676,6 @@ async fn snapshot_rollback_followup_turn_trims_context_updates() -> Result<()> {
     );
 
     Ok(())
->>>>>>> upstream_main
 }
 
 fn normalize_line_endings(value: &mut Value) {
@@ -801,7 +792,6 @@ async fn mount_second_compact_sequence(server: &MockServer) -> ResponseMock {
     let sse7 = sse(vec![ev_completed("r7")]);
     let sse8 = sse(vec![ev_completed("r8")]);
 
-<<<<<<< HEAD
     // Match the second compaction request by the summarization prompt plus the
     // forked-history marker, while excluding the later resume turn.
     let match_second_compact = |req: &wiremock::Request| {
@@ -819,9 +809,7 @@ async fn mount_second_compact_sequence(server: &MockServer) -> ResponseMock {
     let after_second_resume = mount_sse_once_match(server, match_after_second_resume, sse7).await;
 
     vec![second_compact, after_second_resume]
-=======
     mount_sse_sequence(server, vec![sse1, sse2, sse3, sse4, sse5, sse6, sse7, sse8]).await
->>>>>>> upstream_main
 }
 
 async fn start_test_conversation(

--- a/codex-rs/core/tests/suite/exec_policy.rs
+++ b/codex-rs/core/tests/suite/exec_policy.rs
@@ -56,10 +56,7 @@ async fn submit_user_turn(
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode,
             personality: None,
         })
@@ -140,10 +137,7 @@ async fn execpolicy_blocks_shell_invocation() -> Result<()> {
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })

--- a/codex-rs/core/tests/suite/image_rollout.rs
+++ b/codex-rs/core/tests/suite/image_rollout.rs
@@ -127,10 +127,7 @@ async fn copy_paste_local_image_persists_rollout_request_shape() -> anyhow::Resu
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -214,10 +211,7 @@ async fn drag_drop_image_persists_rollout_request_shape() -> anyhow::Result<()> 
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })

--- a/codex-rs/core/tests/suite/items.rs
+++ b/codex-rs/core/tests/suite/items.rs
@@ -527,10 +527,7 @@ async fn plan_mode_emits_plan_item_from_proposed_plan_block() -> anyhow::Result<
             model: session_configured.model.clone(),
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: Some(collaboration_mode),
             personality: None,
         })
@@ -607,10 +604,7 @@ async fn plan_mode_strips_plan_from_agent_messages() -> anyhow::Result<()> {
             model: session_configured.model.clone(),
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: Some(collaboration_mode),
             personality: None,
         })
@@ -714,18 +708,12 @@ async fn plan_mode_streaming_citations_are_stripped_across_added_deltas_and_done
             final_output_json_schema: None,
             cwd: std::env::current_dir()?,
             approval_policy: codex_protocol::protocol::AskForApproval::Never,
-<<<<<<< HEAD
-=======
             approvals_reviewer: None,
->>>>>>> upstream_main
             sandbox_policy: codex_protocol::protocol::SandboxPolicy::DangerFullAccess,
             model: session_configured.model.clone(),
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: Some(collaboration_mode),
             personality: None,
         })
@@ -907,18 +895,12 @@ async fn plan_mode_streaming_proposed_plan_tag_split_across_added_and_delta_is_p
             final_output_json_schema: None,
             cwd: std::env::current_dir()?,
             approval_policy: codex_protocol::protocol::AskForApproval::Never,
-<<<<<<< HEAD
-=======
             approvals_reviewer: None,
->>>>>>> upstream_main
             sandbox_policy: codex_protocol::protocol::SandboxPolicy::DangerFullAccess,
             model: session_configured.model.clone(),
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: Some(collaboration_mode),
             personality: None,
         })
@@ -1032,10 +1014,7 @@ async fn plan_mode_handles_missing_plan_close_tag() -> anyhow::Result<()> {
             model: session_configured.model.clone(),
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: Some(collaboration_mode),
             personality: None,
         })

--- a/codex-rs/core/tests/suite/js_repl.rs
+++ b/codex-rs/core/tests/suite/js_repl.rs
@@ -1,11 +1,8 @@
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use anyhow::Result;
-<<<<<<< HEAD
 use codex_core::features::Feature;
-=======
 use codex_features::Feature;
->>>>>>> upstream_main
 use codex_protocol::protocol::EventMsg;
 use core_test_support::responses;
 use core_test_support::responses::ResponseMock;
@@ -35,8 +32,6 @@ fn custom_tool_output_text_and_success(
     (output.unwrap_or_default(), success)
 }
 
-<<<<<<< HEAD
-=======
 fn assert_js_repl_ok(req: &ResponsesRequest, call_id: &str, expected_output: &str) {
     let (output, success) = custom_tool_output_text_and_success(req, call_id);
     assert_ne!(
@@ -53,7 +48,6 @@ fn assert_js_repl_err(req: &ResponsesRequest, call_id: &str, expected_output: &s
     assert!(output.contains(expected_output), "output was: {output}");
 }
 
->>>>>>> upstream_main
 fn tool_names(body: &serde_json::Value) -> Vec<String> {
     body["tools"]
         .as_array()
@@ -125,7 +119,6 @@ async fn run_js_repl_sequence(
     responses::mount_sse_once(
         server,
         sse(vec![
-<<<<<<< HEAD
             ev_assistant_message("msg-1", "done"),
             ev_completed("resp-2"),
         ]),
@@ -207,8 +200,6 @@ async fn js_repl_persists_top_level_bindings_and_supports_tla() -> Result<()> {
     responses::mount_sse_once(
         &server,
         sse(vec![
-=======
->>>>>>> upstream_main
             ev_response_created("resp-1"),
             ev_custom_tool_call(calls[0].0, "js_repl", calls[0].1),
             ev_completed("resp-1"),

--- a/codex-rs/core/tests/suite/json_result.rs
+++ b/codex-rs/core/tests/suite/json_result.rs
@@ -85,10 +85,7 @@ async fn codex_returns_json_result(model: String) -> anyhow::Result<()> {
             model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })

--- a/codex-rs/core/tests/suite/live_reload.rs
+++ b/codex-rs/core/tests/suite/live_reload.rs
@@ -66,10 +66,7 @@ async fn submit_skill_turn(test: &TestCodex, skill_path: PathBuf, prompt: &str) 
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })

--- a/codex-rs/core/tests/suite/memories.rs
+++ b/codex-rs/core/tests/suite/memories.rs
@@ -1,11 +1,8 @@
 use anyhow::Result;
 use chrono::Duration as ChronoDuration;
 use chrono::Utc;
-<<<<<<< HEAD
 use codex_core::features::Feature;
-=======
 use codex_features::Feature;
->>>>>>> upstream_main
 use codex_protocol::ThreadId;
 use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::Op;
@@ -15,13 +12,10 @@ use core_test_support::responses::ResponsesRequest;
 use core_test_support::responses::ev_assistant_message;
 use core_test_support::responses::ev_completed;
 use core_test_support::responses::ev_response_created;
-<<<<<<< HEAD
 use core_test_support::responses::mount_sse_once;
-=======
 use core_test_support::responses::ev_web_search_call_done;
 use core_test_support::responses::mount_sse_once;
 use core_test_support::responses::mount_sse_sequence;
->>>>>>> upstream_main
 use core_test_support::responses::sse;
 use core_test_support::responses::start_mock_server;
 use core_test_support::test_codex::TestCodex;
@@ -167,13 +161,11 @@ async fn memories_startup_phase2_tracks_added_and_removed_inputs_across_runs() -
     Ok(())
 }
 
-<<<<<<< HEAD
 async fn build_test_codex(server: &wiremock::MockServer, home: Arc<TempDir>) -> Result<TestCodex> {
     let mut builder = test_codex().with_home(home).with_config(|config| {
         config.features.enable(Feature::Sqlite);
         config.features.enable(Feature::MemoryTool);
         config.memories.max_raw_memories_for_global = 1;
-=======
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn web_search_pollution_moves_selected_thread_into_removed_phase2_inputs() -> Result<()> {
     let server = start_mock_server().await;
@@ -348,19 +340,15 @@ async fn build_test_codex(server: &wiremock::MockServer, home: Arc<TempDir>) -> 
             .enable(Feature::MemoryTool)
             .expect("test config should allow feature update");
         config.memories.max_raw_memories_for_consolidation = 1;
->>>>>>> upstream_main
     });
     builder.build(server).await
 }
 
 async fn init_state_db(home: &Arc<TempDir>) -> Result<Arc<codex_state::StateRuntime>> {
     let db =
-<<<<<<< HEAD
         codex_state::StateRuntime::init(home.path().to_path_buf(), "test-provider".into(), None)
             .await?;
-=======
         codex_state::StateRuntime::init(home.path().to_path_buf(), "test-provider".into()).await?;
->>>>>>> upstream_main
     db.mark_backfill_complete(None).await?;
     Ok(db)
 }
@@ -386,7 +374,6 @@ async fn seed_stage1_output(
     let metadata = metadata_builder.build("test-provider");
     db.upsert_thread(&metadata).await?;
 
-<<<<<<< HEAD
     let claim = db
         .try_claim_stage1_job(
             thread_id,
@@ -413,7 +400,6 @@ async fn seed_stage1_output(
         .await?,
         "stage-1 success should enqueue global consolidation"
     );
-=======
     seed_stage1_output_for_existing_thread(
         db,
         thread_id,
@@ -423,13 +409,11 @@ async fn seed_stage1_output(
         Some(rollout_slug),
     )
     .await?;
->>>>>>> upstream_main
 
     Ok(thread_id)
 }
 
 async fn wait_for_single_request(mock: &ResponseMock) -> ResponsesRequest {
-<<<<<<< HEAD
     let deadline = Instant::now() + Duration::from_secs(10);
     loop {
         let requests = mock.requests();
@@ -439,7 +423,6 @@ async fn wait_for_single_request(mock: &ResponseMock) -> ResponsesRequest {
         assert!(
             Instant::now() < deadline,
             "timed out waiting for phase2 request"
-=======
     wait_for_request(mock, 1).await.remove(0)
 }
 
@@ -453,7 +436,6 @@ async fn wait_for_request(mock: &ResponseMock, expected_count: usize) -> Vec<Res
         assert!(
             Instant::now() < deadline,
             "timed out waiting for {expected_count} phase2 requests"
->>>>>>> upstream_main
         );
         tokio::time::sleep(Duration::from_millis(50)).await;
     }
@@ -491,8 +473,6 @@ async fn wait_for_phase2_success(
     }
 }
 
-<<<<<<< HEAD
-=======
 async fn seed_stage1_output_for_existing_thread(
     db: &codex_state::StateRuntime,
     thread_id: ThreadId,
@@ -526,7 +506,6 @@ async fn seed_stage1_output_for_existing_thread(
     Ok(())
 }
 
->>>>>>> upstream_main
 async fn read_rollout_summary_bodies(memory_root: &Path) -> Result<Vec<String>> {
     let mut dir = tokio::fs::read_dir(memory_root.join("rollout_summaries")).await?;
     let mut summaries = Vec::new();

--- a/codex-rs/core/tests/suite/model_switching.rs
+++ b/codex-rs/core/tests/suite/model_switching.rs
@@ -131,10 +131,7 @@ async fn model_change_appends_model_instructions_developer_message() -> Result<(
             model: test.session_configured.model.clone(),
             effort: test.config.model_reasoning_effort,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -171,10 +168,7 @@ async fn model_change_appends_model_instructions_developer_message() -> Result<(
             model: next_model.to_string(),
             effort: test.config.model_reasoning_effort,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -234,10 +228,7 @@ async fn model_and_personality_change_only_appends_model_instructions() -> Resul
             model: test.session_configured.model.clone(),
             effort: test.config.model_reasoning_effort,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -274,10 +265,7 @@ async fn model_and_personality_change_only_appends_model_instructions() -> Resul
             model: next_model.to_string(),
             effort: test.config.model_reasoning_effort,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -361,7 +349,6 @@ async fn model_change_from_image_to_text_strips_prior_image_content() -> Result<
     let server = MockServer::start().await;
     let image_model_slug = "test-image-model";
     let text_model_slug = "test-text-only-model";
-<<<<<<< HEAD
     let image_model = ModelInfo {
         slug: image_model_slug.to_string(),
         display_name: "Test Image Model".to_string(),
@@ -399,7 +386,6 @@ async fn model_change_from_image_to_text_strips_prior_image_content() -> Result<
     text_model.display_name = "Test Text Model".to_string();
     text_model.description = Some("text only".to_string());
     text_model.input_modalities = vec![InputModality::Text];
-=======
     let image_model = test_model_info(
         image_model_slug,
         "Test Image Model",
@@ -412,7 +398,6 @@ async fn model_change_from_image_to_text_strips_prior_image_content() -> Result<
         "text only",
         vec![InputModality::Text],
     );
->>>>>>> upstream_main
     mount_models_once(
         &server,
         ModelsResponse {
@@ -459,10 +444,7 @@ async fn model_change_from_image_to_text_strips_prior_image_content() -> Result<
             model: image_model_slug.to_string(),
             effort: test.config.model_reasoning_effort,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -483,10 +465,7 @@ async fn model_change_from_image_to_text_strips_prior_image_content() -> Result<
             model: text_model_slug.to_string(),
             effort: test.config.model_reasoning_effort,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -1044,10 +1023,7 @@ async fn model_switch_to_smaller_model_updates_token_context_window() -> Result<
             model: large_model_slug.to_string(),
             effort: test.config.model_reasoning_effort,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -1106,10 +1082,7 @@ async fn model_switch_to_smaller_model_updates_token_context_window() -> Result<
             model: smaller_model_slug.to_string(),
             effort: test.config.model_reasoning_effort,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })

--- a/codex-rs/core/tests/suite/model_visible_layout.rs
+++ b/codex-rs/core/tests/suite/model_visible_layout.rs
@@ -5,11 +5,8 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use codex_core::config::types::Personality;
-<<<<<<< HEAD
 use codex_core::features::Feature;
-=======
 use codex_features::Feature;
->>>>>>> upstream_main
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::Op;
@@ -130,10 +127,7 @@ async fn snapshot_model_visible_layout_turn_overrides() -> Result<()> {
             model: test.session_configured.model.clone(),
             effort: test.config.model_reasoning_effort,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -157,10 +151,7 @@ async fn snapshot_model_visible_layout_turn_overrides() -> Result<()> {
             model: test.session_configured.model.clone(),
             effort: test.config.model_reasoning_effort,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: Some(Personality::Friendly),
         })
@@ -239,10 +230,7 @@ async fn snapshot_model_visible_layout_cwd_change_does_not_refresh_agents() -> R
             model: test.session_configured.model.clone(),
             effort: test.config.model_reasoning_effort,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -266,10 +254,7 @@ async fn snapshot_model_visible_layout_cwd_change_does_not_refresh_agents() -> R
             model: test.session_configured.model.clone(),
             effort: test.config.model_reasoning_effort,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -379,10 +364,7 @@ async fn snapshot_model_visible_layout_resume_with_personality_change() -> Resul
             model: resumed.session_configured.model.clone(),
             effort: resumed.config.model_reasoning_effort,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: Some(Personality::Friendly),
         })

--- a/codex-rs/core/tests/suite/models_cache_ttl.rs
+++ b/codex-rs/core/tests/suite/models_cache_ttl.rs
@@ -101,10 +101,7 @@ async fn renews_cache_ttl_on_matching_models_etag() -> Result<()> {
             model: test.session_configured.model.clone(),
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })

--- a/codex-rs/core/tests/suite/models_etag_responses.rs
+++ b/codex-rs/core/tests/suite/models_etag_responses.rs
@@ -107,10 +107,7 @@ async fn refresh_models_on_models_etag_mismatch_and_avoid_duplicate_models_fetch
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })

--- a/codex-rs/core/tests/suite/personality.rs
+++ b/codex-rs/core/tests/suite/personality.rs
@@ -108,10 +108,7 @@ async fn user_turn_personality_none_does_not_add_update_message() -> anyhow::Res
             model: test.session_configured.model.clone(),
             effort: test.config.model_reasoning_effort,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -162,10 +159,7 @@ async fn config_personality_some_sets_instructions_template() -> anyhow::Result<
             model: test.session_configured.model.clone(),
             effort: test.config.model_reasoning_effort,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -223,10 +217,7 @@ async fn config_personality_none_sends_no_personality() -> anyhow::Result<()> {
             model: test.session_configured.model.clone(),
             effort: test.config.model_reasoning_effort,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -290,10 +281,7 @@ async fn default_personality_is_pragmatic_without_config_toml() -> anyhow::Resul
             model: test.session_configured.model.clone(),
             effort: test.config.model_reasoning_effort,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -345,10 +333,7 @@ async fn user_turn_personality_some_adds_update_message() -> anyhow::Result<()> 
             model: test.session_configured.model.clone(),
             effort: test.config.model_reasoning_effort,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -386,10 +371,7 @@ async fn user_turn_personality_some_adds_update_message() -> anyhow::Result<()> 
             model: test.session_configured.model.clone(),
             effort: test.config.model_reasoning_effort,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -456,10 +438,7 @@ async fn user_turn_personality_same_value_does_not_add_update_message() -> anyho
             model: test.session_configured.model.clone(),
             effort: test.config.model_reasoning_effort,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -497,10 +476,7 @@ async fn user_turn_personality_same_value_does_not_add_update_message() -> anyho
             model: test.session_configured.model.clone(),
             effort: test.config.model_reasoning_effort,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -580,10 +556,7 @@ async fn user_turn_personality_skips_if_feature_disabled() -> anyhow::Result<()>
             model: test.session_configured.model.clone(),
             effort: test.config.model_reasoning_effort,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -621,10 +594,7 @@ async fn user_turn_personality_skips_if_feature_disabled() -> anyhow::Result<()>
             model: test.session_configured.model.clone(),
             effort: test.config.model_reasoning_effort,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -741,10 +711,7 @@ async fn remote_model_friendly_personality_instructions_with_feature() -> anyhow
             model: remote_slug.to_string(),
             effort: test.config.model_reasoning_effort,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: Some(Personality::Friendly),
         })
@@ -863,10 +830,7 @@ async fn user_turn_personality_remote_model_template_includes_update_message() -
             model: remote_slug.to_string(),
             effort: test.config.model_reasoning_effort,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -904,10 +868,7 @@ async fn user_turn_personality_remote_model_template_includes_update_message() -
             model: remote_slug.to_string(),
             effort: test.config.model_reasoning_effort,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })

--- a/codex-rs/core/tests/suite/prompt_caching.rs
+++ b/codex-rs/core/tests/suite/prompt_caching.rs
@@ -708,10 +708,7 @@ async fn per_turn_overrides_keep_cached_prefix_and_key_constant() -> anyhow::Res
             model: "o3".to_string(),
             effort: Some(ReasoningEffort::High),
             summary: Some(ReasoningSummary::Detailed),
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             final_output_json_schema: None,
             personality: None,
@@ -824,10 +821,7 @@ async fn send_user_turn_with_no_changes_does_not_send_environment_context() -> a
             model: default_model.clone(),
             effort: default_effort,
             summary: Some(default_summary.unwrap_or(ReasoningSummary::Auto)),
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             final_output_json_schema: None,
             personality: None,
@@ -848,10 +842,7 @@ async fn send_user_turn_with_no_changes_does_not_send_environment_context() -> a
             model: default_model.clone(),
             effort: default_effort,
             summary: Some(default_summary.unwrap_or(ReasoningSummary::Auto)),
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             final_output_json_schema: None,
             personality: None,
@@ -956,10 +947,7 @@ async fn send_user_turn_with_changes_sends_environment_context() -> anyhow::Resu
             model: default_model,
             effort: default_effort,
             summary: Some(default_summary.unwrap_or(ReasoningSummary::Auto)),
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             final_output_json_schema: None,
             personality: None,
@@ -980,10 +968,7 @@ async fn send_user_turn_with_changes_sends_environment_context() -> anyhow::Resu
             model: "o3".to_string(),
             effort: Some(ReasoningEffort::High),
             summary: Some(ReasoningSummary::Detailed),
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             final_output_json_schema: None,
             personality: None,

--- a/codex-rs/core/tests/suite/realtime_conversation.rs
+++ b/codex-rs/core/tests/suite/realtime_conversation.rs
@@ -1780,7 +1780,6 @@ async fn delegated_turn_user_role_echo_does_not_redelegate_and_still_forwards_au
     let mirrored_request = realtime_server.wait_for_request(0, 1).await;
     let mirrored_request_body = mirrored_request.body_json();
     eprintln!(
-<<<<<<< HEAD
         "[realtime test +{}ms] saw mirrored request type={:?} role={:?} text={:?} data={:?}",
         start.elapsed().as_millis(),
         mirrored_request_body["type"].as_str(),
@@ -1795,7 +1794,6 @@ async fn delegated_turn_user_role_echo_does_not_redelegate_and_still_forwards_au
     assert_eq!(
         mirrored_request_body["item"]["content"][0]["text"].as_str(),
         Some("assistant says hi")
-=======
         "[realtime test +{}ms] saw mirrored request type={:?} handoff_id={:?} text={:?}",
         start.elapsed().as_millis(),
         mirrored_request_body["type"].as_str(),
@@ -1813,7 +1811,6 @@ async fn delegated_turn_user_role_echo_does_not_redelegate_and_still_forwards_au
     assert_eq!(
         mirrored_request_body["output_text"].as_str(),
         Some("\"Agent Final Message\":\n\nassistant says hi")
->>>>>>> upstream_main
     );
 
     let audio_out = wait_for_event_match(&test.codex, |msg| match msg {

--- a/codex-rs/core/tests/suite/remote_models.rs
+++ b/codex-rs/core/tests/suite/remote_models.rs
@@ -178,10 +178,7 @@ async fn remote_models_long_model_slug_is_sent_with_high_reasoning() -> Result<(
             model: requested_model.to_string(),
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -244,10 +241,7 @@ async fn namespaced_model_slug_uses_catalog_metadata_without_fallback_warning() 
                     .model_reasoning_summary
                     .unwrap_or(ReasoningSummary::Auto),
             ),
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -407,10 +401,7 @@ async fn remote_models_remote_model_uses_unified_exec() -> Result<()> {
             model: REMOTE_MODEL_SLUG.to_string(),
             effort: None,
             summary: Some(ReasoningSummary::Auto),
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -629,10 +620,7 @@ async fn remote_models_apply_remote_base_instructions() -> Result<()> {
             model: model.to_string(),
             effort: None,
             summary: Some(ReasoningSummary::Auto),
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })

--- a/codex-rs/core/tests/suite/request_permissions.rs
+++ b/codex-rs/core/tests/suite/request_permissions.rs
@@ -3,10 +3,7 @@
 use anyhow::Result;
 use codex_core::config::Constrained;
 use codex_core::sandboxing::SandboxPermissions;
-<<<<<<< HEAD
-=======
 use codex_features::Feature;
->>>>>>> upstream_main
 use codex_protocol::models::FileSystemPermissions;
 use codex_protocol::models::PermissionProfile;
 use codex_protocol::protocol::AskForApproval;
@@ -104,9 +101,7 @@ fn shell_event_with_request_permissions<S: serde::Serialize>(
     Ok(ev_function_call(call_id, "shell_command", &args_str))
 }
 
-<<<<<<< HEAD
 #[cfg(target_os = "macos")]
-=======
 fn request_permissions_tool_event(
     call_id: &str,
     reason: &str,
@@ -166,7 +161,6 @@ fn exec_command_event_with_missing_additional_permissions(
     Ok(ev_function_call(call_id, "exec_command", &args_str))
 }
 
->>>>>>> upstream_main
 fn shell_event_with_raw_request_permissions(
     call_id: &str,
     command: &str,
@@ -205,10 +199,7 @@ async fn submit_turn(
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -354,11 +345,8 @@ async fn with_additional_permissions_requires_approval_under_on_request() -> Res
     let requested_permissions = PermissionProfile {
         file_system: Some(FileSystemPermissions {
             read: Some(vec![]),
-<<<<<<< HEAD
             write: Some(vec![absolute_path(&requested_write)]),
-=======
             write: Some(vec![absolute_path(&requested_dir_canonical)]),
->>>>>>> upstream_main
         }),
         ..Default::default()
     };
@@ -413,20 +401,15 @@ async fn with_additional_permissions_requires_approval_under_on_request() -> Res
 }
 
 #[tokio::test(flavor = "current_thread")]
-<<<<<<< HEAD
 #[cfg(target_os = "macos")]
 async fn relative_additional_permissions_resolve_against_tool_workdir() -> Result<()> {
-=======
 async fn request_permissions_tool_is_auto_denied_when_granular_request_permissions_is_disabled()
 -> Result<()> {
->>>>>>> upstream_main
     skip_if_no_network!(Ok(()));
     skip_if_sandbox!(Ok(()));
 
     let server = start_mock_server().await;
-<<<<<<< HEAD
     let approval_policy = AskForApproval::OnRequest;
-=======
     let approval_policy = AskForApproval::Granular(GranularApprovalConfig {
         sandbox_approval: true,
         rules: true,
@@ -434,14 +417,12 @@ async fn request_permissions_tool_is_auto_denied_when_granular_request_permissio
         request_permissions: false,
         mcp_elicitations: true,
     });
->>>>>>> upstream_main
     let sandbox_policy = SandboxPolicy::new_read_only_policy();
     let sandbox_policy_for_config = sandbox_policy.clone();
 
     let mut builder = test_codex().with_config(move |config| {
         config.permissions.approval_policy = Constrained::allow_any(approval_policy);
         config.permissions.sandbox_policy = Constrained::allow_any(sandbox_policy_for_config);
-<<<<<<< HEAD
         config.features.enable(Feature::RequestPermissions);
     });
     let test = builder.build(&server).await?;
@@ -469,7 +450,6 @@ async fn request_permissions_tool_is_auto_denied_when_granular_request_permissio
                 "write": ["./relative-write.txt"],
             },
         }),
-=======
         config
             .features
             .enable(Feature::RequestPermissionsTool)
@@ -485,39 +465,31 @@ async fn request_permissions_tool_is_auto_denied_when_granular_request_permissio
         call_id,
         "Request access through the standalone tool",
         &requested_permissions,
->>>>>>> upstream_main
     )?;
 
     let _ = mount_sse_once(
         &server,
         sse(vec![
-<<<<<<< HEAD
             ev_response_created("resp-relative-1"),
             event,
             ev_completed("resp-relative-1"),
-=======
             ev_response_created("resp-request-permissions-reject-1"),
             event,
             ev_completed("resp-request-permissions-reject-1"),
->>>>>>> upstream_main
         ]),
     )
     .await;
     let results = mount_sse_once(
         &server,
         sse(vec![
-<<<<<<< HEAD
             ev_assistant_message("msg-relative-1", "done"),
             ev_completed("resp-relative-2"),
-=======
             ev_assistant_message("msg-request-permissions-reject-1", "done"),
             ev_completed("resp-request-permissions-reject-2"),
->>>>>>> upstream_main
         ]),
     )
     .await;
 
-<<<<<<< HEAD
     submit_turn(&test, call_id, approval_policy, sandbox_policy.clone()).await?;
 
     let approval = expect_exec_approval(&test, command).await;
@@ -544,7 +516,6 @@ async fn request_permissions_tool_is_auto_denied_when_granular_request_permissio
     assert!(
         requested_write.exists(),
         "touch command should create requested path"
-=======
     submit_turn(
         &test,
         "request permissions under granular.request_permissions = false",
@@ -574,19 +545,15 @@ async fn request_permissions_tool_is_auto_denied_when_granular_request_permissio
             permissions: RequestPermissionProfile::default(),
             scope: PermissionGrantScope::Turn,
         }
->>>>>>> upstream_main
     );
 
     Ok(())
 }
 
 #[tokio::test(flavor = "current_thread")]
-<<<<<<< HEAD
 #[cfg(target_os = "macos")]
 async fn read_only_with_additional_permissions_widens_to_unrequested_cwd_write() -> Result<()> {
-=======
 async fn relative_additional_permissions_resolve_against_tool_workdir() -> Result<()> {
->>>>>>> upstream_main
     skip_if_no_network!(Ok(()));
     skip_if_sandbox!(Ok(()));
 

--- a/codex-rs/core/tests/suite/request_user_input.rs
+++ b/codex-rs/core/tests/suite/request_user_input.rs
@@ -88,14 +88,11 @@ async fn request_user_input_round_trip_for_mode(mode: ModeKind) -> anyhow::Resul
     } = builder
         .with_config(move |config| {
             if mode == ModeKind::Default {
-<<<<<<< HEAD
                 config.features.enable(Feature::DefaultModeRequestUserInput);
-=======
                 config
                     .features
                     .enable(Feature::DefaultModeRequestUserInput)
                     .expect("test config should allow feature update");
->>>>>>> upstream_main
             }
         })
         .build(&server)
@@ -147,10 +144,7 @@ async fn request_user_input_round_trip_for_mode(mode: ModeKind) -> anyhow::Resul
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: Some(CollaborationMode {
                 mode,
                 settings: Settings {
@@ -268,10 +262,7 @@ where
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: Some(collaboration_mode),
             personality: None,
         })

--- a/codex-rs/core/tests/suite/rmcp_client.rs
+++ b/codex-rs/core/tests/suite/rmcp_client.rs
@@ -134,10 +134,7 @@ async fn stdio_server_round_trip() -> anyhow::Result<()> {
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -307,10 +304,7 @@ async fn stdio_image_responses_round_trip() -> anyhow::Result<()> {
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -514,10 +508,7 @@ async fn stdio_image_responses_are_sanitized_for_text_only_model() -> anyhow::Re
             model: text_only_model_slug.to_string(),
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -632,10 +623,7 @@ async fn stdio_server_propagates_whitelisted_env_vars() -> anyhow::Result<()> {
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -797,10 +785,7 @@ async fn streamable_http_tool_call_round_trip() -> anyhow::Result<()> {
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -1047,10 +1032,7 @@ async fn streamable_http_with_oauth_round_trip_impl() -> anyhow::Result<()> {
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })

--- a/codex-rs/core/tests/suite/safety_check_downgrade.rs
+++ b/codex-rs/core/tests/suite/safety_check_downgrade.rs
@@ -50,10 +50,7 @@ async fn openai_model_header_mismatch_emits_warning_event_and_warning_item() -> 
             model: REQUESTED_MODEL.to_string(),
             effort: test.config.model_reasoning_effort,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -152,10 +149,7 @@ async fn response_model_field_mismatch_emits_warning_when_header_matches_request
             model: REQUESTED_MODEL.to_string(),
             effort: test.config.model_reasoning_effort,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -241,10 +235,7 @@ async fn openai_model_header_mismatch_only_emits_one_warning_per_turn() -> Resul
             model: REQUESTED_MODEL.to_string(),
             effort: test.config.model_reasoning_effort,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -294,10 +285,7 @@ async fn openai_model_header_casing_only_mismatch_does_not_warn() -> Result<()> 
             model: REQUESTED_MODEL.to_string(),
             effort: test.config.model_reasoning_effort,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })

--- a/codex-rs/core/tests/suite/search_tool.rs
+++ b/codex-rs/core/tests/suite/search_tool.rs
@@ -86,7 +86,6 @@ fn tool_search_output_tools(request: &ResponsesRequest, call_id: &str) -> Vec<Va
         .unwrap_or_default()
 }
 
-<<<<<<< HEAD
 fn rmcp_server_config(command: String) -> McpServerConfig {
     McpServerConfig {
         transport: McpServerTransportConfig::Stdio {
@@ -115,13 +114,11 @@ fn configure_apps_with_optional_rmcp(
 ) {
     config.features.enable(Feature::Apps);
     config.features.disable(Feature::AppsMcpGateway);
-=======
 fn configure_apps(config: &mut Config, apps_base_url: &str) {
     config
         .features
         .enable(Feature::Apps)
         .expect("test config should allow feature update");
->>>>>>> upstream_main
     config.chatgpt_base_url = apps_base_url.to_string();
     config.model = Some("gpt-5-codex".to_string());
 

--- a/codex-rs/core/tests/suite/shell_snapshot.rs
+++ b/codex-rs/core/tests/suite/shell_snapshot.rs
@@ -1,9 +1,6 @@
 use anyhow::Result;
-<<<<<<< HEAD
 use codex_core::features::Feature;
-=======
 use codex_features::Feature;
->>>>>>> upstream_main
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::ExecCommandBeginEvent;
@@ -173,10 +170,7 @@ async fn run_snapshot_command_with_options(
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -267,10 +261,7 @@ async fn run_shell_command_snapshot_with_options(
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -341,10 +332,7 @@ async fn run_tool_turn_on_harness(
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -578,10 +566,7 @@ async fn shell_command_snapshot_still_intercepts_apply_patch() -> Result<()> {
             model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })

--- a/codex-rs/core/tests/suite/skill_approval.rs
+++ b/codex-rs/core/tests/suite/skill_approval.rs
@@ -7,11 +7,8 @@ use codex_protocol::models::PermissionProfile;
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::ExecApprovalRequestEvent;
-<<<<<<< HEAD
-=======
 use codex_protocol::protocol::ExecApprovalRequestSkillMetadata;
 use codex_protocol::protocol::GranularApprovalConfig;
->>>>>>> upstream_main
 use codex_protocol::protocol::Op;
 use codex_protocol::protocol::ReviewDecision;
 use codex_protocol::protocol::SandboxPolicy;
@@ -68,18 +65,12 @@ async fn submit_turn_with_policies(
             final_output_json_schema: None,
             cwd: test.cwd_path().to_path_buf(),
             approval_policy,
-<<<<<<< HEAD
-=======
             approvals_reviewer: None,
->>>>>>> upstream_main
             sandbox_policy,
             model: test.session_configured.model.clone(),
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -253,8 +244,6 @@ permissions:
             ..Default::default()
         })
     );
-<<<<<<< HEAD
-=======
     assert_eq!(
         approval.skill_metadata,
         Some(ExecApprovalRequestSkillMetadata {
@@ -263,7 +252,6 @@ permissions:
                 .join("skills/mbolin-test-skill/agents/openai.yaml"),
         })
     );
->>>>>>> upstream_main
 
     test.codex
         .submit(Op::ExecApproval {
@@ -288,7 +276,6 @@ permissions:
     Ok(())
 }
 
-<<<<<<< HEAD
 /// Look for `additional_permissions == None`, then verify that both the first
 /// run and the cached session-approval rerun stay inside the turn sandbox.
 #[cfg(unix)]
@@ -340,7 +327,6 @@ async fn shell_zsh_fork_skill_without_permissions_inherits_turn_sandbox() -> Res
         first_call_id,
         &first_arguments,
         "shell_command",
-=======
 #[cfg(unix)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn shell_zsh_fork_skill_script_reject_policy_with_sandbox_approval_false_still_prompts()
@@ -379,7 +365,6 @@ permissions:
             )
             .unwrap();
         },
->>>>>>> upstream_main
     )
     .await?;
 
@@ -413,7 +398,6 @@ permissions:
     assert_eq!(approval.call_id, tool_call_id);
     assert_eq!(approval.command, vec![script_path_str]);
 
-<<<<<<< HEAD
     submit_turn_with_policies(
         &test,
         "use $mbolin-test-skill",
@@ -431,13 +415,10 @@ permissions:
     assert_eq!(approval.command, vec![script_path_str.clone()]);
     assert_eq!(approval.additional_permissions, None);
 
-=======
->>>>>>> upstream_main
     test.codex
         .submit(Op::ExecApproval {
             id: approval.effective_approval_id(),
             turn_id: None,
-<<<<<<< HEAD
             decision: ReviewDecision::ApprovedForSession,
         })
         .await?;
@@ -482,7 +463,6 @@ permissions:
     assert!(
         cached_approval.is_none(),
         "expected second run to reuse the cached session approval"
-=======
             decision: ReviewDecision::Denied,
         })
         .await?;
@@ -781,7 +761,6 @@ async fn shell_zsh_fork_skill_without_permissions_inherits_turn_sandbox() -> Res
     assert!(
         cached_approval.is_none(),
         "expected permissionless skill rerun to continue skipping exec approval"
->>>>>>> upstream_main
     );
 
     let second_output = second_mocks
@@ -803,8 +782,6 @@ async fn shell_zsh_fork_skill_without_permissions_inherits_turn_sandbox() -> Res
     Ok(())
 }
 
-<<<<<<< HEAD
-=======
 /// Empty skill permissions should behave like no skill override and inherit the
 /// turn sandbox without prompting.
 #[cfg(unix)]
@@ -930,7 +907,6 @@ async fn shell_zsh_fork_skill_with_empty_permissions_inherits_turn_sandbox() -> 
     Ok(())
 }
 
->>>>>>> upstream_main
 /// The validation to focus on is: writes to the skill-approved folder succeed,
 /// and writes to an unrelated folder fail, both before and after cached approval.
 #[cfg(unix)]

--- a/codex-rs/core/tests/suite/skills.rs
+++ b/codex-rs/core/tests/suite/skills.rs
@@ -79,10 +79,7 @@ async fn user_turn_includes_skill_instructions() -> Result<()> {
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })

--- a/codex-rs/core/tests/suite/subagent_notifications.rs
+++ b/codex-rs/core/tests/suite/subagent_notifications.rs
@@ -345,14 +345,11 @@ async fn spawned_child_receives_forked_parent_context() -> Result<()> {
     .await;
 
     let mut builder = test_codex().with_config(|config| {
-<<<<<<< HEAD
         config.features.enable(Feature::Collab);
-=======
         config
             .features
             .enable(Feature::Collab)
             .expect("test config should allow feature update");
->>>>>>> upstream_main
     });
     let test = builder.build(&server).await?;
 
@@ -409,8 +406,6 @@ async fn spawned_child_receives_forked_parent_context() -> Result<()> {
 
     Ok(())
 }
-<<<<<<< HEAD
-=======
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn spawn_agent_requested_model_and_reasoning_override_inherited_settings_without_role()
@@ -534,4 +529,3 @@ async fn spawn_agent_tool_description_mentions_role_locked_settings() -> Result<
 
     Ok(())
 }
->>>>>>> upstream_main

--- a/codex-rs/core/tests/suite/tool_harness.rs
+++ b/codex-rs/core/tests/suite/tool_harness.rs
@@ -3,11 +3,8 @@
 use std::fs;
 
 use assert_matches::assert_matches;
-<<<<<<< HEAD
 use codex_core::features::Feature;
-=======
 use codex_features::Feature;
->>>>>>> upstream_main
 use codex_protocol::plan_tool::StepStatus;
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::EventMsg;
@@ -94,10 +91,7 @@ async fn shell_tool_executes_command_and_streams_output() -> anyhow::Result<()> 
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -168,10 +162,7 @@ async fn update_plan_tool_emits_plan_update_event() -> anyhow::Result<()> {
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -252,10 +243,7 @@ async fn update_plan_tool_rejects_malformed_payload() -> anyhow::Result<()> {
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -351,10 +339,7 @@ async fn apply_patch_tool_executes_and_emits_patch_events() -> anyhow::Result<()
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -458,10 +443,7 @@ async fn apply_patch_reports_parse_diagnostics() -> anyhow::Result<()> {
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })

--- a/codex-rs/core/tests/suite/tool_parallelism.rs
+++ b/codex-rs/core/tests/suite/tool_parallelism.rs
@@ -47,10 +47,7 @@ async fn run_turn(test: &TestCodex, prompt: &str) -> anyhow::Result<()> {
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -367,10 +364,7 @@ async fn shell_tools_start_before_response_completed_when_stream_delayed() -> an
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })

--- a/codex-rs/core/tests/suite/truncation.rs
+++ b/codex-rs/core/tests/suite/truncation.rs
@@ -491,10 +491,7 @@ async fn mcp_image_output_preserves_image_and_no_text_summary() -> Result<()> {
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })

--- a/codex-rs/core/tests/suite/unified_exec.rs
+++ b/codex-rs/core/tests/suite/unified_exec.rs
@@ -4,11 +4,8 @@ use std::fs;
 
 use anyhow::Context;
 use anyhow::Result;
-<<<<<<< HEAD
 use codex_core::features::Feature;
-=======
 use codex_features::Feature;
->>>>>>> upstream_main
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::ExecCommandSource;
@@ -201,10 +198,7 @@ async fn unified_exec_intercepts_apply_patch_exec_command() -> Result<()> {
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -338,10 +332,7 @@ async fn unified_exec_emits_exec_command_begin_event() -> Result<()> {
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -424,10 +415,7 @@ async fn unified_exec_resolves_relative_workdir() -> Result<()> {
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -513,10 +501,7 @@ async fn unified_exec_respects_workdir_override() -> Result<()> {
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -614,10 +599,7 @@ async fn unified_exec_emits_exec_command_end_event() -> Result<()> {
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -697,10 +679,7 @@ async fn unified_exec_emits_output_delta_for_exec_command() -> Result<()> {
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -781,10 +760,7 @@ async fn unified_exec_full_lifecycle_with_background_end_event() -> Result<()> {
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -919,10 +895,7 @@ async fn unified_exec_emits_terminal_interaction_for_write_stdin() -> Result<()>
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -1064,10 +1037,7 @@ async fn unified_exec_terminal_interaction_captures_delayed_output() -> Result<(
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -1232,10 +1202,7 @@ async fn unified_exec_emits_one_begin_and_one_end_event() -> Result<()> {
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -1338,10 +1305,7 @@ async fn exec_command_reports_chunk_and_exit_metadata() -> Result<()> {
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -1464,10 +1428,7 @@ async fn unified_exec_defaults_to_pipe() -> Result<()> {
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -1562,10 +1523,7 @@ async fn unified_exec_can_enable_tty() -> Result<()> {
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -1651,10 +1609,7 @@ async fn unified_exec_respects_early_exit_notifications() -> Result<()> {
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -1790,10 +1745,7 @@ async fn write_stdin_returns_exit_metadata_and_clears_session() -> Result<()> {
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -1966,10 +1918,7 @@ async fn unified_exec_emits_end_event_when_session_dies_via_stdin() -> Result<()
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -2051,10 +2000,7 @@ async fn unified_exec_keeps_long_running_session_after_turn_end() -> Result<()> 
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -2147,10 +2093,7 @@ async fn unified_exec_interrupt_preserves_long_running_session() -> Result<()> {
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -2259,10 +2202,7 @@ async fn unified_exec_reuses_session_via_stdin() -> Result<()> {
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -2402,10 +2342,7 @@ PY
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -2524,10 +2461,7 @@ async fn unified_exec_timeout_and_followup_poll() -> Result<()> {
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -2628,10 +2562,7 @@ PY
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -2732,10 +2663,7 @@ async fn unified_exec_runs_under_sandbox() -> Result<()> {
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -2844,10 +2772,7 @@ async fn unified_exec_python_prompt_under_seatbelt() -> Result<()> {
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -2947,10 +2872,7 @@ async fn unified_exec_runs_on_all_platforms() -> Result<()> {
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -3090,10 +3012,7 @@ async fn unified_exec_prunes_exited_sessions_first() -> Result<()> {
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })

--- a/codex-rs/core/tests/suite/user_shell_cmd.rs
+++ b/codex-rs/core/tests/suite/user_shell_cmd.rs
@@ -1,10 +1,7 @@
 use anyhow::Context;
-<<<<<<< HEAD
 use codex_core::features::Feature;
-=======
 use codex_features::Feature;
 use codex_protocol::permissions::NetworkSandboxPolicy;
->>>>>>> upstream_main
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::ExecCommandEndEvent;
@@ -185,10 +182,7 @@ async fn user_shell_command_does_not_replace_active_turn() -> anyhow::Result<()>
             model: fixture.session_configured.model.clone(),
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })

--- a/codex-rs/core/tests/suite/view_image.rs
+++ b/codex-rs/core/tests/suite/view_image.rs
@@ -175,10 +175,7 @@ async fn user_turn_with_local_image_attaches_image() -> anyhow::Result<()> {
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -287,10 +284,7 @@ async fn view_image_tool_attaches_local_image() -> anyhow::Result<()> {
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -935,10 +929,7 @@ await codex.emitImage(out);
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -1151,10 +1142,7 @@ async fn view_image_tool_errors_when_path_is_directory() -> anyhow::Result<()> {
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -1230,10 +1218,7 @@ async fn view_image_tool_errors_for_non_image_files() -> anyhow::Result<()> {
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -1314,10 +1299,7 @@ async fn view_image_tool_errors_when_file_missing() -> anyhow::Result<()> {
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -1440,10 +1422,7 @@ async fn view_image_tool_returns_unsupported_message_for_text_only_model() -> an
             model: model_slug.to_string(),
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })
@@ -1518,10 +1497,7 @@ async fn replaces_invalid_local_image_after_bad_request() -> anyhow::Result<()> 
             model: session_model,
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })

--- a/codex-rs/core/tests/suite/websocket_fallback.rs
+++ b/codex-rs/core/tests/suite/websocket_fallback.rs
@@ -1,8 +1,5 @@
 use anyhow::Result;
-<<<<<<< HEAD
 use codex_core::features::Feature;
-=======
->>>>>>> upstream_main
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::Op;
@@ -165,10 +162,7 @@ async fn websocket_fallback_hides_first_websocket_retry_stream_error() -> Result
             model: session_configured.model.clone(),
             effort: None,
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier: None,
->>>>>>> upstream_main
             collaboration_mode: None,
             personality: None,
         })

--- a/codex-rs/exec/src/event_processor_with_human_output.rs
+++ b/codex-rs/exec/src/event_processor_with_human_output.rs
@@ -15,7 +15,6 @@ use codex_protocol::protocol::SandboxPolicy;
 use codex_protocol::protocol::SessionConfiguredEvent;
 use owo_colors::OwoColorize;
 use owo_colors::Style;
-<<<<<<< HEAD
 use serde::Deserialize;
 use shlex::try_join;
 use std::collections::HashMap;
@@ -24,8 +23,6 @@ use std::io::Write;
 use std::path::PathBuf;
 use std::time::Duration;
 use std::time::Instant;
-=======
->>>>>>> upstream_main
 
 use crate::event_processor::CodexStatus;
 use crate::event_processor::EventProcessor;
@@ -370,7 +367,6 @@ impl EventProcessor for EventProcessorWithHumanOutput {
                 }
                 CodexStatus::Running
             }
-<<<<<<< HEAD
             EventMsg::ViewImageToolCall(view) => {
                 ts_msg!(
                     self,
@@ -594,10 +590,8 @@ impl EventProcessor for EventProcessorWithHumanOutput {
             | EventMsg::RealtimeConversationClosed(_)
             | EventMsg::DynamicToolCallRequest(_)
             | EventMsg::DynamicToolCallResponse(_) => {}
-=======
             ServerNotification::TurnStarted(_) => CodexStatus::Running,
             _ => CodexStatus::Running,
->>>>>>> upstream_main
         }
     }
 
@@ -624,7 +618,6 @@ impl EventProcessor for EventProcessorWithHumanOutput {
             );
         }
 
-<<<<<<< HEAD
         // In interactive terminals we already emitted the final assistant
         // message on stderr during event processing. Preserve stdout emission
         // only for non-interactive use so pipes and scripts still receive the
@@ -640,7 +633,6 @@ impl EventProcessor for EventProcessorWithHumanOutput {
                 print!("{message}");
             } else {
                 println!("{message}");
-=======
         #[allow(clippy::print_stdout)]
         if should_print_final_message_to_stdout(
             self.emit_final_message_on_shutdown
@@ -719,11 +711,9 @@ fn summarize_sandbox_policy(sandbox_policy: &SandboxPolicy) -> String {
             let mut summary = "read-only".to_string();
             if *network_access {
                 summary.push_str(" (network access enabled)");
->>>>>>> upstream_main
             }
             summary
         }
-<<<<<<< HEAD
     }
 }
 
@@ -797,7 +787,6 @@ impl EventProcessorWithHumanOutput {
                 }
             } else {
                 eprintln!();
-=======
         SandboxPolicy::ExternalSandbox { network_access } => {
             let mut summary = "external-sandbox".to_string();
             if matches!(
@@ -805,7 +794,6 @@ impl EventProcessorWithHumanOutput {
                 codex_protocol::protocol::NetworkAccess::Enabled
             ) {
                 summary.push_str(" (network access enabled)");
->>>>>>> upstream_main
             }
             summary
         }
@@ -821,7 +809,6 @@ impl EventProcessorWithHumanOutput {
             if !*exclude_slash_tmp {
                 writable_entries.push("/tmp".to_string());
             }
-<<<<<<< HEAD
             return;
         }
         if done && self.progress_done {
@@ -911,10 +898,8 @@ fn format_agent_job_progress_line(
             if columns > 2 && truncated.len() > columns {
                 truncated.truncate(columns - 2);
                 truncated.push_str("..");
-=======
             if !*exclude_tmpdir_env_var {
                 writable_entries.push("$TMPDIR".to_string());
->>>>>>> upstream_main
             }
             writable_entries.extend(
                 writable_roots

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -64,18 +64,15 @@ use codex_core::config_loader::ConfigLoadError;
 use codex_core::config_loader::LoaderOverrides;
 use codex_core::config_loader::format_config_error_with_source;
 use codex_core::format_exec_policy_error_with_source;
-<<<<<<< HEAD
 use codex_core::git_info::get_git_repo_root;
 use codex_core::models_manager::collaboration_mode_presets::CollaborationModesConfig;
 use codex_core::models_manager::manager::RefreshStrategy;
 use codex_protocol::approvals::ElicitationAction;
-=======
 use codex_core::path_utils;
 use codex_feedback::CodexFeedback;
 use codex_git_utils::get_git_repo_root;
 use codex_otel::set_parent_from_context;
 use codex_otel::traceparent_context_from_env;
->>>>>>> upstream_main
 use codex_protocol::config_types::SandboxMode;
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::ReviewRequest;
@@ -387,11 +384,8 @@ pub async fn run_main(cli: Cli, arg0_paths: Arg0DispatchPaths) -> anyhow::Result
         codex_core::otel_init::build_provider(
             &config,
             env!("CARGO_PKG_VERSION"),
-<<<<<<< HEAD
             None,
-=======
             /*service_name_override*/ None,
->>>>>>> upstream_main
             DEFAULT_ANALYTICS_ENABLED,
         )
     })) {
@@ -524,7 +518,6 @@ async fn run_exec_session(args: ExecRunArgs) -> anyhow::Result<()> {
         std::process::exit(1);
     }
 
-<<<<<<< HEAD
     let auth_manager = AuthManager::shared(
         config.codex_home.clone(),
         true,
@@ -545,14 +538,12 @@ async fn run_exec_session(args: ExecRunArgs) -> anyhow::Result<()> {
         .get_models_manager()
         .get_default_model(&config.model, RefreshStrategy::OnlineIfUncached)
         .await;
-=======
     let mut request_ids = RequestIdSequencer::new();
     let mut client = InProcessAppServerClient::start(in_process_start_args)
         .await
         .map_err(|err| {
             anyhow::anyhow!("failed to initialize in-process app-server client: {err}")
         })?;
->>>>>>> upstream_main
 
     // Handle resume subcommand through existing `thread/list` + `thread/resume`
     // APIs so exec no longer reaches into rollout storage directly.
@@ -693,7 +684,6 @@ async fn run_exec_session(args: ExecRunArgs) -> anyhow::Result<()> {
             items,
             output_schema,
         } => {
-<<<<<<< HEAD
             let task_id = thread
                 .submit(Op::UserTurn {
                     items,
@@ -708,7 +698,6 @@ async fn run_exec_session(args: ExecRunArgs) -> anyhow::Result<()> {
                     personality: None,
                 })
                 .await?;
-=======
             let response: TurnStartResponse = send_request_with_response(
                 &client,
                 ClientRequest::TurnStart {
@@ -734,7 +723,6 @@ async fn run_exec_session(args: ExecRunArgs) -> anyhow::Result<()> {
             .await
             .map_err(anyhow::Error::msg)?;
             let task_id = response.turn.id;
->>>>>>> upstream_main
             info!("Sent prompt with event ID: {task_id}");
             task_id
         }
@@ -1087,7 +1075,6 @@ fn should_process_notification(
     }
 }
 
-<<<<<<< HEAD
 fn should_suppress_agent_job_event(msg: &EventMsg) -> bool {
     !matches!(
         msg,
@@ -1104,7 +1091,6 @@ fn should_suppress_agent_job_event(msg: &EventMsg) -> bool {
             | EventMsg::ShutdownComplete
     )
 }
-=======
 async fn maybe_backfill_turn_completed_items(
     client: &InProcessAppServerClient,
     request_ids: &mut RequestIdSequencer,
@@ -1120,7 +1106,6 @@ async fn maybe_backfill_turn_completed_items(
     if !payload.turn.items.is_empty() {
         return;
     }
->>>>>>> upstream_main
 
     let response = send_request_with_response::<ThreadReadResponse>(
         client,

--- a/codex-rs/execpolicy/src/execpolicycheck.rs
+++ b/codex-rs/execpolicy/src/execpolicycheck.rs
@@ -44,11 +44,7 @@ impl ExecPolicyCheckCommand {
         let policy = load_policies(&self.rules)?;
         let matched_rules = policy.matches_for_command_with_options(
             &self.command,
-<<<<<<< HEAD
             None,
-=======
-            /*heuristics_fallback*/ None,
->>>>>>> upstream_main
             &MatchOptions {
                 resolve_host_executables: self.resolve_host_executables,
             },

--- a/codex-rs/execpolicy/src/rule.rs
+++ b/codex-rs/execpolicy/src/rule.rs
@@ -255,11 +255,7 @@ pub(crate) fn validate_match_examples(
 
     for example in matches {
         if !policy
-<<<<<<< HEAD
             .matches_for_command_with_options(example, None, &options)
-=======
-            .matches_for_command_with_options(example, /*heuristics_fallback*/ None, &options)
->>>>>>> upstream_main
             .is_empty()
         {
             continue;
@@ -294,11 +290,7 @@ pub(crate) fn validate_not_match_examples(
 
     for example in not_matches {
         if let Some(rule) = policy
-<<<<<<< HEAD
             .matches_for_command_with_options(example, None, &options)
-=======
-            .matches_for_command_with_options(example, /*heuristics_fallback*/ None, &options)
->>>>>>> upstream_main
             .first()
         {
             return Err(Error::ExampleDidMatch {

--- a/codex-rs/features/src/lib.rs
+++ b/codex-rs/features/src/lib.rs
@@ -157,11 +157,8 @@ pub enum Feature {
     Steer,
     /// Allow request_user_input in Default collaboration mode.
     DefaultModeRequestUserInput,
-<<<<<<< HEAD:codex-rs/core/src/features.rs
-=======
     /// Enable automatic review for approval prompts.
     GuardianApproval,
->>>>>>> upstream_main:codex-rs/features/src/lib.rs
     /// Enable collaboration modes (Plan, Default).
     /// Kept for config backward compatibility; behavior is always collaboration-modes-enabled.
     CollaborationModes,
@@ -555,8 +552,6 @@ pub const FEATURES: &[FeatureSpec] = &[
             menu_description: "Enable a persistent Node-backed JavaScript REPL for interactive website debugging and other inline JavaScript execution capabilities. Requires Node >= v22.22.0 installed.",
             announcement: "NEW: JavaScript REPL is now available in /experimental. Enable it, then start a new chat or restart Codex to use it.",
         },
-<<<<<<< HEAD:codex-rs/core/src/features.rs
-=======
         default_enabled: false,
     },
     FeatureSpec {
@@ -569,7 +564,6 @@ pub const FEATURES: &[FeatureSpec] = &[
         id: Feature::CodeModeOnly,
         key: "code_mode_only",
         stage: Stage::UnderDevelopment,
->>>>>>> upstream_main:codex-rs/features/src/lib.rs
         default_enabled: false,
     },
     FeatureSpec {
@@ -758,8 +752,6 @@ pub const FEATURES: &[FeatureSpec] = &[
         key: "steer",
         stage: Stage::Removed,
         default_enabled: true,
-<<<<<<< HEAD:codex-rs/core/src/features.rs
-=======
     },
     FeatureSpec {
         id: Feature::DefaultModeRequestUserInput,
@@ -776,7 +768,6 @@ pub const FEATURES: &[FeatureSpec] = &[
             announcement: "",
         },
         default_enabled: false,
->>>>>>> upstream_main:codex-rs/features/src/lib.rs
     },
     FeatureSpec {
         id: Feature::DefaultModeRequestUserInput,
@@ -911,7 +902,6 @@ pub fn unstable_features_warning_event(
 }
 
 #[cfg(test)]
-<<<<<<< HEAD:codex-rs/core/src/features.rs
 mod tests {
     use super::*;
 
@@ -987,6 +977,4 @@ mod tests {
         assert_eq!(feature_for_key("collab"), Some(Feature::Collab));
     }
 }
-=======
 mod tests;
->>>>>>> upstream_main:codex-rs/features/src/lib.rs

--- a/codex-rs/hooks/src/registry.rs
+++ b/codex-rs/hooks/src/registry.rs
@@ -148,7 +148,6 @@ pub fn command_from_argv(argv: &[String]) -> Option<Command> {
     command.args(args);
     Some(command)
 }
-<<<<<<< HEAD
 
 #[cfg(test)]
 mod tests {
@@ -561,5 +560,3 @@ mod tests {
         Ok(())
     }
 }
-=======
->>>>>>> upstream_main

--- a/codex-rs/linux-sandbox/src/bwrap.rs
+++ b/codex-rs/linux-sandbox/src/bwrap.rs
@@ -209,14 +209,11 @@ fn create_bwrap_flags(
 /// Build the bubblewrap filesystem mounts for a given filesystem policy.
 ///
 /// The mount order is important:
-<<<<<<< HEAD
 /// 1. Full-read policies use `--ro-bind / /`; restricted-read policies start
 ///    from `--tmpfs /` and layer scoped `--ro-bind` mounts.
-=======
 /// 1. Full-read policies, and restricted policies that explicitly read `/`,
 ///    use `--ro-bind / /`; other restricted-read policies start from
 ///    `--tmpfs /` and layer scoped `--ro-bind` mounts.
->>>>>>> upstream_main
 /// 2. `--dev /dev` mounts a minimal writable `/dev` with standard device nodes
 ///    (including `/dev/urandom`) even under a read-only root.
 /// 3. Unreadable ancestors of writable roots are masked before their child
@@ -225,7 +222,6 @@ fn create_bwrap_flags(
 ///    writable subpaths under `/dev` (for example, `/dev/shm`).
 /// 5. `--ro-bind <subpath> <subpath>` re-applies read-only protections under
 ///    those writable roots so protected subpaths win.
-<<<<<<< HEAD
 fn create_filesystem_args(sandbox_policy: &SandboxPolicy, cwd: &Path) -> Result<Vec<String>> {
     let writable_roots = sandbox_policy.get_writable_roots_with_cwd(cwd);
     ensure_mount_targets_exist(&writable_roots)?;
@@ -254,7 +250,6 @@ fn create_filesystem_args(sandbox_policy: &SandboxPolicy, cwd: &Path) -> Result<
         ];
 
         let mut readable_roots: BTreeSet<PathBuf> = sandbox_policy
-=======
 /// 6. Nested unreadable carveouts under a writable root are masked after that
 ///    root is bound, and unrelated unreadable roots are masked afterward.
 fn create_filesystem_args(
@@ -295,16 +290,12 @@ fn create_filesystem_args(
         ];
 
         let mut readable_roots: BTreeSet<PathBuf> = file_system_sandbox_policy
->>>>>>> upstream_main
             .get_readable_roots_with_cwd(cwd)
             .into_iter()
             .map(PathBuf::from)
             .collect();
-<<<<<<< HEAD
         if sandbox_policy.include_platform_defaults() {
-=======
         if file_system_sandbox_policy.include_platform_defaults() {
->>>>>>> upstream_main
             readable_roots.extend(
                 LINUX_PLATFORM_DEFAULT_READ_ROOTS
                     .iter()
@@ -312,7 +303,6 @@ fn create_filesystem_args(
                     .filter(|path| path.exists()),
             );
         }
-<<<<<<< HEAD
 
         // A restricted policy can still explicitly request `/`, which is
         // semantically equivalent to broad read access.
@@ -337,8 +327,6 @@ fn create_filesystem_args(
 
         args
     };
-=======
->>>>>>> upstream_main
 
         // A restricted policy can still explicitly request `/`, which is
         // the broad read baseline. Explicit unreadable carveouts are
@@ -681,14 +669,11 @@ fn find_first_non_existent_component(target_path: &Path) -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
-<<<<<<< HEAD
-=======
     use codex_protocol::protocol::FileSystemAccessMode;
     use codex_protocol::protocol::FileSystemPath;
     use codex_protocol::protocol::FileSystemSandboxEntry;
     use codex_protocol::protocol::FileSystemSandboxPolicy;
     use codex_protocol::protocol::FileSystemSpecialPath;
->>>>>>> upstream_main
     use codex_protocol::protocol::ReadOnlyAccess;
     use codex_protocol::protocol::SandboxPolicy;
     use codex_utils_absolute_path::AbsolutePathBuf;
@@ -885,7 +870,6 @@ mod tests {
                         .expect("absolute readable root"),
                 ],
             },
-<<<<<<< HEAD
         };
 
         let args = create_filesystem_args(&policy, temp_dir.path()).expect("filesystem args");
@@ -894,7 +878,6 @@ mod tests {
 
         let readable_root_str = path_to_string(&readable_root);
         assert!(args.windows(3).any(|window| {
-=======
             network_access: false,
         };
 
@@ -905,7 +888,6 @@ mod tests {
 
         let readable_root_str = path_to_string(&readable_root);
         assert!(args.args.windows(3).any(|window| {
->>>>>>> upstream_main
             window
                 == [
                     "--ro-bind",
@@ -923,16 +905,12 @@ mod tests {
                 include_platform_defaults: true,
                 readable_roots: Vec::new(),
             },
-<<<<<<< HEAD
-=======
             network_access: false,
->>>>>>> upstream_main
         };
 
         // `ReadOnlyAccess::Restricted` always includes `cwd` as a readable
         // root. Using `"/"` here would intentionally collapse to broad read
         // access, so use a non-root cwd to exercise the restricted path.
-<<<<<<< HEAD
         let args = create_filesystem_args(&policy, temp_dir.path()).expect("filesystem args");
 
         assert!(args.starts_with(&["--tmpfs".to_string(), "/".to_string()]));
@@ -940,7 +918,6 @@ mod tests {
         if Path::new("/usr").exists() {
             assert!(
                 args.windows(3)
-=======
         let args = create_filesystem_args(&FileSystemSandboxPolicy::from(&policy), temp_dir.path())
             .expect("filesystem args");
 
@@ -953,13 +930,10 @@ mod tests {
             assert!(
                 args.args
                     .windows(3)
->>>>>>> upstream_main
                     .any(|window| window == ["--ro-bind", "/usr", "/usr"])
             );
         }
     }
-<<<<<<< HEAD
-=======
 
     #[test]
     fn split_policy_reapplies_unreadable_carveouts_after_writable_binds() {
@@ -1354,5 +1328,4 @@ mod tests {
                 && window[4] == blocked_file_str
         }));
     }
->>>>>>> upstream_main
 }

--- a/codex-rs/linux-sandbox/tests/suite/landlock.rs
+++ b/codex-rs/linux-sandbox/tests/suite/landlock.rs
@@ -80,7 +80,6 @@ async fn run_cmd_result_with_writable_roots(
     use_legacy_landlock: bool,
     network_access: bool,
 ) -> Result<codex_core::exec::ExecToolCallOutput> {
-<<<<<<< HEAD
     let cwd = std::env::current_dir().expect("cwd should exist");
     let sandbox_cwd = cwd.clone();
     let params = ExecParams {
@@ -95,8 +94,6 @@ async fn run_cmd_result_with_writable_roots(
         arg0: None,
     };
 
-=======
->>>>>>> upstream_main
     let sandbox_policy = SandboxPolicy::WorkspaceWrite {
         writable_roots: writable_roots
             .iter()

--- a/codex-rs/login/src/auth/manager.rs
+++ b/codex-rs/login/src/auth/manager.rs
@@ -1487,7 +1487,6 @@ impl AuthManager {
 }
 
 #[cfg(test)]
-<<<<<<< HEAD:codex-rs/core/src/auth.rs
 mod tests {
     use super::*;
     use crate::auth::storage::FileAuthStorage;
@@ -1921,7 +1920,5 @@ mod tests {
         pretty_assertions::assert_eq!(auth.account_plan_type(), Some(AccountPlanType::Unknown));
     }
 }
-=======
 #[path = "auth_tests.rs"]
 mod tests;
->>>>>>> upstream_main:codex-rs/login/src/auth/manager.rs

--- a/codex-rs/mcp-server/src/codex_tool_runner.rs
+++ b/codex-rs/mcp-server/src/codex_tool_runner.rs
@@ -228,10 +228,7 @@ async fn run_codex_tool_session_inner(
                             parsed_cmd,
                             network_approval_context: _,
                             additional_permissions: _,
-<<<<<<< HEAD
-=======
                             skill_metadata: _,
->>>>>>> upstream_main
                             available_decisions: _,
                         } = ev;
                         handle_exec_approval_request(

--- a/codex-rs/mcp-server/src/message_processor.rs
+++ b/codex-rs/mcp-server/src/message_processor.rs
@@ -7,10 +7,7 @@ use codex_core::config::Config;
 use codex_core::default_client::USER_AGENT_SUFFIX;
 use codex_core::default_client::get_codex_user_agent;
 use codex_core::models_manager::collaboration_mode_presets::CollaborationModesConfig;
-<<<<<<< HEAD
-=======
 use codex_features::Feature;
->>>>>>> upstream_main
 use codex_protocol::ThreadId;
 use codex_protocol::protocol::SessionSource;
 use codex_protocol::protocol::Submission;
@@ -66,18 +63,15 @@ impl MessageProcessor {
             config.as_ref(),
             auth_manager,
             SessionSource::Mcp,
-<<<<<<< HEAD
             config.model_catalog.clone(),
             CollaborationModesConfig {
                 default_mode_request_user_input: config
                     .features
                     .enabled(codex_core::features::Feature::DefaultModeRequestUserInput),
-=======
             CollaborationModesConfig {
                 default_mode_request_user_input: config
                     .features
                     .enabled(Feature::DefaultModeRequestUserInput),
->>>>>>> upstream_main
             },
         ));
         Self {

--- a/codex-rs/network-proxy/src/http_proxy.rs
+++ b/codex-rs/network-proxy/src/http_proxy.rs
@@ -187,11 +187,7 @@ async fn http_connect_accept(
             client_addr(&req),
             Some("CONNECT".to_string()),
             NetworkProtocol::HttpsConnect,
-<<<<<<< HEAD
-            None,
-=======
             /*audit_endpoint_override*/ None,
->>>>>>> upstream_main
         )
         .await);
     }
@@ -622,11 +618,7 @@ async fn http_plain_proxy(
             client_addr(&req),
             Some(req.method().as_str().to_string()),
             NetworkProtocol::Http,
-<<<<<<< HEAD
-            None,
-=======
             /*audit_endpoint_override*/ None,
->>>>>>> upstream_main
         )
         .await);
     }

--- a/codex-rs/network-proxy/src/runtime.rs
+++ b/codex-rs/network-proxy/src/runtime.rs
@@ -253,11 +253,7 @@ impl NetworkProxyState {
             state,
             reloader,
             audit_metadata,
-<<<<<<< HEAD
-            None,
-=======
             /*blocked_request_observer*/ None,
->>>>>>> upstream_main
         )
     }
 

--- a/codex-rs/otel/src/lib.rs
+++ b/codex-rs/otel/src/lib.rs
@@ -43,7 +43,6 @@ pub enum TelemetryAuthMode {
     Chatgpt,
 }
 
-<<<<<<< HEAD
 #[derive(Debug, Clone)]
 pub struct OtelEventMetadata {
     pub(crate) conversation_id: ThreadId,
@@ -244,7 +243,6 @@ impl OtelManager {
         tags.push((key, value));
         Ok(())
     }
-=======
 impl From<codex_app_server_protocol::AuthMode> for TelemetryAuthMode {
     fn from(mode: codex_app_server_protocol::AuthMode) -> Self {
         match mode {
@@ -253,7 +251,6 @@ impl From<codex_app_server_protocol::AuthMode> for TelemetryAuthMode {
             | codex_app_server_protocol::AuthMode::ChatgptAuthTokens => Self::Chatgpt,
         }
     }
->>>>>>> upstream_main
 }
 
 /// Start a metrics timer using the globally installed metrics client.

--- a/codex-rs/otel/src/provider.rs
+++ b/codex-rs/otel/src/provider.rs
@@ -3,14 +3,11 @@ use crate::config::OtelHttpProtocol;
 use crate::config::OtelSettings;
 use crate::metrics::MetricsClient;
 use crate::metrics::MetricsConfig;
-<<<<<<< HEAD:codex-rs/otel/src/otel_provider.rs
 use gethostname::gethostname;
 use opentelemetry::Context;
-=======
 use crate::targets::is_log_export_target;
 use crate::targets::is_trace_safe_target;
 use gethostname::gethostname;
->>>>>>> upstream_main:codex-rs/otel/src/provider.rs
 use opentelemetry::KeyValue;
 use opentelemetry::global;
 use opentelemetry::trace::TracerProvider as _;
@@ -41,12 +38,9 @@ use tracing_subscriber::registry::LookupSpan;
 
 const ENV_ATTRIBUTE: &str = "env";
 const HOST_NAME_ATTRIBUTE: &str = "host.name";
-<<<<<<< HEAD:codex-rs/otel/src/otel_provider.rs
 const TRACEPARENT_ENV_VAR: &str = "TRACEPARENT";
 const TRACESTATE_ENV_VAR: &str = "TRACESTATE";
 static TRACEPARENT_CONTEXT: OnceLock<Option<Context>> = OnceLock::new();
-=======
->>>>>>> upstream_main:codex-rs/otel/src/provider.rs
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum ResourceKind {
@@ -192,23 +186,17 @@ fn make_resource(settings: &OtelSettings, kind: ResourceKind) -> Resource {
         .with_attributes(resource_attributes(
             settings,
             detected_host_name().as_deref(),
-<<<<<<< HEAD:codex-rs/otel/src/otel_provider.rs
-=======
             kind,
->>>>>>> upstream_main:codex-rs/otel/src/provider.rs
         ))
         .build()
 }
 
-<<<<<<< HEAD:codex-rs/otel/src/otel_provider.rs
 fn resource_attributes(settings: &OtelSettings, host_name: Option<&str>) -> Vec<KeyValue> {
-=======
 fn resource_attributes(
     settings: &OtelSettings,
     host_name: Option<&str>,
     kind: ResourceKind,
 ) -> Vec<KeyValue> {
->>>>>>> upstream_main:codex-rs/otel/src/provider.rs
     let mut attributes = vec![
         KeyValue::new(
             semconv::attribute::SERVICE_VERSION,
@@ -216,13 +204,10 @@ fn resource_attributes(
         ),
         KeyValue::new(ENV_ATTRIBUTE, settings.environment.clone()),
     ];
-<<<<<<< HEAD:codex-rs/otel/src/otel_provider.rs
     if let Some(host_name) = host_name.and_then(normalize_host_name) {
-=======
     if kind == ResourceKind::Logs
         && let Some(host_name) = host_name.and_then(normalize_host_name)
     {
->>>>>>> upstream_main:codex-rs/otel/src/provider.rs
         attributes.push(KeyValue::new(HOST_NAME_ATTRIBUTE, host_name));
     }
     attributes
@@ -407,12 +392,9 @@ fn build_tracer_provider(
 #[cfg(test)]
 mod tests {
     use super::*;
-<<<<<<< HEAD:codex-rs/otel/src/otel_provider.rs
     use opentelemetry::trace::SpanId;
     use opentelemetry::trace::TraceContextExt;
     use opentelemetry::trace::TraceId;
-=======
->>>>>>> upstream_main:codex-rs/otel/src/provider.rs
     use pretty_assertions::assert_eq;
     use std::path::PathBuf;
 

--- a/codex-rs/otel/tests/suite/manager_metrics.rs
+++ b/codex-rs/otel/tests/suite/manager_metrics.rs
@@ -113,11 +113,8 @@ fn manager_allows_disabling_metadata_tags() -> Result<()> {
 #[test]
 fn manager_attaches_optional_service_name_tag() -> Result<()> {
     let (metrics, exporter) = build_metrics_with_defaults(&[])?;
-<<<<<<< HEAD
     let manager = OtelManager::new(
-=======
     let manager = SessionTelemetry::new(
->>>>>>> upstream_main
         ThreadId::new(),
         "gpt-5.1",
         "gpt-5.1",

--- a/codex-rs/protocol/src/approvals.rs
+++ b/codex-rs/protocol/src/approvals.rs
@@ -19,11 +19,8 @@ use ts_rs::TS;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Permissions {
     pub sandbox_policy: SandboxPolicy,
-<<<<<<< HEAD
-=======
     pub file_system_sandbox_policy: FileSystemSandboxPolicy,
     pub network_sandbox_policy: NetworkSandboxPolicy,
->>>>>>> upstream_main
     pub macos_seatbelt_profile_extensions: Option<MacOsSeatbeltProfileExtensions>,
 }
 
@@ -184,13 +181,10 @@ pub struct ExecApprovalRequestEvent {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub additional_permissions: Option<PermissionProfile>,
-<<<<<<< HEAD
-=======
     /// Optional skill metadata when the approval was triggered by a skill script.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub skill_metadata: Option<ExecApprovalRequestSkillMetadata>,
->>>>>>> upstream_main
     /// Ordered list of decisions the client may present for this prompt.
     ///
     /// When absent, clients should derive the legacy default set from the

--- a/codex-rs/protocol/src/models.rs
+++ b/codex-rs/protocol/src/models.rs
@@ -23,11 +23,7 @@ use crate::protocol::SandboxPolicy;
 use crate::protocol::WritableRoot;
 use crate::user_input::UserInput;
 use codex_execpolicy::Policy;
-<<<<<<< HEAD
-use codex_git::GhostCommit;
-=======
 use codex_git_utils::GhostCommit;
->>>>>>> upstream_main
 use codex_utils_absolute_path::AbsolutePathBuf;
 use codex_utils_image::error::ImageProcessingError;
 use schemars::JsonSchema;
@@ -147,32 +143,6 @@ pub enum MacOsAutomationPermission {
     BundleIds(Vec<String>),
 }
 
-<<<<<<< HEAD
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub enum MacOsPreferencesPermission {
-    // IMPORTANT: ReadOnly needs to be the default because it's the
-    // security-sensitive default and keeps cf prefs working.
-    #[default]
-    ReadOnly,
-    ReadWrite,
-    None,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub enum MacOsAutomationPermission {
-    #[default]
-    None,
-    All,
-    BundleIds(Vec<String>),
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub struct MacOsSeatbeltProfileExtensions {
-    pub macos_preferences: MacOsPreferencesPermission,
-    pub macos_automation: MacOsAutomationPermission,
-    pub macos_accessibility: bool,
-    pub macos_calendar: bool,
-=======
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
 enum MacOsAutomationPermissionDe {
@@ -216,7 +186,6 @@ impl TryFrom<MacOsAutomationPermissionDe> for MacOsAutomationPermission {
                 }
             }
         };
-
         Ok(permission)
     }
 }
@@ -238,7 +207,6 @@ pub struct MacOsSeatbeltProfileExtensions {
     pub macos_reminders: bool,
     #[serde(alias = "contacts")]
     pub macos_contacts: MacOsContactsPermission,
->>>>>>> upstream_main
 }
 
 #[derive(Debug, Clone, Default, Eq, Hash, PartialEq, Serialize, Deserialize, JsonSchema, TS)]
@@ -273,9 +241,6 @@ pub enum ResponseInputItem {
     },
     CustomToolCallOutput {
         call_id: String,
-<<<<<<< HEAD
-        output: FunctionCallOutputPayload,
-=======
         #[serde(default, skip_serializing_if = "Option::is_none")]
         #[ts(optional)]
         name: Option<String>,
@@ -289,7 +254,6 @@ pub enum ResponseInputItem {
         execution: String,
         #[ts(type = "unknown[]")]
         tools: Vec<serde_json::Value>,
->>>>>>> upstream_main
     },
 }
 
@@ -421,9 +385,6 @@ pub enum ResponseItem {
     // text or structured content items.
     CustomToolCallOutput {
         call_id: String,
-<<<<<<< HEAD
-        output: FunctionCallOutputPayload,
-=======
         #[serde(default, skip_serializing_if = "Option::is_none")]
         #[ts(optional)]
         name: Option<String>,
@@ -437,7 +398,6 @@ pub enum ResponseItem {
         execution: String,
         #[ts(type = "unknown[]")]
         tools: Vec<serde_json::Value>,
->>>>>>> upstream_main
     },
     // Emitted by the Responses API when the agent triggers a web search.
     // Example payload (from SSE `response.output_item.done`):
@@ -2513,17 +2473,11 @@ mod tests {
     fn serializes_custom_tool_image_outputs_as_array() -> Result<()> {
         let item = ResponseInputItem::CustomToolCallOutput {
             call_id: "call1".into(),
-<<<<<<< HEAD
-            output: FunctionCallOutputPayload::from_content_items(vec![
-                FunctionCallOutputContentItem::InputImage {
-                    image_url: "data:image/png;base64,BASE64".into(),
-=======
             name: None,
             output: FunctionCallOutputPayload::from_content_items(vec![
                 FunctionCallOutputContentItem::InputImage {
                     image_url: "data:image/png;base64,BASE64".into(),
                     detail: None,
->>>>>>> upstream_main
                 },
             ]),
         };

--- a/codex-rs/protocol/src/openai_models.rs
+++ b/codex-rs/protocol/src/openai_models.rs
@@ -742,30 +742,20 @@ mod tests {
                 "limit": 10000
             },
             "supports_parallel_tool_calls": false,
-<<<<<<< HEAD
-=======
             "supports_image_detail_original": false,
->>>>>>> upstream_main
             "context_window": null,
             "auto_compact_token_limit": null,
             "effective_context_window_percent": 95,
             "experimental_supported_tools": [],
-<<<<<<< HEAD
             "input_modalities": ["text", "image"],
             "prefer_websockets": false
-=======
-            "input_modalities": ["text", "image"]
->>>>>>> upstream_main
         }))
         .expect("deserialize model info");
 
         assert_eq!(model.availability_nux, None);
-<<<<<<< HEAD
-=======
         assert!(!model.supports_image_detail_original);
         assert_eq!(model.web_search_tool_type, WebSearchToolType::Text);
         assert!(!model.supports_search_tool);
->>>>>>> upstream_main
     }
 
     #[test]

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -279,8 +279,6 @@ pub enum Op {
         /// fall back to the selected model's default on new sessions).
         #[serde(default, skip_serializing_if = "Option::is_none")]
         summary: Option<ReasoningSummaryConfig>,
-<<<<<<< HEAD
-=======
 
         /// Optional service tier override for this turn.
         ///
@@ -290,7 +288,6 @@ pub enum Op {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         service_tier: Option<Option<ServiceTier>>,
 
->>>>>>> upstream_main
         // The JSON schema to use for the final assistant message
         final_output_json_schema: Option<Value>,
 

--- a/codex-rs/rmcp-client/src/perform_oauth_login.rs
+++ b/codex-rs/rmcp-client/src/perform_oauth_login.rs
@@ -147,11 +147,7 @@ async fn perform_oauth_login_with_browser_output(
         headers,
         scopes,
         oauth_resource,
-<<<<<<< HEAD
         true,
-=======
-        /*launch_browser*/ true,
->>>>>>> upstream_main
         callback_port,
         callback_url,
         /*timeout_secs*/ None,
@@ -185,11 +181,7 @@ pub async fn perform_oauth_login_return_url(
         headers,
         scopes,
         oauth_resource,
-<<<<<<< HEAD
         false,
-=======
-        /*launch_browser*/ false,
->>>>>>> upstream_main
         callback_port,
         callback_url,
         timeout_secs,
@@ -584,10 +576,7 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use super::CallbackOutcome;
-<<<<<<< HEAD
-=======
     use super::OAuthProviderError;
->>>>>>> upstream_main
     use super::append_query_param;
     use super::callback_path_from_redirect_uri;
     use super::parse_oauth_callback;

--- a/codex-rs/rollout/src/policy.rs
+++ b/codex-rs/rollout/src/policy.rs
@@ -148,10 +148,7 @@ fn event_msg_persistence_mode(ev: &EventMsg) -> Option<EventPersistenceMode> {
         | EventMsg::TerminalInteraction(_)
         | EventMsg::ExecCommandOutputDelta(_)
         | EventMsg::ExecApprovalRequest(_)
-<<<<<<< HEAD:codex-rs/core/src/rollout/policy.rs
-=======
         | EventMsg::RequestPermissions(_)
->>>>>>> upstream_main:codex-rs/rollout/src/policy.rs
         | EventMsg::RequestUserInput(_)
         | EventMsg::ElicitationRequest(_)
         | EventMsg::ApplyPatchApprovalRequest(_)

--- a/codex-rs/rollout/src/recorder.rs
+++ b/codex-rs/rollout/src/recorder.rs
@@ -180,11 +180,8 @@ impl RolloutRecorder {
             allowed_sources,
             model_providers,
             default_provider,
-<<<<<<< HEAD:codex-rs/core/src/rollout/recorder.rs
             false,
-=======
             /*archived*/ false,
->>>>>>> upstream_main:codex-rs/rollout/src/recorder.rs
             search_term,
         )
         .await
@@ -210,11 +207,8 @@ impl RolloutRecorder {
             allowed_sources,
             model_providers,
             default_provider,
-<<<<<<< HEAD:codex-rs/core/src/rollout/recorder.rs
             true,
-=======
             /*archived*/ true,
->>>>>>> upstream_main:codex-rs/rollout/src/recorder.rs
             search_term,
         )
         .await
@@ -328,13 +322,10 @@ impl RolloutRecorder {
                     sort_key,
                     allowed_sources,
                     model_providers,
-<<<<<<< HEAD:codex-rs/core/src/rollout/recorder.rs
                     false,
                     None,
-=======
                     /*archived*/ false,
                     /*search_term*/ None,
->>>>>>> upstream_main:codex-rs/rollout/src/recorder.rs
                 )
                 .await
                 else {
@@ -475,13 +466,10 @@ impl RolloutRecorder {
             rollout_path.clone(),
             state_db_ctx.clone(),
             state_builder,
-<<<<<<< HEAD:codex-rs/core/src/rollout/recorder.rs
             config.model_provider_id.clone(),
             config.memories.generate_memories,
-=======
             config.model_provider_id().to_string(),
             config.generate_memories(),
->>>>>>> upstream_main:codex-rs/rollout/src/recorder.rs
         ));
 
         Ok(Self {
@@ -886,11 +874,8 @@ async fn write_session_meta(
         rollout_path,
         state_builder.as_ref(),
         std::slice::from_ref(&rollout_item),
-<<<<<<< HEAD:codex-rs/core/src/rollout/recorder.rs
         None,
-=======
         default_provider,
->>>>>>> upstream_main:codex-rs/rollout/src/recorder.rs
         (!generate_memories).then_some("disabled"),
     )
     .await;
@@ -965,12 +950,9 @@ async fn sync_thread_state_after_write(
         state_builder,
         items,
         "rollout_writer",
-<<<<<<< HEAD:codex-rs/core/src/rollout/recorder.rs
         None,
-=======
         new_thread_memory_mode,
         Some(updated_at),
->>>>>>> upstream_main:codex-rs/rollout/src/recorder.rs
     )
     .await;
 }
@@ -1092,11 +1074,8 @@ async fn resume_candidate_matches_cwd(
         return cwd_matches(latest_turn_context_cwd, cwd);
     }
 
-<<<<<<< HEAD:codex-rs/core/src/rollout/recorder.rs
     metadata::extract_metadata_from_rollout(rollout_path, default_provider, None)
-=======
     metadata::extract_metadata_from_rollout(rollout_path, default_provider)
->>>>>>> upstream_main:codex-rs/rollout/src/recorder.rs
         .await
         .is_ok_and(|outcome| cwd_matches(outcome.metadata.cwd.as_path(), cwd))
 }
@@ -1137,7 +1116,6 @@ fn cwd_matches(session_cwd: &Path, cwd: &Path) -> bool {
 }
 
 #[cfg(test)]
-<<<<<<< HEAD:codex-rs/core/src/rollout/recorder.rs
 mod tests {
     use super::*;
     use crate::config::ConfigBuilder;
@@ -1503,7 +1481,5 @@ mod tests {
         Ok(())
     }
 }
-=======
 #[path = "recorder_tests.rs"]
 mod tests;
->>>>>>> upstream_main:codex-rs/rollout/src/recorder.rs

--- a/codex-rs/rollout/src/state_db.rs
+++ b/codex-rs/rollout/src/state_db.rs
@@ -351,10 +351,7 @@ pub async fn reconcile_rollout(
             items,
             "reconcile_rollout",
             new_thread_memory_mode,
-<<<<<<< HEAD:codex-rs/core/src/state_db.rs
-=======
             /*updated_at_override*/ None,
->>>>>>> upstream_main:codex-rs/rollout/src/state_db.rs
         )
         .await;
         return;
@@ -479,11 +476,8 @@ pub async fn read_repair_rollout_path(
         /*builder*/ None,
         &[],
         archived_only,
-<<<<<<< HEAD:codex-rs/core/src/state_db.rs
         None,
-=======
         /*new_thread_memory_mode*/ None,
->>>>>>> upstream_main:codex-rs/rollout/src/state_db.rs
     )
     .await;
 }
@@ -498,10 +492,7 @@ pub async fn apply_rollout_items(
     items: &[RolloutItem],
     stage: &str,
     new_thread_memory_mode: Option<&str>,
-<<<<<<< HEAD:codex-rs/core/src/state_db.rs
-=======
     updated_at_override: Option<DateTime<Utc>>,
->>>>>>> upstream_main:codex-rs/rollout/src/state_db.rs
 ) {
     let Some(ctx) = context else {
         return;
@@ -523,11 +514,8 @@ pub async fn apply_rollout_items(
     builder.rollout_path = rollout_path.to_path_buf();
     builder.cwd = normalize_cwd_for_state_db(&builder.cwd);
     if let Err(err) = ctx
-<<<<<<< HEAD:codex-rs/core/src/state_db.rs
         .apply_rollout_items(&builder, items, None, new_thread_memory_mode)
-=======
         .apply_rollout_items(&builder, items, new_thread_memory_mode, updated_at_override)
->>>>>>> upstream_main:codex-rs/rollout/src/state_db.rs
         .await
     {
         warn!(

--- a/codex-rs/shell-escalation/src/unix/escalate_server.rs
+++ b/codex-rs/shell-escalation/src/unix/escalate_server.rs
@@ -8,10 +8,7 @@ use std::time::Duration;
 
 use anyhow::Context as _;
 use codex_utils_absolute_path::AbsolutePathBuf;
-<<<<<<< HEAD
-=======
 use socket2::Socket;
->>>>>>> upstream_main
 use tokio::process::Command;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
@@ -23,10 +20,7 @@ use crate::unix::escalate_protocol::EscalateRequest;
 use crate::unix::escalate_protocol::EscalateResponse;
 use crate::unix::escalate_protocol::EscalationDecision;
 use crate::unix::escalate_protocol::EscalationExecution;
-<<<<<<< HEAD
 use crate::unix::escalate_protocol::LEGACY_BASH_EXEC_WRAPPER_ENV_VAR;
-=======
->>>>>>> upstream_main
 use crate::unix::escalate_protocol::SuperExecMessage;
 use crate::unix::escalate_protocol::SuperExecResult;
 use crate::unix::escalation_policy::EscalationPolicy;
@@ -99,8 +93,6 @@ pub struct PreparedExec {
     pub arg0: Option<String>,
 }
 
-<<<<<<< HEAD
-=======
 #[derive(Debug)]
 pub struct EscalationSession {
     env: HashMap<String, String>,
@@ -133,7 +125,6 @@ impl Drop for EscalationSession {
     }
 }
 
->>>>>>> upstream_main
 pub struct EscalateServer {
     shell_path: PathBuf,
     execve_wrapper: PathBuf,
@@ -141,11 +132,8 @@ pub struct EscalateServer {
 }
 
 impl EscalateServer {
-<<<<<<< HEAD
     pub fn new<Policy>(bash_path: PathBuf, execve_wrapper: PathBuf, policy: Policy) -> Self
-=======
     pub fn new<Policy>(shell_path: PathBuf, execve_wrapper: PathBuf, policy: Policy) -> Self
->>>>>>> upstream_main
     where
         Policy: EscalationPolicy + Send + Sync + 'static,
     {
@@ -162,7 +150,6 @@ impl EscalateServer {
         cancel_rx: CancellationToken,
         command_executor: Arc<dyn ShellCommandExecutor>,
     ) -> anyhow::Result<ExecResult> {
-<<<<<<< HEAD
         let (escalate_server, escalate_client) = AsyncDatagramSocket::pair()?;
         let client_socket = escalate_client.into_inner();
         // Only the client endpoint should cross exec into the wrapper process.
@@ -186,11 +173,9 @@ impl EscalateServer {
             self.execve_wrapper.to_string_lossy().to_string(),
         );
 
-=======
         let session = self.start_session(cancel_rx.clone(), Arc::clone(&command_executor))?;
         let env_overlay = session.env().clone();
         let client_socket = Arc::clone(&session.client_socket);
->>>>>>> upstream_main
         let command = vec![
             self.shell_path.to_string_lossy().to_string(),
             if params.login == Some(false) {
@@ -202,9 +187,7 @@ impl EscalateServer {
         ];
         let workdir = AbsolutePathBuf::try_from(params.workdir)?;
         let result = command_executor
-<<<<<<< HEAD
             .run(command, workdir.to_path_buf(), env, cancel_rx)
-=======
             .run(
                 command,
                 workdir.to_path_buf(),
@@ -216,7 +199,6 @@ impl EscalateServer {
                     }
                 })),
             )
->>>>>>> upstream_main
             .await?;
         Ok(result)
     }
@@ -267,11 +249,8 @@ async fn escalate_task(
     socket: AsyncDatagramSocket,
     policy: Arc<dyn EscalationPolicy>,
     command_executor: Arc<dyn ShellCommandExecutor>,
-<<<<<<< HEAD
-=======
     parent_cancellation_token: CancellationToken,
     session_cancellation_token: CancellationToken,
->>>>>>> upstream_main
 ) -> anyhow::Result<()> {
     loop {
         let (_, mut fds) = tokio::select! {
@@ -286,11 +265,9 @@ async fn escalate_task(
         let stream_socket = AsyncSocket::from_fd(fds.remove(0))?;
         let policy = Arc::clone(&policy);
         let command_executor = Arc::clone(&command_executor);
-<<<<<<< HEAD
         tokio::spawn(async move {
             if let Err(err) =
                 handle_escalate_session_with_policy(stream_socket, policy, command_executor).await
-=======
         let parent_cancellation_token = parent_cancellation_token.clone();
         let session_cancellation_token = session_cancellation_token.clone();
         tokio::spawn(async move {
@@ -302,7 +279,6 @@ async fn escalate_task(
                 session_cancellation_token,
             )
             .await
->>>>>>> upstream_main
             {
                 tracing::error!("escalate session failed: {err:?}");
             }
@@ -314,25 +290,20 @@ async fn handle_escalate_session_with_policy(
     socket: AsyncSocket,
     policy: Arc<dyn EscalationPolicy>,
     command_executor: Arc<dyn ShellCommandExecutor>,
-<<<<<<< HEAD
-=======
     parent_cancellation_token: CancellationToken,
     session_cancellation_token: CancellationToken,
->>>>>>> upstream_main
 ) -> anyhow::Result<()> {
     let EscalateRequest {
         file,
         argv,
         workdir,
         env,
-<<<<<<< HEAD
     } = socket.receive::<EscalateRequest>().await?;
     let program = AbsolutePathBuf::resolve_path_against_base(file, workdir.as_path())?;
     let decision = policy
         .determine_action(&program, &argv, &workdir)
         .await
         .context("failed to determine escalation action")?;
-=======
     } = tokio::select! {
         request = socket.receive::<EscalateRequest>() => request?,
         _ = parent_cancellation_token.cancelled() => return Ok(()),
@@ -346,7 +317,6 @@ async fn handle_escalate_session_with_policy(
         _ = parent_cancellation_token.cancelled() => return Ok(()),
         _ = session_cancellation_token.cancelled() => return Ok(()),
     };
->>>>>>> upstream_main
 
     tracing::debug!("decided {decision:?} for {program:?} {argv:?} {workdir:?}");
 
@@ -379,7 +349,6 @@ async fn handle_escalate_session_with_policy(
                 ));
             }
 
-<<<<<<< HEAD
             if msg
                 .fds
                 .iter()
@@ -390,24 +359,19 @@ async fn handle_escalate_session_with_policy(
                 ));
             }
 
-=======
->>>>>>> upstream_main
             let PreparedExec {
                 command,
                 cwd,
                 env,
                 arg0,
-<<<<<<< HEAD
             } = command_executor
                 .prepare_escalated_exec(&program, &argv, &workdir, env, execution)
                 .await?;
-=======
             } = tokio::select! {
                 prepared = command_executor.prepare_escalated_exec(&program, &argv, &workdir, env, execution) => prepared?,
                 _ = parent_cancellation_token.cancelled() => return Ok(()),
                 _ = session_cancellation_token.cancelled() => return Ok(()),
             };
->>>>>>> upstream_main
             let (program, args) = command
                 .split_first()
                 .ok_or_else(|| anyhow::anyhow!("prepared escalated command must not be empty"))?;
@@ -462,20 +426,14 @@ async fn handle_escalate_session_with_policy(
 mod tests {
     use super::*;
     use codex_protocol::approvals::EscalationPermissions;
-<<<<<<< HEAD
-=======
     use codex_protocol::models::NetworkPermissions;
->>>>>>> upstream_main
     use codex_protocol::models::PermissionProfile;
     use codex_utils_absolute_path::AbsolutePathBuf;
     use pretty_assertions::assert_eq;
     use std::collections::HashMap;
-<<<<<<< HEAD
-=======
     use std::io::Write;
     use std::os::fd::AsRawFd;
     use std::os::fd::FromRawFd;
->>>>>>> upstream_main
     use std::path::PathBuf;
     use std::sync::LazyLock;
     use std::sync::atomic::AtomicBool;
@@ -500,7 +458,6 @@ mod tests {
             _workdir: &AbsolutePathBuf,
         ) -> anyhow::Result<EscalationDecision> {
             Ok(self.decision.clone())
-<<<<<<< HEAD
         }
     }
 
@@ -592,8 +549,6 @@ mod tests {
                 env,
                 arg0: argv.first().cloned(),
             })
-=======
->>>>>>> upstream_main
         }
     }
 
@@ -864,11 +819,8 @@ mod tests {
                 decision: EscalationDecision::run(),
             }),
             Arc::new(ForwardingShellCommandExecutor),
-<<<<<<< HEAD
-=======
             CancellationToken::new(),
             CancellationToken::new(),
->>>>>>> upstream_main
         ));
 
         let mut env = HashMap::new();
@@ -899,10 +851,7 @@ mod tests {
     #[tokio::test]
     async fn handle_escalate_session_resolves_relative_file_against_request_workdir()
     -> anyhow::Result<()> {
-<<<<<<< HEAD
-=======
         let _guard = ESCALATE_SERVER_TEST_LOCK.lock().await;
->>>>>>> upstream_main
         let (server, client) = AsyncSocket::pair()?;
         let tmp = tempfile::TempDir::new()?;
         let workdir = tmp.path().join("workspace");
@@ -916,11 +865,8 @@ mod tests {
                 expected_workdir: workdir.clone(),
             }),
             Arc::new(ForwardingShellCommandExecutor),
-<<<<<<< HEAD
-=======
             CancellationToken::new(),
             CancellationToken::new(),
->>>>>>> upstream_main
         ));
 
         client
@@ -952,11 +898,8 @@ mod tests {
                 decision: EscalationDecision::escalate(EscalationExecution::Unsandboxed),
             }),
             Arc::new(ForwardingShellCommandExecutor),
-<<<<<<< HEAD
-=======
             CancellationToken::new(),
             CancellationToken::new(),
->>>>>>> upstream_main
         ));
 
         client
@@ -990,10 +933,8 @@ mod tests {
         server_task.await?
     }
 
-<<<<<<< HEAD
     #[tokio::test]
     async fn handle_escalate_session_passes_permissions_to_executor() -> anyhow::Result<()> {
-=======
     /// Saves a target descriptor, closes it, and restores it when dropped.
     ///
     /// The overlap regression test needs the next received `SCM_RIGHTS` handle
@@ -1117,32 +1058,26 @@ mod tests {
     #[tokio::test]
     async fn handle_escalate_session_passes_permissions_to_executor() -> anyhow::Result<()> {
         let _guard = ESCALATE_SERVER_TEST_LOCK.lock().await;
->>>>>>> upstream_main
         let (server, client) = AsyncSocket::pair()?;
         let server_task = tokio::spawn(handle_escalate_session_with_policy(
             server,
             Arc::new(DeterministicEscalationPolicy {
                 decision: EscalationDecision::escalate(EscalationExecution::Permissions(
                     EscalationPermissions::PermissionProfile(PermissionProfile {
-<<<<<<< HEAD
                         network: Some(true),
-=======
                         network: Some(NetworkPermissions {
                             enabled: Some(true),
                         }),
->>>>>>> upstream_main
                         ..Default::default()
                     }),
                 )),
             }),
             Arc::new(PermissionAssertingShellCommandExecutor {
                 expected_permissions: EscalationPermissions::PermissionProfile(PermissionProfile {
-<<<<<<< HEAD
                     network: Some(true),
                     ..Default::default()
                 }),
             }),
-=======
                     network: Some(NetworkPermissions {
                         enabled: Some(true),
                     }),
@@ -1151,7 +1086,6 @@ mod tests {
             }),
             CancellationToken::new(),
             CancellationToken::new(),
->>>>>>> upstream_main
         ));
 
         client
@@ -1180,8 +1114,6 @@ mod tests {
 
         server_task.await?
     }
-<<<<<<< HEAD
-=======
 
     #[tokio::test]
     async fn dropping_session_aborts_intercept_workers_and_kills_spawned_child()
@@ -1273,5 +1205,4 @@ mod tests {
 
         Ok(())
     }
->>>>>>> upstream_main
 }

--- a/codex-rs/state/src/extract.rs
+++ b/codex-rs/state/src/extract.rs
@@ -71,11 +71,8 @@ fn apply_turn_context(metadata: &mut ThreadMetadata, turn_ctx: &TurnContextItem)
     if metadata.cwd.as_os_str().is_empty() {
         metadata.cwd = turn_ctx.cwd.clone();
     }
-<<<<<<< HEAD
-=======
     metadata.model = Some(turn_ctx.model.clone());
     metadata.reasoning_effort = turn_ctx.effort;
->>>>>>> upstream_main
     metadata.sandbox_policy = enum_to_string(&turn_ctx.sandbox_policy);
     metadata.approval_mode = enum_to_string(&turn_ctx.approval_policy);
 }
@@ -147,10 +144,7 @@ mod tests {
     use codex_protocol::config_types::ReasoningSummary;
     use codex_protocol::models::ContentItem;
     use codex_protocol::models::ResponseItem;
-<<<<<<< HEAD
-=======
     use codex_protocol::openai_models::ReasoningEffort;
->>>>>>> upstream_main
     use codex_protocol::protocol::AskForApproval;
     use codex_protocol::protocol::EventMsg;
     use codex_protocol::protocol::RolloutItem;
@@ -258,19 +252,13 @@ mod tests {
                     originator: "codex_cli_rs".to_string(),
                     cli_version: "0.0.0".to_string(),
                     source: SessionSource::Cli,
-<<<<<<< HEAD
-=======
                     agent_path: None,
->>>>>>> upstream_main
                     agent_nickname: None,
                     agent_role: None,
                     model_provider: Some("openai".to_string()),
                     base_instructions: None,
                     dynamic_tools: None,
-<<<<<<< HEAD
-=======
                     memory_mode: None,
->>>>>>> upstream_main
                 },
                 git: None,
             }),
@@ -280,10 +268,7 @@ mod tests {
             &mut metadata,
             &RolloutItem::TurnContext(TurnContextItem {
                 turn_id: Some("turn-1".to_string()),
-<<<<<<< HEAD
-=======
                 trace_id: None,
->>>>>>> upstream_main
                 cwd: PathBuf::from("/parent/workspace"),
                 current_date: None,
                 timezone: None,
@@ -293,10 +278,7 @@ mod tests {
                 model: "gpt-5".to_string(),
                 personality: None,
                 collaboration_mode: None,
-<<<<<<< HEAD
-=======
                 realtime_active: None,
->>>>>>> upstream_main
                 effort: None,
                 summary: ReasoningSummary::Auto,
                 user_instructions: None,
@@ -324,10 +306,7 @@ mod tests {
             &mut metadata,
             &RolloutItem::TurnContext(TurnContextItem {
                 turn_id: Some("turn-1".to_string()),
-<<<<<<< HEAD
-=======
                 trace_id: None,
->>>>>>> upstream_main
                 cwd: PathBuf::from("/fallback/workspace"),
                 current_date: None,
                 timezone: None,
@@ -337,12 +316,9 @@ mod tests {
                 model: "gpt-5".to_string(),
                 personality: None,
                 collaboration_mode: None,
-<<<<<<< HEAD
                 effort: None,
-=======
                 realtime_active: None,
                 effort: Some(ReasoningEffort::High),
->>>>>>> upstream_main
                 summary: ReasoningSummary::Auto,
                 user_instructions: None,
                 developer_instructions: None,
@@ -355,8 +331,6 @@ mod tests {
         assert_eq!(metadata.cwd, PathBuf::from("/fallback/workspace"));
     }
 
-<<<<<<< HEAD
-=======
     #[test]
     fn turn_context_sets_model_and_reasoning_effort() {
         let mut metadata = metadata_for_test();
@@ -423,7 +397,6 @@ mod tests {
         assert_eq!(metadata.reasoning_effort, None);
     }
 
->>>>>>> upstream_main
     fn metadata_for_test() -> ThreadMetadata {
         let id = ThreadId::from_string(&Uuid::from_u128(42).to_string()).expect("thread id");
         let created_at = DateTime::<Utc>::from_timestamp(1_735_689_600, 0).expect("timestamp");

--- a/codex-rs/state/src/runtime.rs
+++ b/codex-rs/state/src/runtime.rs
@@ -17,12 +17,9 @@ use crate::ThreadMetadata;
 use crate::ThreadMetadataBuilder;
 use crate::ThreadsPage;
 use crate::apply_rollout_item;
-<<<<<<< HEAD
 use crate::migrations::MIGRATOR;
-=======
 use crate::migrations::LOGS_MIGRATOR;
 use crate::migrations::STATE_MIGRATOR;
->>>>>>> upstream_main
 use crate::model::AgentJobRow;
 use crate::model::ThreadRow;
 use crate::model::anchor_from_item;
@@ -133,11 +130,8 @@ impl StateRuntime {
     }
 }
 
-<<<<<<< HEAD
 async fn open_sqlite(path: &Path) -> anyhow::Result<SqlitePool> {
-=======
 async fn open_sqlite(path: &Path, migrator: &'static Migrator) -> anyhow::Result<SqlitePool> {
->>>>>>> upstream_main
     let options = SqliteConnectOptions::new()
         .filename(path)
         .create_if_missing(true)

--- a/codex-rs/state/src/runtime/agent_jobs.rs
+++ b/codex-rs/state/src/runtime/agent_jobs.rs
@@ -435,12 +435,10 @@ WHERE job_id = ? AND item_id = ? AND status = ?
             r#"
 UPDATE agent_job_items
 SET
-<<<<<<< HEAD
     result_json = ?,
     reported_at = ?,
     updated_at = ?,
     last_error = NULL
-=======
     status = ?,
     result_json = ?,
     reported_at = ?,
@@ -448,7 +446,6 @@ SET
     updated_at = ?,
     last_error = NULL,
     assigned_thread_id = NULL
->>>>>>> upstream_main
 WHERE
     job_id = ?
     AND item_id = ?
@@ -456,17 +453,14 @@ WHERE
     AND assigned_thread_id = ?
             "#,
         )
-<<<<<<< HEAD
         .bind(serialized)
         .bind(now)
         .bind(now)
-=======
         .bind(AgentJobItemStatus::Completed.as_str())
         .bind(serialized)
         .bind(now)
         .bind(now)
         .bind(now)
->>>>>>> upstream_main
         .bind(job_id)
         .bind(item_id)
         .bind(AgentJobItemStatus::Running.as_str())
@@ -578,8 +572,6 @@ WHERE job_id = ?
         })
     }
 }
-<<<<<<< HEAD
-=======
 
 #[cfg(test)]
 mod tests {
@@ -697,4 +689,3 @@ mod tests {
         Ok(())
     }
 }
->>>>>>> upstream_main

--- a/codex-rs/state/src/runtime/backfill.rs
+++ b/codex-rs/state/src/runtime/backfill.rs
@@ -160,11 +160,8 @@ mod tests {
             .await
             .expect("write numeric");
 
-<<<<<<< HEAD
         let _runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
-=======
         let _runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
->>>>>>> upstream_main
             .await
             .expect("initialize runtime");
 
@@ -211,11 +208,8 @@ mod tests {
     #[tokio::test]
     async fn backfill_state_persists_progress_and_completion() {
         let codex_home = unique_temp_dir();
-<<<<<<< HEAD
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
-=======
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
->>>>>>> upstream_main
             .await
             .expect("initialize runtime");
 
@@ -268,11 +262,8 @@ mod tests {
     #[tokio::test]
     async fn backfill_claim_is_singleton_until_stale_and_blocked_when_complete() {
         let codex_home = unique_temp_dir();
-<<<<<<< HEAD
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
-=======
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
->>>>>>> upstream_main
             .await
             .expect("initialize runtime");
 

--- a/codex-rs/state/src/runtime/logs.rs
+++ b/codex-rs/state/src/runtime/logs.rs
@@ -11,14 +11,12 @@ impl StateRuntime {
             return Ok(());
         }
 
-<<<<<<< HEAD
         let mut tx = self.pool.begin().await?;
         let mut builder = QueryBuilder::<Sqlite>::new(
             "INSERT INTO logs (ts, ts_nanos, level, target, message, thread_id, process_uuid, module_path, file, line, estimated_bytes) ",
         );
         builder.push_values(entries, |mut row, entry| {
             let estimated_bytes = entry.message.as_ref().map_or(0, String::len) as i64
-=======
         let mut tx = self.logs_pool.begin().await?;
         let mut builder = QueryBuilder::<Sqlite>::new(
             "INSERT INTO logs (ts, ts_nanos, level, target, feedback_log_body, thread_id, process_uuid, module_path, file, line, estimated_bytes) ",
@@ -30,7 +28,6 @@ impl StateRuntime {
             // `feedback_log_body`, while `LogEntry.message` is only a write-time
             // fallback for callers that still populate the old field.
             let estimated_bytes = feedback_log_body.map_or(0, String::len) as i64
->>>>>>> upstream_main
                 + entry.level.len() as i64
                 + entry.target.len() as i64
                 + entry.module_path.as_ref().map_or(0, String::len) as i64
@@ -39,11 +36,8 @@ impl StateRuntime {
                 .push_bind(entry.ts_nanos)
                 .push_bind(&entry.level)
                 .push_bind(&entry.target)
-<<<<<<< HEAD
                 .push_bind(&entry.message)
-=======
                 .push_bind(feedback_log_body)
->>>>>>> upstream_main
                 .push_bind(&entry.thread_id)
                 .push_bind(&entry.process_uuid)
                 .push_bind(&entry.module_path)
@@ -57,11 +51,8 @@ impl StateRuntime {
         Ok(())
     }
 
-<<<<<<< HEAD
     /// Enforce per-partition log size caps after a successful batch insert.
-=======
     /// Enforce per-partition retained-log-content caps after a successful batch insert.
->>>>>>> upstream_main
     ///
     /// We maintain two independent budgets:
     /// - Thread logs: rows with `thread_id IS NOT NULL`, capped per `thread_id`.
@@ -98,11 +89,8 @@ impl StateRuntime {
             over_limit_threads_query.push("estimated_bytes");
             over_limit_threads_query.push(") > ");
             over_limit_threads_query.push_bind(LOG_PARTITION_SIZE_LIMIT_BYTES);
-<<<<<<< HEAD
-=======
             over_limit_threads_query.push(" OR COUNT(*) > ");
             over_limit_threads_query.push_bind(LOG_PARTITION_ROW_LIMIT);
->>>>>>> upstream_main
             let over_limit_thread_ids: Vec<String> = over_limit_threads_query
                 .build()
                 .fetch_all(&mut *tx)
@@ -130,15 +118,12 @@ WHERE id IN (
             ) OVER (
                 PARTITION BY thread_id
                 ORDER BY ts DESC, ts_nanos DESC, id DESC
-<<<<<<< HEAD
             ) AS cumulative_bytes
-=======
             ) AS cumulative_bytes,
             ROW_NUMBER() OVER (
                 PARTITION BY thread_id
                 ORDER BY ts DESC, ts_nanos DESC, id DESC
             ) AS row_number
->>>>>>> upstream_main
         FROM logs
         WHERE thread_id IN (
 "#,
@@ -157,11 +142,8 @@ WHERE id IN (
 "#,
                 );
                 prune_threads.push_bind(LOG_PARTITION_SIZE_LIMIT_BYTES);
-<<<<<<< HEAD
-=======
                 prune_threads.push(" OR row_number > ");
                 prune_threads.push_bind(LOG_PARTITION_ROW_LIMIT);
->>>>>>> upstream_main
                 prune_threads.push("\n)");
                 prune_threads.build().execute(&mut *tx).await?;
             }
@@ -190,11 +172,8 @@ WHERE id IN (
             over_limit_processes_query.push("estimated_bytes");
             over_limit_processes_query.push(") > ");
             over_limit_processes_query.push_bind(LOG_PARTITION_SIZE_LIMIT_BYTES);
-<<<<<<< HEAD
-=======
             over_limit_processes_query.push(" OR COUNT(*) > ");
             over_limit_processes_query.push_bind(LOG_PARTITION_ROW_LIMIT);
->>>>>>> upstream_main
             let over_limit_process_uuids: Vec<String> = over_limit_processes_query
                 .build()
                 .fetch_all(&mut *tx)
@@ -222,15 +201,12 @@ WHERE id IN (
             ) OVER (
                 PARTITION BY process_uuid
                 ORDER BY ts DESC, ts_nanos DESC, id DESC
-<<<<<<< HEAD
             ) AS cumulative_bytes
-=======
             ) AS cumulative_bytes,
             ROW_NUMBER() OVER (
                 PARTITION BY process_uuid
                 ORDER BY ts DESC, ts_nanos DESC, id DESC
             ) AS row_number
->>>>>>> upstream_main
         FROM logs
         WHERE thread_id IS NULL
           AND process_uuid IN (
@@ -250,11 +226,8 @@ WHERE id IN (
 "#,
                 );
                 prune_threadless_process_logs.push_bind(LOG_PARTITION_SIZE_LIMIT_BYTES);
-<<<<<<< HEAD
-=======
                 prune_threadless_process_logs.push(" OR row_number > ");
                 prune_threadless_process_logs.push_bind(LOG_PARTITION_ROW_LIMIT);
->>>>>>> upstream_main
                 prune_threadless_process_logs.push("\n)");
                 prune_threadless_process_logs
                     .build()
@@ -268,7 +241,6 @@ WHERE id IN (
             let mut null_process_usage_query = QueryBuilder::<Sqlite>::new("SELECT SUM(");
             null_process_usage_query.push("estimated_bytes");
             null_process_usage_query.push(
-<<<<<<< HEAD
                 ") AS total_bytes FROM logs WHERE thread_id IS NULL AND process_uuid IS NULL",
             );
             let total_null_process_bytes: Option<i64> = null_process_usage_query
@@ -278,7 +250,6 @@ WHERE id IN (
                 .try_get("total_bytes")?;
 
             if total_null_process_bytes.unwrap_or(0) > LOG_PARTITION_SIZE_LIMIT_BYTES {
-=======
                 ") AS total_bytes, COUNT(*) AS row_count FROM logs WHERE thread_id IS NULL AND process_uuid IS NULL",
             );
             let null_process_usage = null_process_usage_query.build().fetch_one(&mut *tx).await?;
@@ -289,7 +260,6 @@ WHERE id IN (
             if total_null_process_bytes.unwrap_or(0) > LOG_PARTITION_SIZE_LIMIT_BYTES
                 || null_process_row_count > LOG_PARTITION_ROW_LIMIT
             {
->>>>>>> upstream_main
                 let mut prune_threadless_null_process_logs = QueryBuilder::<Sqlite>::new(
                     r#"
 DELETE FROM logs
@@ -307,15 +277,12 @@ WHERE id IN (
             ) OVER (
                 PARTITION BY process_uuid
                 ORDER BY ts DESC, ts_nanos DESC, id DESC
-<<<<<<< HEAD
             ) AS cumulative_bytes
-=======
             ) AS cumulative_bytes,
             ROW_NUMBER() OVER (
                 PARTITION BY process_uuid
                 ORDER BY ts DESC, ts_nanos DESC, id DESC
             ) AS row_number
->>>>>>> upstream_main
         FROM logs
         WHERE thread_id IS NULL
           AND process_uuid IS NULL
@@ -324,11 +291,8 @@ WHERE id IN (
 "#,
                 );
                 prune_threadless_null_process_logs.push_bind(LOG_PARTITION_SIZE_LIMIT_BYTES);
-<<<<<<< HEAD
-=======
                 prune_threadless_null_process_logs.push(" OR row_number > ");
                 prune_threadless_null_process_logs.push_bind(LOG_PARTITION_ROW_LIMIT);
->>>>>>> upstream_main
                 prune_threadless_null_process_logs.push("\n)");
                 prune_threadless_null_process_logs
                     .build()
@@ -342,11 +306,8 @@ WHERE id IN (
     pub(crate) async fn delete_logs_before(&self, cutoff_ts: i64) -> anyhow::Result<u64> {
         let result = sqlx::query("DELETE FROM logs WHERE ts < ?")
             .bind(cutoff_ts)
-<<<<<<< HEAD
             .execute(self.pool.as_ref())
-=======
             .execute(self.logs_pool.as_ref())
->>>>>>> upstream_main
             .await?;
         Ok(result.rows_affected())
     }
@@ -354,11 +315,8 @@ WHERE id IN (
     /// Query logs with optional filters.
     pub async fn query_logs(&self, query: &LogQuery) -> anyhow::Result<Vec<LogRow>> {
         let mut builder = QueryBuilder::<Sqlite>::new(
-<<<<<<< HEAD
             "SELECT id, ts, ts_nanos, level, target, message, thread_id, process_uuid, file, line FROM logs WHERE 1 = 1",
-=======
             "SELECT id, ts, ts_nanos, level, target, feedback_log_body AS message, thread_id, process_uuid, file, line FROM logs WHERE 1 = 1",
->>>>>>> upstream_main
         );
         push_log_filters(&mut builder, query);
         if query.descending {
@@ -372,17 +330,12 @@ WHERE id IN (
 
         let rows = builder
             .build_query_as::<LogRow>()
-<<<<<<< HEAD
             .fetch_all(self.pool.as_ref())
-=======
             .fetch_all(self.logs_pool.as_ref())
->>>>>>> upstream_main
             .await?;
         Ok(rows)
     }
 
-<<<<<<< HEAD
-=======
     /// Query per-thread feedback logs, capped to the per-thread SQLite retention budget.
     pub async fn query_feedback_logs(&self, thread_id: &str) -> anyhow::Result<Vec<u8>> {
         let max_bytes = usize::try_from(LOG_PARTITION_SIZE_LIMIT_BYTES).unwrap_or(usize::MAX);
@@ -452,24 +405,18 @@ ORDER BY ts DESC, ts_nanos DESC, id DESC
         Ok(ordered_bytes)
     }
 
->>>>>>> upstream_main
     /// Return the max log id matching optional filters.
     pub async fn max_log_id(&self, query: &LogQuery) -> anyhow::Result<i64> {
         let mut builder =
             QueryBuilder::<Sqlite>::new("SELECT MAX(id) AS max_id FROM logs WHERE 1 = 1");
         push_log_filters(&mut builder, query);
-<<<<<<< HEAD
         let row = builder.build().fetch_one(self.pool.as_ref()).await?;
-=======
         let row = builder.build().fetch_one(self.logs_pool.as_ref()).await?;
->>>>>>> upstream_main
         let max_id: Option<i64> = row.try_get("max_id")?;
         Ok(max_id.unwrap_or(0))
     }
 }
 
-<<<<<<< HEAD
-=======
 #[derive(sqlx::FromRow)]
 struct FeedbackLogRow {
     ts: i64,
@@ -496,7 +443,6 @@ fn format_feedback_log_line(
     line
 }
 
->>>>>>> upstream_main
 fn push_log_filters<'a>(builder: &mut QueryBuilder<'a, Sqlite>, query: &'a LogQuery) {
     if let Some(level_upper) = query.level_upper.as_ref() {
         builder
@@ -534,11 +480,8 @@ fn push_log_filters<'a>(builder: &mut QueryBuilder<'a, Sqlite>, query: &'a LogQu
         builder.push(" AND id > ").push_bind(after_id);
     }
     if let Some(search) = query.search.as_ref() {
-<<<<<<< HEAD
         builder.push(" AND INSTR(message, ");
-=======
         builder.push(" AND INSTR(COALESCE(feedback_log_body, ''), ");
->>>>>>> upstream_main
         builder.push_bind(search.as_str());
         builder.push(") > 0");
     }
@@ -569,7 +512,6 @@ fn push_like_filters<'a>(
 #[cfg(test)]
 mod tests {
     use super::StateRuntime;
-<<<<<<< HEAD
     use super::test_support::unique_temp_dir;
     use crate::LogEntry;
     use crate::LogQuery;
@@ -578,7 +520,6 @@ mod tests {
     async fn query_logs_with_search_matches_substring() {
         let codex_home = unique_temp_dir();
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
-=======
     use super::format_feedback_log_line;
     use super::test_support::unique_temp_dir;
     use crate::LogEntry;
@@ -762,7 +703,6 @@ mod tests {
     async fn query_logs_with_search_matches_rendered_body_substring() {
         let codex_home = unique_temp_dir();
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
->>>>>>> upstream_main
             .await
             .expect("initialize runtime");
 
@@ -774,10 +714,7 @@ mod tests {
                     level: "INFO".to_string(),
                     target: "cli".to_string(),
                     message: Some("alpha".to_string()),
-<<<<<<< HEAD
-=======
                     feedback_log_body: Some("foo=1 alpha".to_string()),
->>>>>>> upstream_main
                     thread_id: Some("thread-1".to_string()),
                     process_uuid: None,
                     file: Some("main.rs".to_string()),
@@ -790,10 +727,7 @@ mod tests {
                     level: "INFO".to_string(),
                     target: "cli".to_string(),
                     message: Some("alphabet".to_string()),
-<<<<<<< HEAD
-=======
                     feedback_log_body: Some("foo=2 alphabet".to_string()),
->>>>>>> upstream_main
                     thread_id: Some("thread-1".to_string()),
                     process_uuid: None,
                     file: Some("main.rs".to_string()),
@@ -806,22 +740,16 @@ mod tests {
 
         let rows = runtime
             .query_logs(&LogQuery {
-<<<<<<< HEAD
                 search: Some("alphab".to_string()),
-=======
                 search: Some("foo=2".to_string()),
->>>>>>> upstream_main
                 ..Default::default()
             })
             .await
             .expect("query matching logs");
 
         assert_eq!(rows.len(), 1);
-<<<<<<< HEAD
         assert_eq!(rows[0].message.as_deref(), Some("alphabet"));
-=======
         assert_eq!(rows[0].message.as_deref(), Some("foo=2 alphabet"));
->>>>>>> upstream_main
 
         let _ = tokio::fs::remove_dir_all(codex_home).await;
     }
@@ -829,11 +757,8 @@ mod tests {
     #[tokio::test]
     async fn insert_logs_prunes_old_rows_when_thread_exceeds_size_limit() {
         let codex_home = unique_temp_dir();
-<<<<<<< HEAD
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
-=======
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
->>>>>>> upstream_main
             .await
             .expect("initialize runtime");
 
@@ -845,12 +770,9 @@ mod tests {
                     ts_nanos: 0,
                     level: "INFO".to_string(),
                     target: "cli".to_string(),
-<<<<<<< HEAD
                     message: Some(six_mebibytes.clone()),
-=======
                     message: Some("small".to_string()),
                     feedback_log_body: Some(six_mebibytes.clone()),
->>>>>>> upstream_main
                     thread_id: Some("thread-1".to_string()),
                     process_uuid: Some("proc-1".to_string()),
                     file: Some("main.rs".to_string()),
@@ -862,12 +784,9 @@ mod tests {
                     ts_nanos: 0,
                     level: "INFO".to_string(),
                     target: "cli".to_string(),
-<<<<<<< HEAD
                     message: Some(six_mebibytes.clone()),
-=======
                     message: Some("small".to_string()),
                     feedback_log_body: Some(six_mebibytes.clone()),
->>>>>>> upstream_main
                     thread_id: Some("thread-1".to_string()),
                     process_uuid: Some("proc-1".to_string()),
                     file: Some("main.rs".to_string()),
@@ -895,11 +814,8 @@ mod tests {
     #[tokio::test]
     async fn insert_logs_prunes_single_thread_row_when_it_exceeds_size_limit() {
         let codex_home = unique_temp_dir();
-<<<<<<< HEAD
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
-=======
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
->>>>>>> upstream_main
             .await
             .expect("initialize runtime");
 
@@ -910,12 +826,9 @@ mod tests {
                 ts_nanos: 0,
                 level: "INFO".to_string(),
                 target: "cli".to_string(),
-<<<<<<< HEAD
                 message: Some(eleven_mebibytes),
-=======
                 message: Some("small".to_string()),
                 feedback_log_body: Some(eleven_mebibytes),
->>>>>>> upstream_main
                 thread_id: Some("thread-oversized".to_string()),
                 process_uuid: Some("proc-1".to_string()),
                 file: Some("main.rs".to_string()),
@@ -941,11 +854,8 @@ mod tests {
     #[tokio::test]
     async fn insert_logs_prunes_threadless_rows_per_process_uuid_only() {
         let codex_home = unique_temp_dir();
-<<<<<<< HEAD
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
-=======
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
->>>>>>> upstream_main
             .await
             .expect("initialize runtime");
 
@@ -958,10 +868,7 @@ mod tests {
                     level: "INFO".to_string(),
                     target: "cli".to_string(),
                     message: Some(six_mebibytes.clone()),
-<<<<<<< HEAD
-=======
                     feedback_log_body: None,
->>>>>>> upstream_main
                     thread_id: None,
                     process_uuid: Some("proc-1".to_string()),
                     file: Some("main.rs".to_string()),
@@ -974,10 +881,7 @@ mod tests {
                     level: "INFO".to_string(),
                     target: "cli".to_string(),
                     message: Some(six_mebibytes.clone()),
-<<<<<<< HEAD
-=======
                     feedback_log_body: None,
->>>>>>> upstream_main
                     thread_id: None,
                     process_uuid: Some("proc-1".to_string()),
                     file: Some("main.rs".to_string()),
@@ -990,10 +894,7 @@ mod tests {
                     level: "INFO".to_string(),
                     target: "cli".to_string(),
                     message: Some(six_mebibytes),
-<<<<<<< HEAD
-=======
                     feedback_log_body: None,
->>>>>>> upstream_main
                     thread_id: Some("thread-1".to_string()),
                     process_uuid: Some("proc-1".to_string()),
                     file: Some("main.rs".to_string()),
@@ -1023,11 +924,8 @@ mod tests {
     #[tokio::test]
     async fn insert_logs_prunes_single_threadless_process_row_when_it_exceeds_size_limit() {
         let codex_home = unique_temp_dir();
-<<<<<<< HEAD
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
-=======
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
->>>>>>> upstream_main
             .await
             .expect("initialize runtime");
 
@@ -1038,12 +936,9 @@ mod tests {
                 ts_nanos: 0,
                 level: "INFO".to_string(),
                 target: "cli".to_string(),
-<<<<<<< HEAD
                 message: Some(eleven_mebibytes),
-=======
                 message: Some("small".to_string()),
                 feedback_log_body: Some(eleven_mebibytes),
->>>>>>> upstream_main
                 thread_id: None,
                 process_uuid: Some("proc-oversized".to_string()),
                 file: Some("main.rs".to_string()),
@@ -1069,11 +964,8 @@ mod tests {
     #[tokio::test]
     async fn insert_logs_prunes_threadless_rows_with_null_process_uuid() {
         let codex_home = unique_temp_dir();
-<<<<<<< HEAD
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
-=======
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
->>>>>>> upstream_main
             .await
             .expect("initialize runtime");
 
@@ -1086,10 +978,7 @@ mod tests {
                     level: "INFO".to_string(),
                     target: "cli".to_string(),
                     message: Some(six_mebibytes.clone()),
-<<<<<<< HEAD
-=======
                     feedback_log_body: None,
->>>>>>> upstream_main
                     thread_id: None,
                     process_uuid: None,
                     file: Some("main.rs".to_string()),
@@ -1102,10 +991,7 @@ mod tests {
                     level: "INFO".to_string(),
                     target: "cli".to_string(),
                     message: Some(six_mebibytes),
-<<<<<<< HEAD
-=======
                     feedback_log_body: None,
->>>>>>> upstream_main
                     thread_id: None,
                     process_uuid: None,
                     file: Some("main.rs".to_string()),
@@ -1118,10 +1004,7 @@ mod tests {
                     level: "INFO".to_string(),
                     target: "cli".to_string(),
                     message: Some("small".to_string()),
-<<<<<<< HEAD
-=======
                     feedback_log_body: None,
->>>>>>> upstream_main
                     thread_id: None,
                     process_uuid: Some("proc-1".to_string()),
                     file: Some("main.rs".to_string()),
@@ -1150,11 +1033,8 @@ mod tests {
     #[tokio::test]
     async fn insert_logs_prunes_single_threadless_null_process_row_when_it_exceeds_limit() {
         let codex_home = unique_temp_dir();
-<<<<<<< HEAD
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
-=======
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
->>>>>>> upstream_main
             .await
             .expect("initialize runtime");
 
@@ -1165,12 +1045,9 @@ mod tests {
                 ts_nanos: 0,
                 level: "INFO".to_string(),
                 target: "cli".to_string(),
-<<<<<<< HEAD
                 message: Some(eleven_mebibytes),
-=======
                 message: Some("small".to_string()),
                 feedback_log_body: Some(eleven_mebibytes),
->>>>>>> upstream_main
                 thread_id: None,
                 process_uuid: None,
                 file: Some("main.rs".to_string()),
@@ -1192,8 +1069,6 @@ mod tests {
 
         let _ = tokio::fs::remove_dir_all(codex_home).await;
     }
-<<<<<<< HEAD
-=======
 
     #[tokio::test]
     async fn insert_logs_prunes_old_rows_when_thread_exceeds_row_limit() {
@@ -1692,5 +1567,4 @@ mod tests {
 
         let _ = tokio::fs::remove_dir_all(codex_home).await;
     }
->>>>>>> upstream_main
 }

--- a/codex-rs/state/src/runtime/memories.rs
+++ b/codex-rs/state/src/runtime/memories.rs
@@ -30,12 +30,9 @@ impl StateRuntime {
     /// stage-1 (`memory_stage1`) and phase-2 (`memory_consolidate_global`)
     /// memory pipelines.
     pub async fn clear_memory_data(&self) -> anyhow::Result<()> {
-<<<<<<< HEAD
         self.clear_memory_data_inner(false).await
-=======
         self.clear_memory_data_inner(/*disable_existing_threads*/ false)
             .await
->>>>>>> upstream_main
     }
 
     /// Resets persisted memory state for a clean-slate local start.
@@ -44,12 +41,9 @@ impl StateRuntime {
     /// jobs, this disables memory generation for all existing threads so
     /// historical rollouts are not immediately picked up again.
     pub async fn reset_memory_data_for_fresh_start(&self) -> anyhow::Result<()> {
-<<<<<<< HEAD
         self.clear_memory_data_inner(true).await
-=======
         self.clear_memory_data_inner(/*disable_existing_threads*/ true)
             .await
->>>>>>> upstream_main
     }
 
     async fn clear_memory_data_inner(&self, disable_existing_threads: bool) -> anyhow::Result<()> {
@@ -211,11 +205,8 @@ LEFT JOIN jobs
             /*model_providers*/ None,
             /*anchor*/ None,
             SortKey::UpdatedAt,
-<<<<<<< HEAD
             None,
-=======
             /*search_term*/ None,
->>>>>>> upstream_main
         );
         builder.push(" AND threads.memory_mode = 'enabled'");
         builder
@@ -309,8 +300,6 @@ LIMIT ?
             .collect::<Result<Vec<_>, _>>()
     }
 
-<<<<<<< HEAD
-=======
     /// Prunes stale stage-1 outputs while preserving the latest phase-2
     /// baseline and stage-1 job watermarks.
     ///
@@ -354,7 +343,6 @@ WHERE thread_id IN (
         Ok(rows_affected as usize)
     }
 
->>>>>>> upstream_main
     /// Returns the current phase-2 input set along with its diff against the
     /// last successful phase-2 selection.
     ///
@@ -368,13 +356,11 @@ WHERE thread_id IN (
     ///   `thread_id DESC`
     /// - previously selected rows are identified by `selected_for_phase2 = 1`
     /// - `previous_selected` contains the current persisted rows that belonged
-<<<<<<< HEAD
     ///   to the last successful phase-2 baseline
     /// - `retained_thread_ids` records which current rows still match the exact
     ///   snapshot selected in the last successful phase-2 run
     /// - removed rows are previously selected rows that are still present in
     ///   `stage1_outputs` but fall outside the current top-`n` selection
-=======
     ///   to the last successful phase-2 baseline, even if those threads are no
     ///   longer memory-eligible
     /// - `retained_thread_ids` records which current rows still match the exact
@@ -382,7 +368,6 @@ WHERE thread_id IN (
     /// - removed rows are previously selected rows that are still present in
     ///   `stage1_outputs` but are no longer in the current selection, including
     ///   threads that are no longer memory-eligible
->>>>>>> upstream_main
     pub async fn get_phase2_input_selection(
         &self,
         n: usize,
@@ -410,12 +395,9 @@ SELECT
 FROM stage1_outputs AS so
 LEFT JOIN threads AS t
     ON t.id = so.thread_id
-<<<<<<< HEAD
 WHERE (length(trim(so.raw_memory)) > 0 OR length(trim(so.rollout_summary)) > 0)
-=======
 WHERE t.memory_mode = 'enabled'
   AND (length(trim(so.raw_memory)) > 0 OR length(trim(so.rollout_summary)) > 0)
->>>>>>> upstream_main
   AND (
         (so.last_usage IS NOT NULL AND so.last_usage >= ?)
         OR (so.last_usage IS NULL AND so.source_updated_at >= ?)
@@ -500,8 +482,6 @@ ORDER BY so.source_updated_at DESC, so.thread_id DESC
         })
     }
 
-<<<<<<< HEAD
-=======
     /// Marks a thread as polluted and enqueues phase-2 forgetting when the
     /// thread participated in the last successful phase-2 baseline.
     pub async fn mark_thread_memory_mode_polluted(
@@ -547,7 +527,6 @@ WHERE thread_id = ?
         Ok(true)
     }
 
->>>>>>> upstream_main
     /// Attempts to claim a stage-1 job for a thread at `source_updated_at`.
     ///
     /// Claim semantics:
@@ -1329,11 +1308,8 @@ mod tests {
     #[tokio::test]
     async fn stage1_claim_skips_when_up_to_date() {
         let codex_home = unique_temp_dir();
-<<<<<<< HEAD
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
-=======
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
->>>>>>> upstream_main
             .await
             .expect("initialize runtime");
 
@@ -1392,11 +1368,8 @@ mod tests {
     #[tokio::test]
     async fn stage1_running_stale_can_be_stolen_but_fresh_running_is_skipped() {
         let codex_home = unique_temp_dir();
-<<<<<<< HEAD
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
-=======
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
->>>>>>> upstream_main
             .await
             .expect("initialize runtime");
 
@@ -1442,11 +1415,8 @@ mod tests {
     #[tokio::test]
     async fn stage1_concurrent_claim_for_same_thread_is_conflict_safe() {
         let codex_home = unique_temp_dir();
-<<<<<<< HEAD
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
-=======
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
->>>>>>> upstream_main
             .await
             .expect("initialize runtime");
 
@@ -1511,11 +1481,8 @@ mod tests {
     #[tokio::test]
     async fn stage1_concurrent_claims_respect_running_cap() {
         let codex_home = unique_temp_dir();
-<<<<<<< HEAD
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
-=======
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
->>>>>>> upstream_main
             .await
             .expect("initialize runtime");
 
@@ -1577,11 +1544,8 @@ mod tests {
     #[tokio::test]
     async fn claim_stage1_jobs_filters_by_age_idle_and_current_thread() {
         let codex_home = unique_temp_dir();
-<<<<<<< HEAD
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
-=======
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
->>>>>>> upstream_main
             .await
             .expect("initialize runtime");
 
@@ -1671,11 +1635,8 @@ mod tests {
     #[tokio::test]
     async fn claim_stage1_jobs_prefilters_threads_with_up_to_date_memory() {
         let codex_home = unique_temp_dir();
-<<<<<<< HEAD
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
-=======
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
->>>>>>> upstream_main
             .await
             .expect("initialize runtime");
 
@@ -1774,11 +1735,8 @@ mod tests {
     #[tokio::test]
     async fn claim_stage1_jobs_skips_threads_with_disabled_memory_mode() {
         let codex_home = unique_temp_dir();
-<<<<<<< HEAD
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
-=======
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
->>>>>>> upstream_main
             .await
             .expect("initialize runtime");
 
@@ -1849,11 +1807,8 @@ mod tests {
     #[tokio::test]
     async fn reset_memory_data_for_fresh_start_clears_rows_and_disables_threads() {
         let codex_home = unique_temp_dir();
-<<<<<<< HEAD
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
-=======
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
->>>>>>> upstream_main
             .await
             .expect("initialize runtime");
 
@@ -1962,11 +1917,8 @@ mod tests {
     #[tokio::test]
     async fn claim_stage1_jobs_enforces_global_running_cap() {
         let codex_home = unique_temp_dir();
-<<<<<<< HEAD
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
-=======
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
->>>>>>> upstream_main
             .await
             .expect("initialize runtime");
 
@@ -2093,11 +2045,8 @@ WHERE kind = 'memory_stage1'
     #[tokio::test]
     async fn claim_stage1_jobs_processes_two_full_batches_across_startup_passes() {
         let codex_home = unique_temp_dir();
-<<<<<<< HEAD
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
-=======
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
->>>>>>> upstream_main
             .await
             .expect("initialize runtime");
 
@@ -2184,11 +2133,8 @@ WHERE kind = 'memory_stage1'
     #[tokio::test]
     async fn stage1_output_cascades_on_thread_delete() {
         let codex_home = unique_temp_dir();
-<<<<<<< HEAD
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
-=======
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
->>>>>>> upstream_main
             .await
             .expect("initialize runtime");
 
@@ -2255,11 +2201,8 @@ WHERE kind = 'memory_stage1'
     #[tokio::test]
     async fn mark_stage1_job_succeeded_no_output_skips_phase2_when_output_was_already_absent() {
         let codex_home = unique_temp_dir();
-<<<<<<< HEAD
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
-=======
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
->>>>>>> upstream_main
             .await
             .expect("initialize runtime");
 
@@ -2338,11 +2281,8 @@ WHERE kind = 'memory_stage1'
     #[tokio::test]
     async fn mark_stage1_job_succeeded_no_output_enqueues_phase2_when_deleting_output() {
         let codex_home = unique_temp_dir();
-<<<<<<< HEAD
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
-=======
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
->>>>>>> upstream_main
             .await
             .expect("initialize runtime");
 
@@ -2453,11 +2393,8 @@ WHERE kind = 'memory_stage1'
     #[tokio::test]
     async fn stage1_retry_exhaustion_does_not_block_newer_watermark() {
         let codex_home = unique_temp_dir();
-<<<<<<< HEAD
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
-=======
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
->>>>>>> upstream_main
             .await
             .expect("initialize runtime");
 
@@ -2539,11 +2476,8 @@ WHERE kind = 'memory_stage1'
     #[tokio::test]
     async fn phase2_global_consolidation_reruns_when_watermark_advances() {
         let codex_home = unique_temp_dir();
-<<<<<<< HEAD
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
-=======
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
->>>>>>> upstream_main
             .await
             .expect("initialize runtime");
 
@@ -2599,11 +2533,8 @@ WHERE kind = 'memory_stage1'
     #[tokio::test]
     async fn list_stage1_outputs_for_global_returns_latest_outputs() {
         let codex_home = unique_temp_dir();
-<<<<<<< HEAD
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
-=======
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
->>>>>>> upstream_main
             .await
             .expect("initialize runtime");
 
@@ -2694,11 +2625,8 @@ WHERE kind = 'memory_stage1'
     #[tokio::test]
     async fn list_stage1_outputs_for_global_skips_empty_payloads() {
         let codex_home = unique_temp_dir();
-<<<<<<< HEAD
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
-=======
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
->>>>>>> upstream_main
             .await
             .expect("initialize runtime");
 
@@ -2765,11 +2693,9 @@ VALUES (?, ?, ?, ?, ?)
     }
 
     #[tokio::test]
-<<<<<<< HEAD
     async fn get_phase2_input_selection_reports_added_retained_and_removed_rows() {
         let codex_home = unique_temp_dir();
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
-=======
     async fn list_stage1_outputs_for_global_skips_polluted_threads() {
         let codex_home = unique_temp_dir();
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
@@ -2838,7 +2764,6 @@ VALUES (?, ?, ?, ?, ?)
     async fn get_phase2_input_selection_reports_added_retained_and_removed_rows() {
         let codex_home = unique_temp_dir();
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
->>>>>>> upstream_main
             .await
             .expect("initialize runtime");
 
@@ -2948,11 +2873,9 @@ VALUES (?, ?, ?, ?, ?)
     }
 
     #[tokio::test]
-<<<<<<< HEAD
     async fn get_phase2_input_selection_treats_regenerated_selected_rows_as_added() {
         let codex_home = unique_temp_dir();
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
-=======
     async fn get_phase2_input_selection_marks_polluted_previous_selection_as_removed() {
         let codex_home = unique_temp_dir();
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
@@ -3147,7 +3070,6 @@ VALUES (?, ?, ?, ?, ?)
     async fn get_phase2_input_selection_treats_regenerated_selected_rows_as_added() {
         let codex_home = unique_temp_dir();
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
->>>>>>> upstream_main
             .await
             .expect("initialize runtime");
 
@@ -3263,11 +3185,8 @@ VALUES (?, ?, ?, ?, ?)
     #[tokio::test]
     async fn get_phase2_input_selection_reports_regenerated_previous_selection_as_removed() {
         let codex_home = unique_temp_dir();
-<<<<<<< HEAD
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
-=======
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
->>>>>>> upstream_main
             .await
             .expect("initialize runtime");
 
@@ -3422,11 +3341,8 @@ VALUES (?, ?, ?, ?, ?)
     #[tokio::test]
     async fn mark_global_phase2_job_succeeded_updates_selected_snapshot_timestamp() {
         let codex_home = unique_temp_dir();
-<<<<<<< HEAD
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
-=======
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
->>>>>>> upstream_main
             .await
             .expect("initialize runtime");
 
@@ -3568,11 +3484,8 @@ VALUES (?, ?, ?, ?, ?)
     #[tokio::test]
     async fn mark_global_phase2_job_succeeded_only_marks_exact_selected_snapshots() {
         let codex_home = unique_temp_dir();
-<<<<<<< HEAD
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
-=======
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
->>>>>>> upstream_main
             .await
             .expect("initialize runtime");
 
@@ -3687,11 +3600,8 @@ VALUES (?, ?, ?, ?, ?)
     #[tokio::test]
     async fn record_stage1_output_usage_updates_usage_metadata() {
         let codex_home = unique_temp_dir();
-<<<<<<< HEAD
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
-=======
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
->>>>>>> upstream_main
             .await
             .expect("initialize runtime");
 
@@ -3790,11 +3700,8 @@ VALUES (?, ?, ?, ?, ?)
     #[tokio::test]
     async fn get_phase2_input_selection_prioritizes_usage_count_then_recent_usage() {
         let codex_home = unique_temp_dir();
-<<<<<<< HEAD
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
-=======
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
->>>>>>> upstream_main
             .await
             .expect("initialize runtime");
 
@@ -3885,11 +3792,8 @@ VALUES (?, ?, ?, ?, ?)
     #[tokio::test]
     async fn get_phase2_input_selection_excludes_stale_used_memories_but_keeps_fresh_never_used() {
         let codex_home = unique_temp_dir();
-<<<<<<< HEAD
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
-=======
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
->>>>>>> upstream_main
             .await
             .expect("initialize runtime");
 
@@ -3980,11 +3884,8 @@ VALUES (?, ?, ?, ?, ?)
     #[tokio::test]
     async fn get_phase2_input_selection_prefers_recent_thread_updates_over_recent_generation() {
         let codex_home = unique_temp_dir();
-<<<<<<< HEAD
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
-=======
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
->>>>>>> upstream_main
             .await
             .expect("initialize runtime");
 
@@ -4062,11 +3963,9 @@ VALUES (?, ?, ?, ?, ?)
     }
 
     #[tokio::test]
-<<<<<<< HEAD
     async fn mark_stage1_job_succeeded_enqueues_global_consolidation() {
         let codex_home = unique_temp_dir();
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
-=======
     async fn prune_stage1_outputs_for_retention_prunes_stale_unselected_rows_only() {
         let codex_home = unique_temp_dir();
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
@@ -4278,7 +4177,6 @@ VALUES (?, ?, ?, ?, ?)
     async fn mark_stage1_job_succeeded_enqueues_global_consolidation() {
         let codex_home = unique_temp_dir();
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
->>>>>>> upstream_main
             .await
             .expect("initialize runtime");
 
@@ -4367,11 +4265,8 @@ VALUES (?, ?, ?, ?, ?)
     #[tokio::test]
     async fn phase2_global_lock_allows_only_one_fresh_runner() {
         let codex_home = unique_temp_dir();
-<<<<<<< HEAD
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
-=======
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
->>>>>>> upstream_main
             .await
             .expect("initialize runtime");
 
@@ -4404,11 +4299,8 @@ VALUES (?, ?, ?, ?, ?)
     #[tokio::test]
     async fn phase2_global_lock_stale_lease_allows_takeover() {
         let codex_home = unique_temp_dir();
-<<<<<<< HEAD
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
-=======
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
->>>>>>> upstream_main
             .await
             .expect("initialize runtime");
 
@@ -4475,11 +4367,8 @@ VALUES (?, ?, ?, ?, ?)
     #[tokio::test]
     async fn phase2_backfilled_inputs_below_last_success_still_become_dirty() {
         let codex_home = unique_temp_dir();
-<<<<<<< HEAD
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
-=======
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
->>>>>>> upstream_main
             .await
             .expect("initialize runtime");
 
@@ -4538,11 +4427,8 @@ VALUES (?, ?, ?, ?, ?)
     #[tokio::test]
     async fn phase2_failure_fallback_updates_unowned_running_job() {
         let codex_home = unique_temp_dir();
-<<<<<<< HEAD
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
-=======
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
->>>>>>> upstream_main
             .await
             .expect("initialize runtime");
 

--- a/codex-rs/state/src/runtime/test_support.rs
+++ b/codex-rs/state/src/runtime/test_support.rs
@@ -5,11 +5,8 @@ use chrono::Utc;
 #[cfg(test)]
 use codex_protocol::ThreadId;
 #[cfg(test)]
-<<<<<<< HEAD
-=======
 use codex_protocol::openai_models::ReasoningEffort;
 #[cfg(test)]
->>>>>>> upstream_main
 use codex_protocol::protocol::AskForApproval;
 #[cfg(test)]
 use codex_protocol::protocol::SandboxPolicy;
@@ -53,14 +50,11 @@ pub(super) fn test_thread_metadata(
         source: "cli".to_string(),
         agent_nickname: None,
         agent_role: None,
-<<<<<<< HEAD
         model_provider: "test-provider".to_string(),
-=======
         agent_path: None,
         model_provider: "test-provider".to_string(),
         model: Some("gpt-5".to_string()),
         reasoning_effort: Some(ReasoningEffort::Medium),
->>>>>>> upstream_main
         cwd,
         cli_version: "0.0.0".to_string(),
         title: String::new(),

--- a/codex-rs/state/src/runtime/threads.rs
+++ b/codex-rs/state/src/runtime/threads.rs
@@ -1,8 +1,5 @@
 use super::*;
-<<<<<<< HEAD
-=======
 use codex_protocol::protocol::SessionSource;
->>>>>>> upstream_main
 
 impl StateRuntime {
     pub async fn get_thread(&self, id: ThreadId) -> anyhow::Result<Option<crate::ThreadMetadata>> {
@@ -16,14 +13,11 @@ SELECT
     source,
     agent_nickname,
     agent_role,
-<<<<<<< HEAD
     model_provider,
-=======
     agent_path,
     model_provider,
     model,
     reasoning_effort,
->>>>>>> upstream_main
     cwd,
     cli_version,
     title,
@@ -46,8 +40,6 @@ WHERE id = ?
             .transpose()
     }
 
-<<<<<<< HEAD
-=======
     pub async fn get_thread_memory_mode(&self, id: ThreadId) -> anyhow::Result<Option<String>> {
         let row = sqlx::query("SELECT memory_mode FROM threads WHERE id = ?")
             .bind(id.to_string())
@@ -56,7 +48,6 @@ WHERE id = ?
         Ok(row.and_then(|row| row.try_get("memory_mode").ok()))
     }
 
->>>>>>> upstream_main
     /// Get dynamic tools for a thread, if present.
     pub async fn get_dynamic_tools(
         &self,
@@ -64,11 +55,8 @@ WHERE id = ?
     ) -> anyhow::Result<Option<Vec<DynamicToolSpec>>> {
         let rows = sqlx::query(
             r#"
-<<<<<<< HEAD
 SELECT name, description, input_schema
-=======
 SELECT name, description, input_schema, defer_loading
->>>>>>> upstream_main
 FROM thread_dynamic_tools
 WHERE thread_id = ?
 ORDER BY position ASC
@@ -88,17 +76,12 @@ ORDER BY position ASC
                 name: row.try_get("name")?,
                 description: row.try_get("description")?,
                 input_schema,
-<<<<<<< HEAD
-=======
                 defer_loading: row.try_get("defer_loading")?,
->>>>>>> upstream_main
             });
         }
         Ok(Some(tools))
     }
 
-<<<<<<< HEAD
-=======
     /// Persist or replace the directional parent-child edge for a spawned thread.
     pub async fn upsert_thread_spawn_edge(
         &self,
@@ -321,7 +304,6 @@ ON CONFLICT(child_thread_id) DO NOTHING
             .await
     }
 
->>>>>>> upstream_main
     /// Find a rollout path by thread id using the underlying database.
     pub async fn find_rollout_path_by_id(
         &self,
@@ -370,14 +352,11 @@ SELECT
     source,
     agent_nickname,
     agent_role,
-<<<<<<< HEAD
     model_provider,
-=======
     agent_path,
     model_provider,
     model,
     reasoning_effort,
->>>>>>> upstream_main
     cwd,
     cli_version,
     title,
@@ -442,11 +421,8 @@ FROM threads
             model_providers,
             anchor,
             sort_key,
-<<<<<<< HEAD
             None,
-=======
             /*search_term*/ None,
->>>>>>> upstream_main
         );
         push_thread_order_and_limit(&mut builder, sort_key, limit);
 
@@ -461,12 +437,10 @@ FROM threads
 
     /// Insert or replace thread metadata directly.
     pub async fn upsert_thread(&self, metadata: &crate::ThreadMetadata) -> anyhow::Result<()> {
-<<<<<<< HEAD
         self.upsert_thread_with_creation_memory_mode(metadata, None)
             .await
     }
 
-=======
         self.upsert_thread_with_creation_memory_mode(metadata, /*creation_memory_mode*/ None)
             .await
     }
@@ -597,7 +571,6 @@ WHERE id = ?
         Ok(result.rows_affected() > 0)
     }
 
->>>>>>> upstream_main
     async fn upsert_thread_with_creation_memory_mode(
         &self,
         metadata: &crate::ThreadMetadata,
@@ -613,14 +586,11 @@ INSERT INTO threads (
     source,
     agent_nickname,
     agent_role,
-<<<<<<< HEAD
     model_provider,
-=======
     agent_path,
     model_provider,
     model,
     reasoning_effort,
->>>>>>> upstream_main
     cwd,
     cli_version,
     title,
@@ -634,11 +604,8 @@ INSERT INTO threads (
     git_branch,
     git_origin_url,
     memory_mode
-<<<<<<< HEAD
 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-=======
 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
->>>>>>> upstream_main
 ON CONFLICT(id) DO UPDATE SET
     rollout_path = excluded.rollout_path,
     created_at = excluded.created_at,
@@ -646,14 +613,11 @@ ON CONFLICT(id) DO UPDATE SET
     source = excluded.source,
     agent_nickname = excluded.agent_nickname,
     agent_role = excluded.agent_role,
-<<<<<<< HEAD
     model_provider = excluded.model_provider,
-=======
     agent_path = excluded.agent_path,
     model_provider = excluded.model_provider,
     model = excluded.model,
     reasoning_effort = excluded.reasoning_effort,
->>>>>>> upstream_main
     cwd = excluded.cwd,
     cli_version = excluded.cli_version,
     title = excluded.title,
@@ -675,9 +639,7 @@ ON CONFLICT(id) DO UPDATE SET
         .bind(metadata.source.as_str())
         .bind(metadata.agent_nickname.as_deref())
         .bind(metadata.agent_role.as_deref())
-<<<<<<< HEAD
         .bind(metadata.model_provider.as_str())
-=======
         .bind(metadata.agent_path.as_deref())
         .bind(metadata.model_provider.as_str())
         .bind(metadata.model.as_deref())
@@ -687,7 +649,6 @@ ON CONFLICT(id) DO UPDATE SET
                 .as_ref()
                 .map(crate::extract::enum_to_string),
         )
->>>>>>> upstream_main
         .bind(metadata.cwd.display().to_string())
         .bind(metadata.cli_version.as_str())
         .bind(metadata.title.as_str())
@@ -703,11 +664,8 @@ ON CONFLICT(id) DO UPDATE SET
         .bind(creation_memory_mode.unwrap_or("enabled"))
         .execute(self.pool.as_ref())
         .await?;
-<<<<<<< HEAD
-=======
         self.insert_thread_spawn_edge_from_source_if_absent(metadata.id, metadata.source.as_str())
             .await?;
->>>>>>> upstream_main
         Ok(())
     }
 
@@ -738,14 +696,11 @@ INSERT INTO thread_dynamic_tools (
     position,
     name,
     description,
-<<<<<<< HEAD
     input_schema
 ) VALUES (?, ?, ?, ?, ?)
-=======
     input_schema,
     defer_loading
 ) VALUES (?, ?, ?, ?, ?, ?)
->>>>>>> upstream_main
 ON CONFLICT(thread_id, position) DO NOTHING
                 "#,
             )
@@ -754,10 +709,7 @@ ON CONFLICT(thread_id, position) DO NOTHING
             .bind(tool.name.as_str())
             .bind(tool.description.as_str())
             .bind(input_schema)
-<<<<<<< HEAD
-=======
             .bind(tool.defer_loading)
->>>>>>> upstream_main
             .execute(&mut *tx)
             .await?;
         }
@@ -770,13 +722,10 @@ ON CONFLICT(thread_id, position) DO NOTHING
         &self,
         builder: &ThreadMetadataBuilder,
         items: &[RolloutItem],
-<<<<<<< HEAD
         otel: Option<&OtelManager>,
         new_thread_memory_mode: Option<&str>,
-=======
         new_thread_memory_mode: Option<&str>,
         updated_at_override: Option<DateTime<Utc>>,
->>>>>>> upstream_main
     ) -> anyhow::Result<()> {
         if items.is_empty() {
             return Ok(());
@@ -789,9 +738,7 @@ ON CONFLICT(thread_id, position) DO NOTHING
         for item in items {
             apply_rollout_item(&mut metadata, item, &self.default_provider);
         }
-<<<<<<< HEAD
         if let Some(updated_at) = file_modified_time_utc(builder.rollout_path.as_path()).await {
-=======
         if let Some(existing_metadata) = existing_metadata.as_ref() {
             metadata.prefer_existing_git_info(existing_metadata);
         }
@@ -800,7 +747,6 @@ ON CONFLICT(thread_id, position) DO NOTHING
             None => file_modified_time_utc(builder.rollout_path.as_path()).await,
         };
         if let Some(updated_at) = updated_at {
->>>>>>> upstream_main
             metadata.updated_at = updated_at;
         }
         // Keep the thread upsert before dynamic tools to satisfy the foreign key constraint:
@@ -811,19 +757,16 @@ ON CONFLICT(thread_id, position) DO NOTHING
         } else {
             self.upsert_thread(&metadata).await
         };
-<<<<<<< HEAD
         if let Err(err) = upsert_result {
             if let Some(otel) = otel {
                 otel.counter(DB_ERROR_METRIC, 1, &[("stage", "apply_rollout_items")]);
             }
-=======
         upsert_result?;
         if let Some(memory_mode) = extract_memory_mode(items)
             && let Err(err) = self
                 .set_thread_memory_mode(builder.id, memory_mode.as_str())
                 .await
         {
->>>>>>> upstream_main
             return Err(err);
         }
         let dynamic_tools = extract_dynamic_tools(items);
@@ -832,12 +775,9 @@ ON CONFLICT(thread_id, position) DO NOTHING
                 .persist_dynamic_tools(builder.id, dynamic_tools.as_deref())
                 .await
         {
-<<<<<<< HEAD
             if let Some(otel) = otel {
                 otel.counter(DB_ERROR_METRIC, 1, &[("stage", "persist_dynamic_tools")]);
             }
-=======
->>>>>>> upstream_main
             return Err(err);
         }
         Ok(())
@@ -900,8 +840,6 @@ ON CONFLICT(thread_id, position) DO NOTHING
     }
 }
 
-<<<<<<< HEAD
-=======
 fn one_thread_id_from_rows(
     rows: Vec<sqlx::sqlite::SqliteRow>,
     agent_path: &str,
@@ -922,7 +860,6 @@ fn one_thread_id_from_rows(
     }
 }
 
->>>>>>> upstream_main
 pub(super) fn extract_dynamic_tools(items: &[RolloutItem]) -> Option<Option<Vec<DynamicToolSpec>>> {
     items.iter().find_map(|item| match item {
         RolloutItem::SessionMeta(meta_line) => Some(meta_line.meta.dynamic_tools.clone()),
@@ -933,8 +870,6 @@ pub(super) fn extract_dynamic_tools(items: &[RolloutItem]) -> Option<Option<Vec<
     })
 }
 
-<<<<<<< HEAD
-=======
 pub(super) fn extract_memory_mode(items: &[RolloutItem]) -> Option<String> {
     items.iter().rev().find_map(|item| match item {
         RolloutItem::SessionMeta(meta_line) => meta_line.meta.memory_mode.clone(),
@@ -957,7 +892,6 @@ fn thread_spawn_parent_thread_id_from_source_str(source: &str) -> Option<ThreadI
     }
 }
 
->>>>>>> upstream_main
 pub(super) fn push_thread_filters<'a>(
     builder: &mut QueryBuilder<'a, Sqlite>,
     archived_only: bool,
@@ -1036,11 +970,9 @@ pub(super) fn push_thread_order_and_limit(
 #[cfg(test)]
 mod tests {
     use super::*;
-<<<<<<< HEAD
     use crate::runtime::test_support::test_thread_metadata;
     use crate::runtime::test_support::unique_temp_dir;
     use pretty_assertions::assert_eq;
-=======
     use crate::DirectionalThreadSpawnEdgeStatus;
     use crate::runtime::test_support::test_thread_metadata;
     use crate::runtime::test_support::unique_temp_dir;
@@ -1051,16 +983,12 @@ mod tests {
     use codex_protocol::protocol::SessionSource;
     use pretty_assertions::assert_eq;
     use std::path::PathBuf;
->>>>>>> upstream_main
 
     #[tokio::test]
     async fn upsert_thread_keeps_creation_memory_mode_for_existing_rows() {
         let codex_home = unique_temp_dir();
-<<<<<<< HEAD
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)
-=======
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
->>>>>>> upstream_main
             .await
             .expect("state db should initialize");
         let thread_id =
@@ -1094,8 +1022,6 @@ mod tests {
                 .expect("memory mode should remain readable");
         assert_eq!(memory_mode, "disabled");
     }
-<<<<<<< HEAD
-=======
 
     #[tokio::test]
     async fn apply_rollout_items_restores_memory_mode_from_session_meta() {
@@ -1533,5 +1459,4 @@ mod tests {
             .expect("open descendants from child should load");
         assert_eq!(open_descendants_from_child, vec![grandchild_thread_id]);
     }
->>>>>>> upstream_main
 }

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -64,17 +64,14 @@ use codex_core::config::ConfigBuilder;
 use codex_core::config::ConfigOverrides;
 use codex_core::config::edit::ConfigEdit;
 use codex_core::config::edit::ConfigEditsBuilder;
-<<<<<<< HEAD
 use codex_core::config::types::ModelAvailabilityNuxConfig;
 use codex_core::config_loader::ConfigLayerStackOrdering;
 use codex_core::features::Feature;
-=======
 use codex_core::config::types::ApprovalsReviewer;
 use codex_core::config::types::ModelAvailabilityNuxConfig;
 use codex_core::config_loader::CloudRequirementsLoader;
 use codex_core::config_loader::ConfigLayerStackOrdering;
 use codex_core::config_loader::LoaderOverrides;
->>>>>>> upstream_main
 use codex_core::models_manager::collaboration_mode_presets::CollaborationModesConfig;
 use codex_core::models_manager::manager::RefreshStrategy;
 use codex_core::models_manager::model_presets::HIDE_GPT_5_1_CODEX_MAX_MIGRATION_PROMPT_CONFIG;
@@ -962,11 +959,8 @@ pub(crate) struct App {
 
     thread_event_channels: HashMap<ThreadId, ThreadEventChannel>,
     thread_event_listener_tasks: HashMap<ThreadId, JoinHandle<()>>,
-<<<<<<< HEAD
     agent_picker_threads: HashMap<ThreadId, AgentPickerThreadEntry>,
-=======
     agent_navigation: AgentNavigationState,
->>>>>>> upstream_main
     active_thread_id: Option<ThreadId>,
     active_thread_rx: Option<mpsc::Receiver<Event>>,
     primary_thread_id: Option<ThreadId>,
@@ -1713,11 +1707,8 @@ impl App {
             let short_id: String = thread_id.chars().take(8).collect();
             format!("Agent ({short_id})")
         };
-<<<<<<< HEAD
         if let Some(entry) = self.agent_picker_threads.get(&thread_id) {
-=======
         if let Some(entry) = self.agent_navigation.get(&thread_id) {
->>>>>>> upstream_main
             let label = format_agent_picker_item_name(
                 entry.agent_nickname.as_deref(),
                 entry.agent_role.as_deref(),
@@ -1735,8 +1726,6 @@ impl App {
         }
     }
 
-<<<<<<< HEAD
-=======
     /// Returns the thread whose transcript is currently on screen.
     ///
     /// `active_thread_id` is the source of truth during steady state, but the widget can briefly
@@ -1760,7 +1749,6 @@ impl App {
         self.chat_widget.set_active_agent_label(label);
     }
 
->>>>>>> upstream_main
     async fn thread_cwd(&self, thread_id: ThreadId) -> Option<PathBuf> {
         let channel = self.thread_event_channels.get(&thread_id)?;
         let store = channel.store.lock().await;
@@ -1770,7 +1758,6 @@ impl App {
         }
     }
 
-<<<<<<< HEAD
     async fn approval_request_for_thread_event(
         &self,
         thread_id: ThreadId,
@@ -1806,7 +1793,6 @@ impl App {
                 request_id: ev.id.clone(),
                 message: ev.message.clone(),
             }),
-=======
     async fn interactive_request_for_thread_event(
         &self,
         thread_id: ThreadId,
@@ -1865,7 +1851,6 @@ impl App {
                     permissions: ev.permissions.clone(),
                 },
             )),
->>>>>>> upstream_main
             _ => None,
         }
     }
@@ -1933,13 +1918,10 @@ impl App {
     async fn enqueue_thread_event(&mut self, thread_id: ThreadId, event: Event) -> Result<()> {
         let refresh_pending_thread_approvals =
             ThreadEventStore::event_can_change_pending_thread_approvals(&event);
-<<<<<<< HEAD
         let inactive_approval_request = if self.active_thread_id != Some(thread_id) {
             self.approval_request_for_thread_event(thread_id, &event)
-=======
         let inactive_interactive_request = if self.active_thread_id != Some(thread_id) {
             self.interactive_request_for_thread_event(thread_id, &event)
->>>>>>> upstream_main
                 .await
         } else {
             None
@@ -1972,10 +1954,8 @@ impl App {
                     tracing::warn!("thread {thread_id} event channel closed");
                 }
             }
-<<<<<<< HEAD
         } else if let Some(request) = inactive_approval_request {
             self.chat_widget.push_approval_request(request);
-=======
         } else if let Some(request) = inactive_interactive_request {
             match request {
                 ThreadInteractiveRequest::Approval(request) => {
@@ -1986,7 +1966,6 @@ impl App {
                         .push_mcp_server_elicitation_request(request);
                 }
             }
->>>>>>> upstream_main
         }
         if refresh_pending_thread_approvals {
             self.refresh_pending_thread_approvals().await;
@@ -2221,8 +2200,6 @@ impl App {
         self.primary_thread_id = None;
         self.pending_primary_events.clear();
         self.chat_widget.set_pending_thread_approvals(Vec::new());
-<<<<<<< HEAD
-=======
         self.sync_active_agent_label();
     }
 
@@ -2234,7 +2211,6 @@ impl App {
         self.chat_widget = chat_widget;
         self.sync_active_agent_label();
         self.refresh_status_surfaces();
->>>>>>> upstream_main
     }
 
     async fn start_fresh_session_with_summary_hint(&mut self, tui: &mut tui::Tui) {
@@ -2426,18 +2402,15 @@ impl App {
             &config,
             auth_manager.clone(),
             SessionSource::Cli,
-<<<<<<< HEAD
             config.model_catalog.clone(),
             CollaborationModesConfig {
                 default_mode_request_user_input: config
                     .features
                     .enabled(codex_core::features::Feature::DefaultModeRequestUserInput),
-=======
             CollaborationModesConfig {
                 default_mode_request_user_input: config
                     .features
                     .enabled(Feature::DefaultModeRequestUserInput),
->>>>>>> upstream_main
             },
         ));
         let mut model = thread_manager
@@ -2540,10 +2513,7 @@ impl App {
                         config.clone(),
                         target_session.path.clone(),
                         auth_manager.clone(),
-<<<<<<< HEAD
-=======
                         /*parent_trace*/ None,
->>>>>>> upstream_main
                     )
                     .await
                     .wrap_err_with(|| {
@@ -2576,7 +2546,6 @@ impl App {
                 ChatWidget::new_from_existing(init, resumed.thread, resumed.session_configured)
             }
             SessionSelection::Fork(target_session) => {
-<<<<<<< HEAD
                 otel_manager.counter("codex.thread.fork", 1, &[("source", "cli_subcommand")]);
                 let forked = thread_manager
                     .fork_thread(
@@ -2584,7 +2553,6 @@ impl App {
                         config.clone(),
                         target_session.path.clone(),
                         false,
-=======
                 session_telemetry.counter(
                     "codex.thread.fork",
                     /*inc*/ 1,
@@ -2597,7 +2565,6 @@ impl App {
                         target_session.path.clone(),
                         /*persist_extended_history*/ false,
                         /*parent_trace*/ None,
->>>>>>> upstream_main
                     )
                     .await
                     .wrap_err_with(|| {
@@ -2672,11 +2639,8 @@ impl App {
             windows_sandbox: WindowsSandboxState::default(),
             thread_event_channels: HashMap::new(),
             thread_event_listener_tasks: HashMap::new(),
-<<<<<<< HEAD
             agent_picker_threads: HashMap::new(),
-=======
             agent_navigation: AgentNavigationState::default(),
->>>>>>> upstream_main
             active_thread_id: None,
             active_thread_rx: None,
             primary_thread_id: None,
@@ -2900,9 +2864,7 @@ impl App {
                 self.start_fresh_session_with_summary_hint(tui).await;
             }
             AppEvent::OpenResumePicker => {
-<<<<<<< HEAD
                 match crate::resume_picker::run_resume_picker(tui, &self.config, false).await? {
-=======
                 match crate::resume_picker::run_resume_picker(
                     tui,
                     &self.config,
@@ -2910,7 +2872,6 @@ impl App {
                 )
                 .await?
                 {
->>>>>>> upstream_main
                     SessionSelection::Resume(target_session) => {
                         let current_cwd = self.config.cwd.clone();
                         let resume_cwd = match crate::resolve_cwd_for_resume_or_fork(
@@ -3780,8 +3741,6 @@ impl App {
                     }
                 }
             }
-<<<<<<< HEAD
-=======
             AppEvent::PersistServiceTierSelection { service_tier } => {
                 self.refresh_status_surfaces();
                 let profile = self.active_profile.as_deref();
@@ -3815,7 +3774,6 @@ impl App {
                     }
                 }
             }
->>>>>>> upstream_main
             AppEvent::PersistRealtimeAudioDeviceSelection { kind, name } => {
                 let builder = match kind {
                     RealtimeAudioDeviceKind::Microphone => {
@@ -3847,11 +3805,8 @@ impl App {
                             let selection = name.unwrap_or_else(|| "System default".to_string());
                             self.chat_widget.add_info_message(
                                 format!("Realtime {} set to {selection}", kind.noun()),
-<<<<<<< HEAD
                                 None,
-=======
                                 /*hint*/ None,
->>>>>>> upstream_main
                             );
                         }
                     }
@@ -4859,11 +4814,9 @@ mod tests {
     use codex_core::config::ConfigBuilder;
     use codex_core::config::ConfigOverrides;
     use codex_core::config::types::ModelAvailabilityNuxConfig;
-<<<<<<< HEAD
     use codex_otel::OtelManager;
     use codex_protocol::ThreadId;
     use codex_protocol::openai_models::ModelAvailabilityNux;
-=======
     use codex_otel::SessionTelemetry;
     use codex_protocol::ThreadId;
     use codex_protocol::config_types::CollaborationMode;
@@ -4872,7 +4825,6 @@ mod tests {
     use codex_protocol::config_types::Settings;
     use codex_protocol::openai_models::ModelAvailabilityNux;
     use codex_protocol::protocol::AgentMessageDeltaEvent;
->>>>>>> upstream_main
     use codex_protocol::protocol::AskForApproval;
     use codex_protocol::protocol::Event;
     use codex_protocol::protocol::EventMsg;
@@ -5073,10 +5025,7 @@ mod tests {
                     proposed_execpolicy_amendment: None,
                     proposed_network_policy_amendments: None,
                     additional_permissions: None,
-<<<<<<< HEAD
-=======
                     skill_metadata: None,
->>>>>>> upstream_main
                     available_decisions: None,
                     parsed_cmd: Vec::new(),
                 },
@@ -5090,13 +5039,10 @@ mod tests {
                 thread_name: None,
                 model: "gpt-test".to_string(),
                 model_provider_id: "test-provider".to_string(),
-<<<<<<< HEAD
                 approval_policy: AskForApproval::Never,
-=======
                 service_tier: None,
                 approval_policy: AskForApproval::Never,
                 approvals_reviewer: ApprovalsReviewer::User,
->>>>>>> upstream_main
                 sandbox_policy: SandboxPolicy::new_read_only_policy(),
                 cwd: PathBuf::from("/tmp/project"),
                 reasoning_effort: None,
@@ -6123,8 +6069,6 @@ mod tests {
     }
 
     #[tokio::test]
-<<<<<<< HEAD
-=======
     async fn open_agent_picker_prompts_to_enable_multi_agent_when_disabled() -> Result<()> {
         let (mut app, mut app_event_rx, _op_rx) = make_test_app_with_channels().await;
         let _ = app.config.features.disable(Feature::Collab);
@@ -6700,7 +6644,6 @@ guardian_approval = true
     }
 
     #[tokio::test]
->>>>>>> upstream_main
     async fn refresh_pending_thread_approvals_only_lists_inactive_threads() {
         let mut app = make_test_app().await;
         let main_thread_id =
@@ -6730,10 +6673,7 @@ guardian_approval = true
                         proposed_execpolicy_amendment: None,
                         proposed_network_policy_amendments: None,
                         additional_permissions: None,
-<<<<<<< HEAD
-=======
                         skill_metadata: None,
->>>>>>> upstream_main
                         available_decisions: None,
                         parsed_cmd: Vec::new(),
                     },
@@ -6742,7 +6682,6 @@ guardian_approval = true
         }
         app.thread_event_channels
             .insert(agent_thread_id, agent_channel);
-<<<<<<< HEAD
         app.agent_picker_threads.insert(
             agent_thread_id,
             AgentPickerThreadEntry {
@@ -6750,13 +6689,11 @@ guardian_approval = true
                 agent_role: Some("explorer".to_string()),
                 is_closed: false,
             },
-=======
         app.agent_navigation.upsert(
             agent_thread_id,
             Some("Robie".to_string()),
             Some("explorer".to_string()),
             false,
->>>>>>> upstream_main
         );
 
         app.refresh_pending_thread_approvals().await;
@@ -6794,13 +6731,10 @@ guardian_approval = true
                         thread_name: None,
                         model: "gpt-5".to_string(),
                         model_provider_id: "test-provider".to_string(),
-<<<<<<< HEAD
                         approval_policy: AskForApproval::OnRequest,
-=======
                         service_tier: None,
                         approval_policy: AskForApproval::OnRequest,
                         approvals_reviewer: ApprovalsReviewer::User,
->>>>>>> upstream_main
                         sandbox_policy: SandboxPolicy::new_workspace_write_policy(),
                         cwd: PathBuf::from("/tmp/agent"),
                         reasoning_effort: None,
@@ -6813,7 +6747,6 @@ guardian_approval = true
                 },
             ),
         );
-<<<<<<< HEAD
         app.agent_picker_threads.insert(
             agent_thread_id,
             AgentPickerThreadEntry {
@@ -6821,13 +6754,11 @@ guardian_approval = true
                 agent_role: Some("explorer".to_string()),
                 is_closed: false,
             },
-=======
         app.agent_navigation.upsert(
             agent_thread_id,
             Some("Robie".to_string()),
             Some("explorer".to_string()),
             false,
->>>>>>> upstream_main
         );
 
         app.enqueue_thread_event(
@@ -6846,10 +6777,7 @@ guardian_approval = true
                         proposed_execpolicy_amendment: None,
                         proposed_network_policy_amendments: None,
                         additional_permissions: None,
-<<<<<<< HEAD
-=======
                         skill_metadata: None,
->>>>>>> upstream_main
                         available_decisions: None,
                         parsed_cmd: Vec::new(),
                     },
@@ -7051,10 +6979,7 @@ guardian_approval = true
                 is_first,
                 None,
                 None,
-<<<<<<< HEAD
-=======
                 false,
->>>>>>> upstream_main
             )) as Arc<dyn HistoryCell>
         };
 
@@ -7184,11 +7109,8 @@ guardian_approval = true
             windows_sandbox: WindowsSandboxState::default(),
             thread_event_channels: HashMap::new(),
             thread_event_listener_tasks: HashMap::new(),
-<<<<<<< HEAD
             agent_picker_threads: HashMap::new(),
-=======
             agent_navigation: AgentNavigationState::default(),
->>>>>>> upstream_main
             active_thread_id: None,
             active_thread_rx: None,
             primary_thread_id: None,
@@ -7252,11 +7174,8 @@ guardian_approval = true
                 windows_sandbox: WindowsSandboxState::default(),
                 thread_event_channels: HashMap::new(),
                 thread_event_listener_tasks: HashMap::new(),
-<<<<<<< HEAD
                 agent_picker_threads: HashMap::new(),
-=======
                 agent_navigation: AgentNavigationState::default(),
->>>>>>> upstream_main
                 active_thread_id: None,
                 active_thread_rx: None,
                 primary_thread_id: None,
@@ -7837,10 +7756,7 @@ guardian_approval = true
                 is_first,
                 None,
                 None,
-<<<<<<< HEAD
-=======
                 false,
->>>>>>> upstream_main
             )) as Arc<dyn HistoryCell>
         };
 

--- a/codex-rs/tui/src/app/pending_interactive_replay.rs
+++ b/codex-rs/tui/src/app/pending_interactive_replay.rs
@@ -52,10 +52,7 @@ impl PendingInteractiveReplayState {
             EventMsg::ExecApprovalRequest(_)
                 | EventMsg::ApplyPatchApprovalRequest(_)
                 | EventMsg::ElicitationRequest(_)
-<<<<<<< HEAD
-=======
                 | EventMsg::RequestPermissions(_)
->>>>>>> upstream_main
                 | EventMsg::ExecCommandBegin(_)
                 | EventMsg::PatchApplyBegin(_)
                 | EventMsg::TurnComplete(_)
@@ -301,10 +298,7 @@ impl PendingInteractiveReplayState {
         !self.exec_approval_call_ids.is_empty()
             || !self.patch_approval_call_ids.is_empty()
             || !self.elicitation_requests.is_empty()
-<<<<<<< HEAD
-=======
             || !self.request_permissions_call_ids.is_empty()
->>>>>>> upstream_main
     }
 
     fn clear_request_user_input_turn(&mut self, turn_id: &str) {
@@ -459,10 +453,7 @@ mod tests {
                     proposed_execpolicy_amendment: None,
                     proposed_network_policy_amendments: None,
                     additional_permissions: None,
-<<<<<<< HEAD
-=======
                     skill_metadata: None,
->>>>>>> upstream_main
                     available_decisions: None,
                     parsed_cmd: Vec::new(),
                 },
@@ -606,10 +597,7 @@ mod tests {
                     proposed_execpolicy_amendment: None,
                     proposed_network_policy_amendments: None,
                     additional_permissions: None,
-<<<<<<< HEAD
-=======
                     skill_metadata: None,
->>>>>>> upstream_main
                     available_decisions: None,
                     parsed_cmd: Vec::new(),
                 },
@@ -699,10 +687,7 @@ mod tests {
                     proposed_execpolicy_amendment: None,
                     proposed_network_policy_amendments: None,
                     additional_permissions: None,
-<<<<<<< HEAD
-=======
                     skill_metadata: None,
->>>>>>> upstream_main
                     available_decisions: None,
                     parsed_cmd: Vec::new(),
                 },

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -284,14 +284,11 @@ pub(crate) enum AppEvent {
         personality: Personality,
     },
 
-<<<<<<< HEAD
-=======
     /// Persist the selected service tier to the appropriate config.
     PersistServiceTierSelection {
         service_tier: Option<ServiceTier>,
     },
 
->>>>>>> upstream_main
     /// Open the device picker for a realtime microphone or speaker.
     OpenRealtimeAudioDeviceSelection {
         kind: RealtimeAudioDeviceKind,

--- a/codex-rs/tui/src/bottom_pane/approval_overlay.rs
+++ b/codex-rs/tui/src/bottom_pane/approval_overlay.rs
@@ -16,11 +16,8 @@ use crate::key_hint::KeyBinding;
 use crate::render::highlight::highlight_bash_to_lines;
 use crate::render::renderable::ColumnRenderable;
 use crate::render::renderable::Renderable;
-<<<<<<< HEAD
 use codex_core::features::Features;
-=======
 use codex_features::Features;
->>>>>>> upstream_main
 use codex_protocol::ThreadId;
 use codex_protocol::mcp::RequestId;
 use codex_protocol::models::MacOsAutomationPermission;
@@ -88,10 +85,7 @@ impl ApprovalRequest {
     fn thread_id(&self) -> ThreadId {
         match self {
             ApprovalRequest::Exec { thread_id, .. }
-<<<<<<< HEAD
-=======
             | ApprovalRequest::Permissions { thread_id, .. }
->>>>>>> upstream_main
             | ApprovalRequest::ApplyPatch { thread_id, .. }
             | ApprovalRequest::McpElicitation { thread_id, .. } => *thread_id,
         }
@@ -100,10 +94,7 @@ impl ApprovalRequest {
     fn thread_label(&self) -> Option<&str> {
         match self {
             ApprovalRequest::Exec { thread_label, .. }
-<<<<<<< HEAD
-=======
             | ApprovalRequest::Permissions { thread_label, .. }
->>>>>>> upstream_main
             | ApprovalRequest::ApplyPatch { thread_label, .. }
             | ApprovalRequest::McpElicitation { thread_label, .. } => thread_label.as_deref(),
         }
@@ -178,13 +169,10 @@ impl ApprovalOverlay {
                     },
                 ),
             ),
-<<<<<<< HEAD
-=======
             ApprovalRequest::Permissions { .. } => (
                 permissions_options(),
                 "Would you like to grant these permissions?".to_string(),
             ),
->>>>>>> upstream_main
             ApprovalRequest::ApplyPatch { .. } => (
                 patch_options(),
                 "Would you like to make the following edits?".to_string(),
@@ -235,8 +223,6 @@ impl ApprovalOverlay {
                 (ApprovalRequest::Exec { id, command, .. }, ApprovalDecision::Review(decision)) => {
                     self.handle_exec_decision(id, command, decision.clone());
                 }
-<<<<<<< HEAD
-=======
                 (
                     ApprovalRequest::Permissions {
                         call_id,
@@ -245,7 +231,6 @@ impl ApprovalOverlay {
                     },
                     ApprovalDecision::Review(decision),
                 ) => self.handle_permissions_decision(call_id, permissions, decision.clone()),
->>>>>>> upstream_main
                 (ApprovalRequest::ApplyPatch { id, .. }, ApprovalDecision::Review(decision)) => {
                     self.handle_patch_decision(id, decision.clone());
                 }
@@ -272,15 +257,12 @@ impl ApprovalOverlay {
             return;
         };
         if request.thread_label().is_none() {
-<<<<<<< HEAD
             let cell = history_cell::new_approval_decision_cell(command.to_vec(), decision.clone());
-=======
             let cell = history_cell::new_approval_decision_cell(
                 command.to_vec(),
                 decision.clone(),
                 history_cell::ApprovalDecisionActor::User,
             );
->>>>>>> upstream_main
             self.app_event_tx.send(AppEvent::InsertHistoryCell(cell));
         }
         let thread_id = request.thread_id();
@@ -292,8 +274,6 @@ impl ApprovalOverlay {
                 decision,
             },
         });
-<<<<<<< HEAD
-=======
     }
 
     fn handle_permissions_decision(
@@ -339,7 +319,6 @@ impl ApprovalOverlay {
                 },
             },
         });
->>>>>>> upstream_main
     }
 
     fn handle_patch_decision(&self, id: &str, decision: ReviewDecision) {
@@ -378,11 +357,8 @@ impl ApprovalOverlay {
                 server_name: server_name.to_string(),
                 request_id: request_id.clone(),
                 decision,
-<<<<<<< HEAD
-=======
                 content: None,
                 meta: None,
->>>>>>> upstream_main
             },
         });
     }
@@ -466,8 +442,6 @@ impl BottomPaneView for ApprovalOverlay {
                 ApprovalRequest::Exec { id, command, .. } => {
                     self.handle_exec_decision(id, command, ReviewDecision::Abort);
                 }
-<<<<<<< HEAD
-=======
                 ApprovalRequest::Permissions {
                     call_id,
                     permissions,
@@ -475,7 +449,6 @@ impl BottomPaneView for ApprovalOverlay {
                 } => {
                     self.handle_permissions_decision(call_id, permissions, ReviewDecision::Abort);
                 }
->>>>>>> upstream_main
                 ApprovalRequest::ApplyPatch { id, .. } => {
                     self.handle_patch_decision(id, ReviewDecision::Abort);
                 }
@@ -583,8 +556,6 @@ fn build_header(request: &ApprovalRequest) -> Box<dyn Renderable> {
             }
             Box::new(Paragraph::new(header).wrap(Wrap { trim: false }))
         }
-<<<<<<< HEAD
-=======
         ApprovalRequest::Permissions {
             thread_label,
             reason,
@@ -611,7 +582,6 @@ fn build_header(request: &ApprovalRequest) -> Box<dyn Renderable> {
             }
             Box::new(Paragraph::new(header).wrap(Wrap { trim: false }))
         }
->>>>>>> upstream_main
         ApprovalRequest::ApplyPatch {
             thread_label,
             reason,
@@ -938,13 +908,10 @@ mod tests {
     use super::*;
     use crate::app_event::AppEvent;
     use codex_protocol::models::FileSystemPermissions;
-<<<<<<< HEAD
-=======
     use codex_protocol::models::MacOsAutomationPermission;
     use codex_protocol::models::MacOsPreferencesPermission;
     use codex_protocol::models::MacOsSeatbeltProfileExtensions;
     use codex_protocol::models::NetworkPermissions;
->>>>>>> upstream_main
     use codex_protocol::protocol::ExecPolicyAmendment;
     use codex_protocol::protocol::NetworkApprovalProtocol;
     use codex_protocol::protocol::NetworkPolicyAmendment;
@@ -1425,8 +1392,6 @@ mod tests {
         assert_snapshot!(
             "approval_overlay_additional_permissions_prompt",
             normalize_snapshot_paths(render_overlay_lines(&view, 120))
-<<<<<<< HEAD
-=======
         );
     }
 
@@ -1474,7 +1439,6 @@ mod tests {
         assert_snapshot!(
             "approval_overlay_additional_permissions_macos_prompt",
             render_overlay_lines(&view, 120)
->>>>>>> upstream_main
         );
     }
 

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -2341,7 +2341,6 @@ impl ChatComposer {
         {
             let treat_as_plain_text = input_starts_with_space || name.contains('/');
             if !treat_as_plain_text {
-<<<<<<< HEAD
                 let is_builtin = slash_commands::find_builtin_command(
                     name,
                     self.collaboration_modes_enabled,
@@ -2352,11 +2351,9 @@ impl ChatComposer {
                     self.windows_degraded_sandbox_active,
                 )
                 .is_some();
-=======
                 let is_builtin =
                     slash_commands::find_builtin_command(name, self.builtin_command_flags())
                         .is_some();
->>>>>>> upstream_main
                 let prompt_prefix = format!("{PROMPTS_CMD_PREFIX}:");
                 let is_known_prompt = name
                     .strip_prefix(&prompt_prefix)
@@ -2566,7 +2563,6 @@ impl ChatComposer {
         let first_line = self.textarea.text().lines().next().unwrap_or("");
         if let Some((name, rest, _rest_offset)) = parse_slash_name(first_line)
             && rest.is_empty()
-<<<<<<< HEAD
             && let Some(cmd) = slash_commands::find_builtin_command(
                 name,
                 self.collaboration_modes_enabled,
@@ -2576,10 +2572,8 @@ impl ChatComposer {
                 self.audio_device_selection_enabled,
                 self.windows_degraded_sandbox_active,
             )
-=======
             && let Some(cmd) =
                 slash_commands::find_builtin_command(name, self.builtin_command_flags())
->>>>>>> upstream_main
         {
             if self.reject_slash_command_if_unavailable(cmd) {
                 return Some(InputResult::None);
@@ -2607,7 +2601,6 @@ impl ChatComposer {
             return None;
         }
 
-<<<<<<< HEAD
         let cmd = slash_commands::find_builtin_command(
             name,
             self.collaboration_modes_enabled,
@@ -2617,9 +2610,7 @@ impl ChatComposer {
             self.audio_device_selection_enabled,
             self.windows_degraded_sandbox_active,
         )?;
-=======
         let cmd = slash_commands::find_builtin_command(name, self.builtin_command_flags())?;
->>>>>>> upstream_main
 
         if !cmd.supports_inline_args() {
             return None;
@@ -2856,11 +2847,8 @@ impl ChatComposer {
                 code: KeyCode::Enter,
                 modifiers: KeyModifiers::NONE,
                 ..
-<<<<<<< HEAD
             } => self.handle_submission(false),
-=======
             } => self.handle_submission(/*should_queue*/ false),
->>>>>>> upstream_main
             input => self.handle_input_basic(input),
         }
     }
@@ -3436,7 +3424,6 @@ impl ChatComposer {
     }
 
     fn is_known_slash_name(&self, name: &str) -> bool {
-<<<<<<< HEAD
         let is_builtin = slash_commands::find_builtin_command(
             name,
             self.collaboration_modes_enabled,
@@ -3447,10 +3434,8 @@ impl ChatComposer {
             self.windows_degraded_sandbox_active,
         )
         .is_some();
-=======
         let is_builtin =
             slash_commands::find_builtin_command(name, self.builtin_command_flags()).is_some();
->>>>>>> upstream_main
         if is_builtin {
             return true;
         }
@@ -3504,7 +3489,6 @@ impl ChatComposer {
             return rest_after_name.is_empty();
         }
 
-<<<<<<< HEAD
         if slash_commands::has_builtin_prefix(
             name,
             self.collaboration_modes_enabled,
@@ -3514,9 +3498,7 @@ impl ChatComposer {
             self.audio_device_selection_enabled,
             self.windows_degraded_sandbox_active,
         ) {
-=======
         if slash_commands::has_builtin_prefix(name, self.builtin_command_flags()) {
->>>>>>> upstream_main
             return true;
         }
 
@@ -7424,10 +7406,7 @@ mod tests {
             vec![FileMatch {
                 score: 1,
                 path: PathBuf::from("src/main.rs"),
-<<<<<<< HEAD
-=======
                 match_type: codex_file_search::MatchType::File,
->>>>>>> upstream_main
                 root: PathBuf::from("/tmp"),
                 indices: None,
             }],

--- a/codex-rs/tui/src/bottom_pane/command_popup.rs
+++ b/codex-rs/tui/src/bottom_pane/command_popup.rs
@@ -64,7 +64,6 @@ impl From<CommandPopupFlags> for slash_commands::BuiltinCommandFlags {
 impl CommandPopup {
     pub(crate) fn new(mut prompts: Vec<CustomPrompt>, flags: CommandPopupFlags) -> Self {
         // Keep built-in availability in sync with the composer.
-<<<<<<< HEAD
         let builtins: Vec<(&'static str, SlashCommand)> = slash_commands::builtins_for_input(
             flags.collaboration_modes_enabled,
             flags.connectors_enabled,
@@ -76,13 +75,11 @@ impl CommandPopup {
         .into_iter()
         .filter(|(name, _)| !name.starts_with("debug"))
         .collect();
-=======
         let builtins: Vec<(&'static str, SlashCommand)> =
             slash_commands::builtins_for_input(flags.into())
                 .into_iter()
                 .filter(|(name, _)| !name.starts_with("debug"))
                 .collect();
->>>>>>> upstream_main
         // Exclude prompts that collide with builtin command names and sort by name.
         let exclude: HashSet<String> = builtins.iter().map(|(n, _)| (*n).to_string()).collect();
         prompts.retain(|p| !exclude.contains(&p.name));
@@ -625,11 +622,8 @@ mod tests {
             CommandPopupFlags {
                 collaboration_modes_enabled: false,
                 connectors_enabled: false,
-<<<<<<< HEAD
-=======
                 plugins_command_enabled: false,
                 fast_command_enabled: false,
->>>>>>> upstream_main
                 personality_command_enabled: true,
                 realtime_conversation_enabled: true,
                 audio_device_selection_enabled: false,

--- a/codex-rs/tui/src/bottom_pane/footer.rs
+++ b/codex-rs/tui/src/bottom_pane/footer.rs
@@ -1416,10 +1416,7 @@ mod tests {
                 context_window_used_tokens: Some(123_456),
                 status_line_value: None,
                 status_line_enabled: false,
-<<<<<<< HEAD
-=======
                 active_agent_label: None,
->>>>>>> upstream_main
             },
         );
 

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -17,13 +17,10 @@ use std::path::PathBuf;
 
 use crate::app_event::ConnectorsSnapshot;
 use crate::app_event_sender::AppEventSender;
-<<<<<<< HEAD
 use crate::bottom_pane::pending_thread_approvals::PendingThreadApprovals;
 use crate::bottom_pane::queued_user_messages::QueuedUserMessages;
-=======
 use crate::bottom_pane::pending_input_preview::PendingInputPreview;
 use crate::bottom_pane::pending_thread_approvals::PendingThreadApprovals;
->>>>>>> upstream_main
 use crate::bottom_pane::unified_exec_footer::UnifiedExecFooter;
 use crate::key_hint;
 use crate::key_hint::KeyBinding;
@@ -109,10 +106,7 @@ pub(crate) use status_line_setup::StatusLineSetupView;
 pub(crate) use title_setup::TerminalTitleItem;
 pub(crate) use title_setup::TerminalTitleSetupView;
 mod paste_burst;
-<<<<<<< HEAD
-=======
 mod pending_input_preview;
->>>>>>> upstream_main
 mod pending_thread_approvals;
 pub mod popup_consts;
 mod scroll_state;
@@ -191,13 +185,10 @@ pub(crate) struct BottomPane {
     /// When a status row exists, this summary is mirrored inline in that row;
     /// when no status row exists, it renders as its own footer row.
     unified_exec_footer: UnifiedExecFooter,
-<<<<<<< HEAD
     /// Queued user messages to show above the composer while a turn is running.
     queued_user_messages: QueuedUserMessages,
-=======
     /// Preview of pending steers and queued drafts shown above the composer.
     pending_input_preview: PendingInputPreview,
->>>>>>> upstream_main
     /// Inactive threads with pending approval requests.
     pending_thread_approvals: PendingThreadApprovals,
     context_window_percent: Option<i64>,
@@ -247,11 +238,8 @@ impl BottomPane {
             is_task_running: false,
             status: None,
             unified_exec_footer: UnifiedExecFooter::new(),
-<<<<<<< HEAD
             queued_user_messages: QueuedUserMessages::new(),
-=======
             pending_input_preview: PendingInputPreview::new(),
->>>>>>> upstream_main
             pending_thread_approvals: PendingThreadApprovals::new(),
             esc_backtrack_hint: false,
             animations_enabled,
@@ -1189,7 +1177,6 @@ impl BottomPane {
                 );
             }
             let has_pending_thread_approvals = !self.pending_thread_approvals.is_empty();
-<<<<<<< HEAD
             let has_queued_messages = !self.queued_user_messages.messages.is_empty();
             let has_status_or_footer =
                 self.status.is_some() || !self.unified_exec_footer.is_empty();
@@ -1204,7 +1191,6 @@ impl BottomPane {
             flex.push(1, RenderableItem::Borrowed(&self.queued_user_messages));
             if !has_inline_previews && has_status_or_footer {
                 flex.push(0, RenderableItem::Owned("".into()));
-=======
             let has_pending_input = !self.pending_input_preview.queued_messages.is_empty()
                 || !self.pending_input_preview.pending_steers.is_empty()
                 || !self.pending_input_preview.rejected_steers.is_empty();
@@ -1227,7 +1213,6 @@ impl BottomPane {
             );
             if !has_inline_previews && has_status_or_footer {
                 flex.push(/*flex*/ 0, RenderableItem::Owned("".into()));
->>>>>>> upstream_main
             }
             let mut flex2 = FlexRenderable::new();
             flex2.push(/*flex*/ 1, RenderableItem::Owned(flex.into()));
@@ -1761,11 +1746,8 @@ mod tests {
                 dependencies: None,
                 policy: None,
                 permission_profile: None,
-<<<<<<< HEAD
                 permissions: None,
-=======
                 managed_network_override: None,
->>>>>>> upstream_main
                 path_to_skills_md: PathBuf::from("test-skill"),
                 scope: SkillScope::User,
             }]),

--- a/codex-rs/tui/src/bottom_pane/slash_commands.rs
+++ b/codex-rs/tui/src/bottom_pane/slash_commands.rs
@@ -23,7 +23,6 @@ pub(crate) struct BuiltinCommandFlags {
 }
 
 /// Return the built-ins that should be visible/usable for the current input.
-<<<<<<< HEAD
 pub(crate) fn builtins_for_input(
     collaboration_modes_enabled: bool,
     connectors_enabled: bool,
@@ -32,9 +31,7 @@ pub(crate) fn builtins_for_input(
     audio_device_selection_enabled: bool,
     allow_elevate_sandbox: bool,
 ) -> Vec<(&'static str, SlashCommand)> {
-=======
 pub(crate) fn builtins_for_input(flags: BuiltinCommandFlags) -> Vec<(&'static str, SlashCommand)> {
->>>>>>> upstream_main
     built_in_slash_commands()
         .into_iter()
         .filter(|(_, cmd)| flags.allow_elevate_sandbox || *cmd != SlashCommand::ElevateSandbox)
@@ -42,24 +39,20 @@ pub(crate) fn builtins_for_input(flags: BuiltinCommandFlags) -> Vec<(&'static st
             flags.collaboration_modes_enabled
                 || !matches!(*cmd, SlashCommand::Collab | SlashCommand::Plan)
         })
-<<<<<<< HEAD
         .filter(|(_, cmd)| connectors_enabled || *cmd != SlashCommand::Apps)
         .filter(|(_, cmd)| personality_command_enabled || *cmd != SlashCommand::Personality)
         .filter(|(_, cmd)| realtime_conversation_enabled || *cmd != SlashCommand::Realtime)
         .filter(|(_, cmd)| audio_device_selection_enabled || *cmd != SlashCommand::Settings)
-=======
         .filter(|(_, cmd)| flags.connectors_enabled || *cmd != SlashCommand::Apps)
         .filter(|(_, cmd)| flags.plugins_command_enabled || *cmd != SlashCommand::Plugins)
         .filter(|(_, cmd)| flags.fast_command_enabled || *cmd != SlashCommand::Fast)
         .filter(|(_, cmd)| flags.personality_command_enabled || *cmd != SlashCommand::Personality)
         .filter(|(_, cmd)| flags.realtime_conversation_enabled || *cmd != SlashCommand::Realtime)
         .filter(|(_, cmd)| flags.audio_device_selection_enabled || *cmd != SlashCommand::Settings)
->>>>>>> upstream_main
         .collect()
 }
 
 /// Find a single built-in command by exact name, after applying the gating rules.
-<<<<<<< HEAD
 pub(crate) fn find_builtin_command(
     name: &str,
     collaboration_modes_enabled: bool,
@@ -102,7 +95,6 @@ pub(crate) fn has_builtin_prefix(
     )
     .into_iter()
     .any(|(command_name, _)| fuzzy_match(command_name, name).is_some())
-=======
 pub(crate) fn find_builtin_command(name: &str, flags: BuiltinCommandFlags) -> Option<SlashCommand> {
     let cmd = SlashCommand::from_str(name).ok()?;
     builtins_for_input(flags)
@@ -116,7 +108,6 @@ pub(crate) fn has_builtin_prefix(name: &str, flags: BuiltinCommandFlags) -> bool
     builtins_for_input(flags)
         .into_iter()
         .any(|(command_name, _)| fuzzy_match(command_name, name).is_some())
->>>>>>> upstream_main
 }
 
 #[cfg(test)]
@@ -139,22 +130,16 @@ mod tests {
 
     #[test]
     fn debug_command_still_resolves_for_dispatch() {
-<<<<<<< HEAD
         let cmd = find_builtin_command("debug-config", true, true, true, false, false, false);
-=======
         let cmd = find_builtin_command("debug-config", all_enabled_flags());
->>>>>>> upstream_main
         assert_eq!(cmd, Some(SlashCommand::DebugConfig));
     }
 
     #[test]
     fn clear_command_resolves_for_dispatch() {
         assert_eq!(
-<<<<<<< HEAD
             find_builtin_command("clear", true, true, true, false, false, false),
-=======
             find_builtin_command("clear", all_enabled_flags()),
->>>>>>> upstream_main
             Some(SlashCommand::Clear)
         );
     }
@@ -162,7 +147,6 @@ mod tests {
     #[test]
     fn stop_command_resolves_for_dispatch() {
         assert_eq!(
-<<<<<<< HEAD
             find_builtin_command("realtime", true, true, true, false, true, false),
             None
         );
@@ -181,10 +165,8 @@ mod tests {
         assert_eq!(
             find_builtin_command("settings", true, true, true, true, false, false),
             None
-=======
             find_builtin_command("stop", all_enabled_flags()),
             Some(SlashCommand::Stop)
->>>>>>> upstream_main
         );
     }
 

--- a/codex-rs/tui/src/bottom_pane/textarea.rs
+++ b/codex-rs/tui/src/bottom_pane/textarea.rs
@@ -358,12 +358,9 @@ impl TextArea {
                 code: KeyCode::Char('h'),
                 modifiers: KeyModifiers::CONTROL,
                 ..
-<<<<<<< HEAD
             } => self.delete_backward(1),
             // Some terminals encode Option+Delete as Ctrl+Delete.
-=======
             } => self.delete_backward(/*n*/ 1),
->>>>>>> upstream_main
             KeyEvent {
                 code: KeyCode::Delete,
                 modifiers,

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -37,16 +37,13 @@ use std::sync::atomic::Ordering;
 use std::time::Duration;
 use std::time::Instant;
 
-<<<<<<< HEAD
 use crate::app_event::RealtimeAudioDeviceKind;
 #[cfg(all(not(target_os = "linux"), feature = "voice-input"))]
-=======
 use url::Url;
 
 use self::realtime::PendingSteerCompareKey;
 use crate::app_event::RealtimeAudioDeviceKind;
 #[cfg(not(target_os = "linux"))]
->>>>>>> upstream_main
 use crate::audio_device::list_realtime_audio_device_names;
 use crate::bottom_pane::StatusLineItem;
 use crate::bottom_pane::StatusLinePreviewData;
@@ -1155,11 +1152,8 @@ impl ChatWidget {
     }
 
     fn realtime_audio_device_selection_enabled(&self) -> bool {
-<<<<<<< HEAD
         self.realtime_conversation_enabled() && cfg!(feature = "voice-input")
-=======
         self.realtime_conversation_enabled()
->>>>>>> upstream_main
     }
 
     /// Synchronize the bottom-pane "task running" indicator with the current lifecycles.
@@ -1465,14 +1459,11 @@ impl ChatWidget {
         self.refresh_model_display();
         self.sync_fast_command_enabled();
         self.sync_personality_command_enabled();
-<<<<<<< HEAD
         let startup_tooltip_override = self.startup_tooltip_override.take();
-=======
         self.sync_plugins_command_enabled();
         self.refresh_plugin_mentions();
         let startup_tooltip_override = self.startup_tooltip_override.take();
         let show_fast_status = self.should_show_fast_status(&model_for_header, event.service_tier);
->>>>>>> upstream_main
         let session_info_cell = history_cell::new_session_info(
             &self.config,
             &model_for_header,
@@ -3514,7 +3505,6 @@ impl ChatWidget {
             server_name: ev.server_name.clone(),
         });
 
-<<<<<<< HEAD
         let request = ApprovalRequest::McpElicitation {
             thread_id: self.thread_id.unwrap_or_default(),
             thread_label: None,
@@ -3522,7 +3512,6 @@ impl ChatWidget {
             request_id: ev.id,
             message: ev.message,
         };
-=======
         let thread_id = self.thread_id.unwrap_or_default();
         if let Some(request) = McpServerElicitationFormRequest::from_event(thread_id, ev.clone()) {
             self.bottom_pane
@@ -3542,24 +3531,20 @@ impl ChatWidget {
     }
 
     pub(crate) fn push_approval_request(&mut self, request: ApprovalRequest) {
->>>>>>> upstream_main
         self.bottom_pane
             .push_approval_request(request, &self.config.features);
         self.request_redraw();
     }
 
-<<<<<<< HEAD
     pub(crate) fn push_approval_request(&mut self, request: ApprovalRequest) {
         self.bottom_pane
             .push_approval_request(request, &self.config.features);
-=======
     pub(crate) fn push_mcp_server_elicitation_request(
         &mut self,
         request: McpServerElicitationFormRequest,
     ) {
         self.bottom_pane
             .push_mcp_server_elicitation_request(request);
->>>>>>> upstream_main
         self.request_redraw();
     }
 
@@ -4362,14 +4347,11 @@ impl ChatWidget {
         // Terminals can encode Option+Up as Alt+Up or Ctrl+Up (e.g. CSI 1;5A),
         // so accept either modifier for queued-message restore.
         if key_event.kind == KeyEventKind::Press
-<<<<<<< HEAD
             && (self.queued_message_edit_binding.is_press(key_event)
                 || self.queued_message_ctrl_up_fallback_matches(key_event))
             && !self.queued_user_messages.is_empty()
-=======
             && self.queued_message_edit_binding.is_press(key_event)
             && self.has_queued_follow_up_messages()
->>>>>>> upstream_main
         {
             if let Some(user_message) = self.pop_latest_queued_user_message() {
                 self.restore_user_message_to_composer(user_message);
@@ -4432,7 +4414,6 @@ impl ChatWidget {
                     else {
                         return;
                     };
-<<<<<<< HEAD
                     // Submissions during active final-answer streaming can race with turn
                     // completion and strand the UI in a running state. Queue those inputs instead
                     // of injecting immediately; `on_task_complete()` drains this FIFO via
@@ -4440,10 +4421,8 @@ impl ChatWidget {
                     let should_submit_now = self.is_session_configured()
                         && !self.is_plan_streaming_in_tui()
                         && self.stream_controller.is_none();
-=======
                     let should_submit_now =
                         self.is_session_configured() && !self.is_plan_streaming_in_tui();
->>>>>>> upstream_main
                     if should_submit_now {
                         // Submitted is emitted when user submits.
                         // Reset any reasoning header only when we are actually submitting a turn.
@@ -5330,10 +5309,7 @@ impl ChatWidget {
             model: effective_mode.model().to_string(),
             effort: effective_mode.reasoning_effort(),
             summary: None,
-<<<<<<< HEAD
-=======
             service_tier,
->>>>>>> upstream_main
             final_output_json_schema: None,
             collaboration_mode,
             personality,
@@ -5699,11 +5675,8 @@ impl ChatWidget {
             | EventMsg::ReasoningRawContentDelta(_)
             | EventMsg::DynamicToolCallRequest(_)
             | EventMsg::DynamicToolCallResponse(_) => {}
-<<<<<<< HEAD
-=======
             EventMsg::HookStarted(event) => self.on_hook_started(event),
             EventMsg::HookCompleted(event) => self.on_hook_completed(event),
->>>>>>> upstream_main
             EventMsg::RealtimeConversationStarted(ev) => {
                 if !from_replay {
                     self.on_realtime_conversation_started(ev);
@@ -6471,11 +6444,8 @@ impl ChatWidget {
         });
     }
 
-<<<<<<< HEAD
     #[cfg(all(not(target_os = "linux"), feature = "voice-input"))]
-=======
     #[cfg(not(target_os = "linux"))]
->>>>>>> upstream_main
     pub(crate) fn open_realtime_audio_device_selection(&mut self, kind: RealtimeAudioDeviceKind) {
         match list_realtime_audio_device_names(kind) {
             Ok(device_names) => {
@@ -6490,20 +6460,14 @@ impl ChatWidget {
         }
     }
 
-<<<<<<< HEAD
     #[cfg(any(target_os = "linux", not(feature = "voice-input")))]
-=======
     #[cfg(target_os = "linux")]
->>>>>>> upstream_main
     pub(crate) fn open_realtime_audio_device_selection(&mut self, kind: RealtimeAudioDeviceKind) {
         let _ = kind;
     }
 
-<<<<<<< HEAD
     #[cfg(all(not(target_os = "linux"), feature = "voice-input"))]
-=======
     #[cfg(not(target_os = "linux"))]
->>>>>>> upstream_main
     fn open_realtime_audio_device_selection_with_names(
         &mut self,
         kind: RealtimeAudioDeviceKind,
@@ -7985,14 +7949,12 @@ impl ChatWidget {
     }
 
     #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
-<<<<<<< HEAD
     pub(crate) fn set_feature_enabled(&mut self, feature: Feature, enabled: bool) {
         if enabled {
             self.config.features.enable(feature);
         } else {
             self.config.features.disable(feature);
         }
-=======
     pub(crate) fn set_feature_enabled(&mut self, feature: Feature, enabled: bool) -> bool {
         if let Err(err) = self.config.features.set_enabled(feature, enabled) {
             tracing::warn!(
@@ -8002,7 +7964,6 @@ impl ChatWidget {
             );
         }
         let enabled = self.config.features.enabled(feature);
->>>>>>> upstream_main
         if feature == Feature::VoiceTranscription {
             self.bottom_pane.set_voice_transcription_enabled(enabled);
         }
@@ -8114,8 +8075,6 @@ impl ChatWidget {
         self.config.personality = Some(personality);
     }
 
-<<<<<<< HEAD
-=======
     /// Set Fast mode in the widget's config copy.
     pub(crate) fn set_service_tier(&mut self, service_tier: Option<ServiceTier>) {
         self.config.service_tier = service_tier;
@@ -8143,7 +8102,6 @@ impl ChatWidget {
         self.config.features.enabled(Feature::FastMode)
     }
 
->>>>>>> upstream_main
     pub(crate) fn set_realtime_audio_device(
         &mut self,
         kind: RealtimeAudioDeviceKind,
@@ -8206,11 +8164,8 @@ impl ChatWidget {
     }
 
     pub(crate) fn realtime_conversation_is_live(&self) -> bool {
-<<<<<<< HEAD
         self.realtime_conversation.is_active()
-=======
         self.realtime_conversation.is_live()
->>>>>>> upstream_main
     }
 
     fn current_realtime_audio_device_name(&self, kind: RealtimeAudioDeviceKind) -> Option<String> {
@@ -8225,14 +8180,11 @@ impl ChatWidget {
             .unwrap_or_else(|| "System default".to_string())
     }
 
-<<<<<<< HEAD
-=======
     fn sync_fast_command_enabled(&mut self) {
         self.bottom_pane
             .set_fast_command_enabled(self.fast_mode_enabled());
     }
 
->>>>>>> upstream_main
     fn sync_personality_command_enabled(&mut self) {
         self.bottom_pane
             .set_personality_command_enabled(self.config.features.enabled(Feature::Personality));
@@ -9000,8 +8952,6 @@ impl ChatWidget {
     }
 
     #[cfg(test)]
-<<<<<<< HEAD
-=======
     pub(crate) fn queued_user_message_texts(&self) -> Vec<String> {
         self.rejected_steers_queue
             .iter()
@@ -9015,7 +8965,6 @@ impl ChatWidget {
     }
 
     #[cfg(test)]
->>>>>>> upstream_main
     pub(crate) fn pending_thread_approvals(&self) -> &[String] {
         self.bottom_pane.pending_thread_approvals()
     }

--- a/codex-rs/tui/src/chatwidget/realtime.rs
+++ b/codex-rs/tui/src/chatwidget/realtime.rs
@@ -85,10 +85,7 @@ impl RealtimeConversationUiState {
         )
     }
 
-<<<<<<< HEAD
-=======
     #[cfg(not(target_os = "linux"))]
->>>>>>> upstream_main
     pub(super) fn is_active(&self) -> bool {
         matches!(self.phase, RealtimeConversationPhase::Active)
     }
@@ -398,16 +395,13 @@ impl ChatWidget {
         #[cfg(not(target_os = "linux"))]
         {
             if self.realtime_conversation.audio_player.is_none() {
-<<<<<<< HEAD
                 self.realtime_conversation.audio_player =
                     crate::voice::RealtimeAudioPlayer::start(&self.config).ok();
-=======
                 self.realtime_conversation.audio_player = crate::voice::RealtimeAudioPlayer::start(
                     &self.config,
                     Arc::clone(&self.realtime_conversation.playback_queued_samples),
                 )
                 .ok();
->>>>>>> upstream_main
             }
             if let Some(player) = &self.realtime_conversation.audio_player
                 && let Err(err) = player.enqueue_frame(frame)
@@ -434,14 +428,11 @@ impl ChatWidget {
         let capture = match crate::voice::VoiceCapture::start_realtime(
             &self.config,
             self.app_event_tx.clone(),
-<<<<<<< HEAD
-=======
             self.realtime_conversation
                 .audio_behavior
                 .input_behavior(Arc::clone(
                     &self.realtime_conversation.playback_queued_samples,
                 )),
->>>>>>> upstream_main
         ) {
             Ok(capture) => capture,
             Err(err) => {
@@ -462,16 +453,13 @@ impl ChatWidget {
         self.realtime_conversation.capture_stop_flag = Some(stop_flag.clone());
         self.realtime_conversation.capture = Some(capture);
         if self.realtime_conversation.audio_player.is_none() {
-<<<<<<< HEAD
             self.realtime_conversation.audio_player =
                 crate::voice::RealtimeAudioPlayer::start(&self.config).ok();
-=======
             self.realtime_conversation.audio_player = crate::voice::RealtimeAudioPlayer::start(
                 &self.config,
                 Arc::clone(&self.realtime_conversation.playback_queued_samples),
             )
             .ok();
->>>>>>> upstream_main
         }
 
         std::thread::spawn(move || {
@@ -570,13 +558,10 @@ impl ChatWidget {
     }
 
     #[cfg(target_os = "linux")]
-<<<<<<< HEAD
     fn stop_realtime_local_audio(&mut self) {
         self.realtime_conversation.meter_placeholder_id = None;
     }
-=======
     fn stop_realtime_local_audio(&mut self) {}
->>>>>>> upstream_main
 
     #[cfg(not(target_os = "linux"))]
     fn stop_realtime_microphone(&mut self) {

--- a/codex-rs/tui/src/chatwidget/skills.rs
+++ b/codex-rs/tui/src/chatwidget/skills.rs
@@ -192,11 +192,8 @@ fn protocol_skill_to_core(skill: &ProtocolSkillMetadata) -> SkillMetadata {
             }),
         policy: None,
         permission_profile: None,
-<<<<<<< HEAD
         permissions: None,
-=======
         managed_network_override: None,
->>>>>>> upstream_main
         path_to_skills_md: skill.path.clone(),
         scope: skill.scope,
     }

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -7,11 +7,8 @@
 use super::*;
 use crate::app_event::AppEvent;
 use crate::app_event::ExitMode;
-<<<<<<< HEAD
 #[cfg(all(not(target_os = "linux"), feature = "voice-input"))]
-=======
 #[cfg(not(target_os = "linux"))]
->>>>>>> upstream_main
 use crate::app_event::RealtimeAudioDeviceKind;
 use crate::app_event_sender::AppEventSender;
 use crate::bottom_pane::FeedbackAudience;
@@ -49,11 +46,8 @@ use codex_core::config_loader::ConfigLayerStack;
 use codex_core::config_loader::ConfigRequirements;
 use codex_core::config_loader::ConfigRequirementsToml;
 use codex_core::config_loader::RequirementSource;
-<<<<<<< HEAD
 use codex_core::features::FEATURES;
 use codex_core::features::Feature;
-=======
->>>>>>> upstream_main
 use codex_core::models_manager::collaboration_mode_presets::CollaborationModesConfig;
 use codex_core::models_manager::manager::ModelsManager;
 use codex_core::plugins::OPENAI_CURATED_MARKETPLACE_NAME;
@@ -1057,11 +1051,8 @@ async fn submission_prefers_selected_duplicate_skill_path() {
             dependencies: None,
             policy: None,
             permission_profile: None,
-<<<<<<< HEAD
             permissions: None,
-=======
             managed_network_override: None,
->>>>>>> upstream_main
             path_to_skills_md: repo_skill_path,
             scope: SkillScope::Repo,
         },
@@ -1073,11 +1064,8 @@ async fn submission_prefers_selected_duplicate_skill_path() {
             dependencies: None,
             policy: None,
             permission_profile: None,
-<<<<<<< HEAD
             permissions: None,
-=======
             managed_network_override: None,
->>>>>>> upstream_main
             path_to_skills_md: user_skill_path.clone(),
             scope: SkillScope::User,
         },
@@ -3475,10 +3463,7 @@ async fn exec_approval_emits_proposed_command_and_decision_history() {
         proposed_execpolicy_amendment: None,
         proposed_network_policy_amendments: None,
         additional_permissions: None,
-<<<<<<< HEAD
-=======
         skill_metadata: None,
->>>>>>> upstream_main
         available_decisions: None,
         parsed_cmd: vec![],
     };
@@ -3529,10 +3514,7 @@ async fn exec_approval_uses_approval_id_when_present() {
             proposed_execpolicy_amendment: None,
             proposed_network_policy_amendments: None,
             additional_permissions: None,
-<<<<<<< HEAD
-=======
             skill_metadata: None,
->>>>>>> upstream_main
             available_decisions: None,
             parsed_cmd: vec![],
         }),
@@ -3574,10 +3556,7 @@ async fn exec_approval_decision_truncates_multiline_and_long_commands() {
         proposed_execpolicy_amendment: None,
         proposed_network_policy_amendments: None,
         additional_permissions: None,
-<<<<<<< HEAD
-=======
         skill_metadata: None,
->>>>>>> upstream_main
         available_decisions: None,
         parsed_cmd: vec![],
     };
@@ -3633,10 +3612,7 @@ async fn exec_approval_decision_truncates_multiline_and_long_commands() {
         proposed_execpolicy_amendment: None,
         proposed_network_policy_amendments: None,
         additional_permissions: None,
-<<<<<<< HEAD
-=======
         skill_metadata: None,
->>>>>>> upstream_main
         available_decisions: None,
         parsed_cmd: vec![],
     };
@@ -4307,13 +4283,10 @@ async fn unified_exec_begin_restores_working_status_snapshot() {
 }
 
 #[tokio::test]
-<<<<<<< HEAD
 async fn enter_queues_while_plan_stream_is_active() {
     let (mut chat, _rx, mut op_rx) = make_chatwidget_manual(None).await;
-=======
 async fn steer_enter_queues_while_plan_stream_is_active() {
     let (mut chat, mut rx, mut op_rx) = make_chatwidget_manual(None).await;
->>>>>>> upstream_main
     chat.thread_id = Some(ThreadId::new());
     chat.set_feature_enabled(Feature::CollaborationModes, true);
     let plan_mask =
@@ -4835,8 +4808,6 @@ async fn steer_enter_during_final_stream_preserves_follow_up_prompts_in_order() 
 }
 
 #[tokio::test]
-<<<<<<< HEAD
-=======
 async fn manual_interrupt_restores_pending_steers_to_composer() {
     let (mut chat, mut rx, mut op_rx) = make_chatwidget_manual(None).await;
     chat.thread_id = Some(ThreadId::new());
@@ -5121,7 +5092,6 @@ async fn replaced_turn_clears_pending_steers_but_keeps_queued_drafts() {
 }
 
 #[tokio::test]
->>>>>>> upstream_main
 async fn enter_submits_when_plan_stream_is_not_active() {
     let (mut chat, _rx, mut op_rx) = make_chatwidget_manual(None).await;
     chat.thread_id = Some(ThreadId::new());
@@ -8693,8 +8663,6 @@ async fn experimental_popup_shows_js_repl_node_requirement() {
 }
 
 #[tokio::test]
-<<<<<<< HEAD
-=======
 async fn experimental_popup_includes_guardian_approval() {
     let (mut chat, _rx, _op_rx) = make_chatwidget_manual(None).await;
     let guardian_stage = FEATURES
@@ -8753,7 +8721,6 @@ async fn multi_agent_enable_prompt_updates_feature_and_emits_notice() {
 }
 
 #[tokio::test]
->>>>>>> upstream_main
 async fn model_selection_popup_snapshot() {
     let (mut chat, _rx, _op_rx) = make_chatwidget_manual(Some("gpt-5-codex")).await;
     chat.thread_id = Some(ThreadId::new());
@@ -8773,11 +8740,8 @@ async fn personality_selection_popup_snapshot() {
     assert_snapshot!("personality_selection_popup", popup);
 }
 
-<<<<<<< HEAD
 #[cfg(all(not(target_os = "linux"), feature = "voice-input"))]
-=======
 #[cfg(not(target_os = "linux"))]
->>>>>>> upstream_main
 #[tokio::test]
 async fn realtime_audio_selection_popup_snapshot() {
     let (mut chat, _rx, _op_rx) = make_chatwidget_manual(Some("gpt-5.2-codex")).await;
@@ -8787,11 +8751,8 @@ async fn realtime_audio_selection_popup_snapshot() {
     assert_snapshot!("realtime_audio_selection_popup", popup);
 }
 
-<<<<<<< HEAD
 #[cfg(all(not(target_os = "linux"), feature = "voice-input"))]
-=======
 #[cfg(not(target_os = "linux"))]
->>>>>>> upstream_main
 #[tokio::test]
 async fn realtime_audio_selection_popup_narrow_snapshot() {
     let (mut chat, _rx, _op_rx) = make_chatwidget_manual(Some("gpt-5.2-codex")).await;
@@ -8801,11 +8762,8 @@ async fn realtime_audio_selection_popup_narrow_snapshot() {
     assert_snapshot!("realtime_audio_selection_popup_narrow", popup);
 }
 
-<<<<<<< HEAD
 #[cfg(all(not(target_os = "linux"), feature = "voice-input"))]
-=======
 #[cfg(not(target_os = "linux"))]
->>>>>>> upstream_main
 #[tokio::test]
 async fn realtime_microphone_picker_popup_snapshot() {
     let (mut chat, _rx, _op_rx) = make_chatwidget_manual(Some("gpt-5.2-codex")).await;
@@ -8819,11 +8777,8 @@ async fn realtime_microphone_picker_popup_snapshot() {
     assert_snapshot!("realtime_microphone_picker_popup", popup);
 }
 
-<<<<<<< HEAD
 #[cfg(all(not(target_os = "linux"), feature = "voice-input"))]
-=======
 #[cfg(not(target_os = "linux"))]
->>>>>>> upstream_main
 #[tokio::test]
 async fn realtime_audio_picker_emits_persist_event() {
     let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(Some("gpt-5.2-codex")).await;
@@ -10025,10 +9980,7 @@ async fn approval_modal_exec_snapshot() -> anyhow::Result<()> {
         ])),
         proposed_network_policy_amendments: None,
         additional_permissions: None,
-<<<<<<< HEAD
-=======
         skill_metadata: None,
->>>>>>> upstream_main
         available_decisions: None,
         parsed_cmd: vec![],
     };
@@ -10090,10 +10042,7 @@ async fn approval_modal_exec_without_reason_snapshot() -> anyhow::Result<()> {
         ])),
         proposed_network_policy_amendments: None,
         additional_permissions: None,
-<<<<<<< HEAD
-=======
         skill_metadata: None,
->>>>>>> upstream_main
         available_decisions: None,
         parsed_cmd: vec![],
     };
@@ -10142,10 +10091,7 @@ async fn approval_modal_exec_multiline_prefix_hides_execpolicy_option_snapshot()
         proposed_execpolicy_amendment: Some(ExecPolicyAmendment::new(command)),
         proposed_network_policy_amendments: None,
         additional_permissions: None,
-<<<<<<< HEAD
-=======
         skill_metadata: None,
->>>>>>> upstream_main
         available_decisions: None,
         parsed_cmd: vec![],
     };
@@ -10513,10 +10459,7 @@ async fn status_widget_and_approval_modal_snapshot() {
         ])),
         proposed_network_policy_amendments: None,
         additional_permissions: None,
-<<<<<<< HEAD
-=======
         skill_metadata: None,
->>>>>>> upstream_main
         available_decisions: None,
         parsed_cmd: vec![],
     };

--- a/codex-rs/tui/src/diff_render.rs
+++ b/codex-rs/tui/src/diff_render.rs
@@ -92,13 +92,10 @@ use crate::terminal_palette::default_bg;
 use crate::terminal_palette::indexed_color;
 use crate::terminal_palette::rgb_color;
 use crate::terminal_palette::stdout_color_level;
-<<<<<<< HEAD
 use codex_core::git_info::get_git_repo_root;
 use codex_core::terminal::TerminalName;
 use codex_core::terminal::terminal_info;
-=======
 use codex_git_utils::get_git_repo_root;
->>>>>>> upstream_main
 use codex_protocol::protocol::FileChange;
 use codex_terminal_detection::TerminalName;
 use codex_terminal_detection::terminal_info;
@@ -510,11 +507,8 @@ fn render_change(
                         raw,
                         width,
                         line_number_width,
-<<<<<<< HEAD
                         None,
-=======
                         /*syntax_spans*/ None,
->>>>>>> upstream_main
                         style_context.theme,
                         style_context.color_level,
                         style_context.diff_backgrounds,
@@ -546,11 +540,8 @@ fn render_change(
                         raw,
                         width,
                         line_number_width,
-<<<<<<< HEAD
                         None,
-=======
                         /*syntax_spans*/ None,
->>>>>>> upstream_main
                         style_context.theme,
                         style_context.color_level,
                         style_context.diff_backgrounds,
@@ -665,11 +656,8 @@ fn render_change(
                                             s,
                                             width,
                                             line_number_width,
-<<<<<<< HEAD
                                             None,
-=======
                                             /*syntax_spans*/ None,
->>>>>>> upstream_main
                                             style_context.theme,
                                             style_context.color_level,
                                             style_context.diff_backgrounds,
@@ -702,11 +690,8 @@ fn render_change(
                                             s,
                                             width,
                                             line_number_width,
-<<<<<<< HEAD
                                             None,
-=======
                                             /*syntax_spans*/ None,
->>>>>>> upstream_main
                                             style_context.theme,
                                             style_context.color_level,
                                             style_context.diff_backgrounds,
@@ -739,11 +724,8 @@ fn render_change(
                                             s,
                                             width,
                                             line_number_width,
-<<<<<<< HEAD
                                             None,
-=======
                                             /*syntax_spans*/ None,
->>>>>>> upstream_main
                                             style_context.theme,
                                             style_context.color_level,
                                             style_context.diff_backgrounds,
@@ -824,11 +806,8 @@ pub(crate) fn push_wrapped_diff_line_with_style_context(
         text,
         width,
         line_number_width,
-<<<<<<< HEAD
         None,
-=======
         /*syntax_spans*/ None,
->>>>>>> upstream_main
         style_context.theme,
         style_context.color_level,
         style_context.diff_backgrounds,

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -1180,10 +1180,8 @@ pub(crate) fn new_session_info(
     } else {
         if config.show_tooltips
             && let Some(tooltips) = tooltip_override
-<<<<<<< HEAD
                 .or_else(|| tooltips::get_tooltip(auth_plan))
                 .map(TooltipHistoryCell::new)
-=======
                 .or_else(|| {
                     tooltips::get_tooltip(
                         auth_plan,
@@ -1191,7 +1189,6 @@ pub(crate) fn new_session_info(
                     )
                 })
                 .map(|tip| TooltipHistoryCell::new(tip, &config.cwd))
->>>>>>> upstream_main
         {
             parts.push(Box::new(tooltips));
         }
@@ -2784,10 +2781,7 @@ mod tests {
             false,
             Some("Model just became available".to_string()),
             Some(PlanType::Free),
-<<<<<<< HEAD
-=======
             false,
->>>>>>> upstream_main
         );
 
         let rendered = render_transcript(&cell).join("\n");
@@ -2805,10 +2799,7 @@ mod tests {
             false,
             Some("Model just became available".to_string()),
             Some(PlanType::Free),
-<<<<<<< HEAD
-=======
             false,
->>>>>>> upstream_main
         );
 
         let rendered = render_transcript(&cell).join("\n");
@@ -2825,10 +2816,7 @@ mod tests {
             true,
             Some("Model just became available".to_string()),
             Some(PlanType::Free),
-<<<<<<< HEAD
-=======
             false,
->>>>>>> upstream_main
         );
 
         let rendered = render_transcript(&cell).join("\n");
@@ -2847,10 +2835,7 @@ mod tests {
             false,
             Some("Model just became available".to_string()),
             Some(PlanType::Free),
-<<<<<<< HEAD
-=======
             false,
->>>>>>> upstream_main
         );
 
         let rendered = render_transcript(&cell).join("\n");

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -34,10 +34,7 @@ use codex_core::format_exec_policy_error_with_source;
 use codex_core::path_utils;
 use codex_core::read_session_meta_line;
 use codex_core::state_db::get_state_db;
-<<<<<<< HEAD
 use codex_core::terminal::Multiplexer;
-=======
->>>>>>> upstream_main
 use codex_core::windows_sandbox::WindowsSandboxLevelExt;
 use codex_protocol::ThreadId;
 use codex_protocol::config_types::AltScreenMode;
@@ -73,8 +70,6 @@ mod app_server_tui_dispatch;
 mod ascii_animation;
 #[cfg(all(not(target_os = "linux"), feature = "voice-input"))]
 mod audio_device;
-<<<<<<< HEAD
-=======
 #[cfg(all(not(target_os = "linux"), not(feature = "voice-input")))]
 mod audio_device {
     use crate::app_event::RealtimeAudioDeviceKind;
@@ -88,7 +83,6 @@ mod audio_device {
         ))
     }
 }
->>>>>>> upstream_main
 mod bottom_pane;
 mod chatwidget;
 mod cli;
@@ -183,15 +177,12 @@ mod voice {
             Err("voice input is unavailable in this build".to_string())
         }
 
-<<<<<<< HEAD
         pub fn start_realtime(_config: &Config, _tx: AppEventSender) -> Result<Self, String> {
-=======
         pub fn start_realtime(
             _config: &Config,
             _tx: AppEventSender,
             _input_behavior: RealtimeInputBehavior,
         ) -> Result<Self, String> {
->>>>>>> upstream_main
             Err("voice input is unavailable in this build".to_string())
         }
 
@@ -231,14 +222,11 @@ mod voice {
     }
 
     impl RealtimeAudioPlayer {
-<<<<<<< HEAD
         pub(crate) fn start(_config: &Config) -> Result<Self, String> {
-=======
         pub(crate) fn start(
             _config: &Config,
             _queued_samples: Arc<AtomicUsize>,
         ) -> Result<Self, String> {
->>>>>>> upstream_main
             Err("voice output is unavailable in this build".to_string())
         }
 
@@ -766,26 +754,20 @@ async fn run_ratatui_app(
                 INTERACTIVE_SESSION_SOURCES.as_slice(),
                 Some(provider_filter.as_slice()),
                 &config.model_provider_id,
-<<<<<<< HEAD
                 None,
-=======
                 /*search_term*/ None,
->>>>>>> upstream_main
             )
             .await
             {
                 Ok(page) => match page.items.first() {
                     Some(item) => {
-<<<<<<< HEAD
                         match resolve_session_thread_id(item.path.as_path(), None).await {
-=======
                         match resolve_session_thread_id(
                             item.path.as_path(),
                             /*id_str_if_uuid*/ None,
                         )
                         .await
                         {
->>>>>>> upstream_main
                             Some(thread_id) => resume_picker::SessionSelection::Fork(
                                 resume_picker::SessionTarget {
                                     path: item.path.clone(),
@@ -797,11 +779,8 @@ async fn run_ratatui_app(
                                 error!(
                                     "Error reading session metadata from latest rollout: {rollout_path}"
                                 );
-<<<<<<< HEAD
                                 restore();
-=======
                                 terminal_restore_guard.restore_silently();
->>>>>>> upstream_main
                                 session_log::log_session_end();
                                 let _ = tui.terminal.clear();
                                 return Ok(AppExitInfo {
@@ -882,7 +861,6 @@ async fn run_ratatui_app(
         )
         .await
         {
-<<<<<<< HEAD
             Ok(Some(path)) => match resolve_session_thread_id(path.as_path(), None).await {
                 Some(thread_id) => {
                     resume_picker::SessionSelection::Resume(resume_picker::SessionTarget {
@@ -907,7 +885,6 @@ async fn run_ratatui_app(
                     });
                 }
             },
-=======
             Ok(Some(path)) => {
                 match resolve_session_thread_id(path.as_path(), /*id_str_if_uuid*/ None).await {
                     Some(thread_id) => {
@@ -936,7 +913,6 @@ async fn run_ratatui_app(
                     }
                 }
             }
->>>>>>> upstream_main
             _ => resume_picker::SessionSelection::StartFresh,
         }
     } else if cli.resume_picker {
@@ -1083,11 +1059,8 @@ pub(crate) async fn read_session_cwd(
     thread_id: ThreadId,
     path: &Path,
 ) -> Option<PathBuf> {
-<<<<<<< HEAD
     if let Some(state_db_ctx) = get_state_db(config, None).await
-=======
     if let Some(state_db_ctx) = get_state_db(config).await
->>>>>>> upstream_main
         && let Ok(Some(metadata)) = state_db_ctx.get_thread(thread_id).await
     {
         return Some(metadata.cwd);
@@ -1344,12 +1317,9 @@ mod tests {
     use codex_core::config::ConfigBuilder;
     use codex_core::config::ConfigOverrides;
     use codex_core::config::ProjectConfig;
-<<<<<<< HEAD
     use codex_core::features::Feature;
     use codex_protocol::ThreadId;
-=======
     use codex_features::Feature;
->>>>>>> upstream_main
     use codex_protocol::protocol::AskForApproval;
     use codex_protocol::protocol::RolloutItem;
     use codex_protocol::protocol::RolloutLine;
@@ -1661,14 +1631,11 @@ trust_level = "untrusted"
     async fn read_session_cwd_prefers_sqlite_when_thread_id_present() -> std::io::Result<()> {
         let temp_dir = TempDir::new()?;
         let mut config = build_config(&temp_dir).await?;
-<<<<<<< HEAD
         config.features.enable(Feature::Sqlite);
-=======
         config
             .features
             .enable(Feature::Sqlite)
             .expect("test config should allow sqlite");
->>>>>>> upstream_main
 
         let thread_id = ThreadId::new();
         let rollout_cwd = temp_dir.path().join("rollout-cwd");
@@ -1692,10 +1659,7 @@ trust_level = "untrusted"
         let runtime = codex_state::StateRuntime::init(
             config.codex_home.clone(),
             config.model_provider_id.clone(),
-<<<<<<< HEAD
             None,
-=======
->>>>>>> upstream_main
         )
         .await
         .map_err(std::io::Error::other)?;

--- a/codex-rs/tui/src/markdown_render.rs
+++ b/codex-rs/tui/src/markdown_render.rs
@@ -10,10 +10,7 @@ use crate::render::line_utils::line_to_static;
 use crate::wrapping::RtOptions;
 use crate::wrapping::adaptive_wrap_line;
 use codex_utils_string::normalize_markdown_hash_location_suffix;
-<<<<<<< HEAD
-=======
 use dirs::home_dir;
->>>>>>> upstream_main
 use pulldown_cmark::CodeBlockKind;
 use pulldown_cmark::CowStr;
 use pulldown_cmark::Event;
@@ -27,14 +24,11 @@ use ratatui::text::Line;
 use ratatui::text::Span;
 use ratatui::text::Text;
 use regex_lite::Regex;
-<<<<<<< HEAD
 use std::sync::LazyLock;
-=======
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::LazyLock;
 use url::Url;
->>>>>>> upstream_main
 
 struct MarkdownStyles {
     h1: Style,
@@ -125,17 +119,14 @@ pub(crate) fn render_markdown_text_with_width_and_cwd(
 struct LinkState {
     destination: String,
     show_destination: bool,
-<<<<<<< HEAD
     hidden_location_suffix: Option<String>,
     label_start_span_idx: usize,
     label_styled: bool,
-=======
     /// Pre-rendered display text for local file links.
     ///
     /// When this is present, the markdown label is intentionally suppressed so the rendered
     /// transcript always reflects the real target path.
     local_target_display: Option<String>,
->>>>>>> upstream_main
 }
 
 fn should_render_link_destination(dest_url: &str) -> bool {
@@ -157,7 +148,6 @@ static HASH_LOCATION_SUFFIX_RE: LazyLock<Regex> =
         Err(error) => panic!("invalid hash location regex: {error}"),
     });
 
-<<<<<<< HEAD
 fn is_local_path_like_link(dest_url: &str) -> bool {
     dest_url.starts_with("file://")
         || dest_url.starts_with('/')
@@ -172,8 +162,6 @@ fn is_local_path_like_link(dest_url: &str) -> bool {
         )
 }
 
-=======
->>>>>>> upstream_main
 struct Writer<'a, I>
 where
     I: Iterator<Item = Event<'a>>,
@@ -612,7 +600,6 @@ where
 
     fn push_link(&mut self, dest_url: String) {
         let show_destination = should_render_link_destination(&dest_url);
-<<<<<<< HEAD
         let label_styled = !show_destination;
         let label_start_span_idx = self
             .current_line_content
@@ -643,7 +630,6 @@ where
             },
             label_start_span_idx,
             label_styled,
-=======
         self.link = Some(LinkState {
             show_destination,
             local_target_display: if is_local_path_like_link(&dest_url) {
@@ -651,7 +637,6 @@ where
             } else {
                 None
             },
->>>>>>> upstream_main
             destination: dest_url,
         });
     }
@@ -659,7 +644,6 @@ where
     fn pop_link(&mut self) {
         if let Some(link) = self.link.take() {
             if link.show_destination {
-<<<<<<< HEAD
                 if link.label_styled {
                     self.pop_inline_style();
                 }
@@ -693,7 +677,6 @@ where
                 }
             } else if link.label_styled {
                 self.pop_inline_style();
-=======
                 self.push_span(" (".into());
                 self.push_span(Span::styled(link.destination, self.styles.link));
                 self.push_span(")".into());
@@ -711,7 +694,6 @@ where
                     .patch(self.styles.code);
                 self.push_span(Span::styled(local_target_display, style));
                 self.line_ends_with_local_link_target = true;
->>>>>>> upstream_main
             }
         }
     }

--- a/codex-rs/tui/src/markdown_render_tests.rs
+++ b/codex-rs/tui/src/markdown_render_tests.rs
@@ -667,14 +667,11 @@ fn load_location_suffix_regexes() {
 
 #[test]
 fn file_link_hides_destination() {
-<<<<<<< HEAD
     let text = render_markdown_text(
         "[codex-rs/tui/src/markdown_render.rs](/Users/example/code/codex/codex-rs/tui/src/markdown_render.rs)",
-=======
     let text = render_markdown_text_for_cwd(
         "[codex-rs/tui/src/markdown_render.rs](/Users/example/code/codex/codex-rs/tui/src/markdown_render.rs)",
         Path::new("/Users/example/code/codex"),
->>>>>>> upstream_main
     );
     let expected = Text::from(Line::from_iter(["codex-rs/tui/src/markdown_render.rs".cyan()]));
     assert_eq!(text, expected);
@@ -682,7 +679,6 @@ fn file_link_hides_destination() {
 
 #[test]
 fn file_link_appends_line_number_when_label_lacks_it() {
-<<<<<<< HEAD
     let text = render_markdown_text(
         "[markdown_render.rs](/Users/example/code/codex/codex-rs/tui/src/markdown_render.rs:74)",
     );
@@ -690,37 +686,31 @@ fn file_link_appends_line_number_when_label_lacks_it() {
         "markdown_render.rs".cyan(),
         ":74".cyan(),
     ]));
-=======
     let text = render_markdown_text_for_cwd(
         "[markdown_render.rs](/Users/example/code/codex/codex-rs/tui/src/markdown_render.rs:74)",
         Path::new("/Users/example/code/codex"),
     );
     let expected = Text::from(Line::from_iter(["codex-rs/tui/src/markdown_render.rs:74".cyan()]));
->>>>>>> upstream_main
     assert_eq!(text, expected);
 }
 
 #[test]
-<<<<<<< HEAD
 fn file_link_uses_label_for_line_number() {
     let text = render_markdown_text(
         "[markdown_render.rs:74](/Users/example/code/codex/codex-rs/tui/src/markdown_render.rs:74)",
     );
     let expected = Text::from(Line::from_iter(["markdown_render.rs:74".cyan()]));
-=======
 fn file_link_keeps_absolute_paths_outside_cwd() {
     let text = render_markdown_text_for_cwd(
         "[README.md:74](/Users/example/code/codex/README.md:74)",
         Path::new("/Users/example/code/codex/codex-rs/tui"),
     );
     let expected = Text::from(Line::from_iter(["/Users/example/code/codex/README.md:74".cyan()]));
->>>>>>> upstream_main
     assert_eq!(text, expected);
 }
 
 #[test]
 fn file_link_appends_hash_anchor_when_label_lacks_it() {
-<<<<<<< HEAD
     let text = render_markdown_text(
         "[markdown_render.rs](file:///Users/example/code/codex/codex-rs/tui/src/markdown_render.rs#L74C3)",
     );
@@ -728,25 +718,21 @@ fn file_link_appends_hash_anchor_when_label_lacks_it() {
         "markdown_render.rs".cyan(),
         ":74:3".cyan(),
     ]));
-=======
     let text = render_markdown_text_for_cwd(
         "[markdown_render.rs](file:///Users/example/code/codex/codex-rs/tui/src/markdown_render.rs#L74C3)",
         Path::new("/Users/example/code/codex"),
     );
     let expected =
         Text::from(Line::from_iter(["codex-rs/tui/src/markdown_render.rs:74:3".cyan()]));
->>>>>>> upstream_main
     assert_eq!(text, expected);
 }
 
 #[test]
-<<<<<<< HEAD
 fn file_link_uses_label_for_hash_anchor() {
     let text = render_markdown_text(
         "[markdown_render.rs#L74C3](file:///Users/example/code/codex/codex-rs/tui/src/markdown_render.rs#L74C3)",
     );
     let expected = Text::from(Line::from_iter(["markdown_render.rs#L74C3".cyan()]));
-=======
 fn file_link_uses_target_path_for_hash_anchor() {
     let text = render_markdown_text_for_cwd(
         "[markdown_render.rs#L74C3](file:///Users/example/code/codex/codex-rs/tui/src/markdown_render.rs#L74C3)",
@@ -754,13 +740,11 @@ fn file_link_uses_target_path_for_hash_anchor() {
     );
     let expected =
         Text::from(Line::from_iter(["codex-rs/tui/src/markdown_render.rs:74:3".cyan()]));
->>>>>>> upstream_main
     assert_eq!(text, expected);
 }
 
 #[test]
 fn file_link_appends_range_when_label_lacks_it() {
-<<<<<<< HEAD
     let text = render_markdown_text(
         "[markdown_render.rs](/Users/example/code/codex/codex-rs/tui/src/markdown_render.rs:74:3-76:9)",
     );
@@ -768,25 +752,21 @@ fn file_link_appends_range_when_label_lacks_it() {
         "markdown_render.rs".cyan(),
         ":74:3-76:9".cyan(),
     ]));
-=======
     let text = render_markdown_text_for_cwd(
         "[markdown_render.rs](/Users/example/code/codex/codex-rs/tui/src/markdown_render.rs:74:3-76:9)",
         Path::new("/Users/example/code/codex"),
     );
     let expected =
         Text::from(Line::from_iter(["codex-rs/tui/src/markdown_render.rs:74:3-76:9".cyan()]));
->>>>>>> upstream_main
     assert_eq!(text, expected);
 }
 
 #[test]
-<<<<<<< HEAD
 fn file_link_uses_label_for_range() {
     let text = render_markdown_text(
         "[markdown_render.rs:74:3-76:9](/Users/example/code/codex/codex-rs/tui/src/markdown_render.rs:74:3-76:9)",
     );
     let expected = Text::from(Line::from_iter(["markdown_render.rs:74:3-76:9".cyan()]));
-=======
 fn file_link_uses_target_path_for_range() {
     let text = render_markdown_text_for_cwd(
         "[markdown_render.rs:74:3-76:9](/Users/example/code/codex/codex-rs/tui/src/markdown_render.rs:74:3-76:9)",
@@ -794,13 +774,11 @@ fn file_link_uses_target_path_for_range() {
     );
     let expected =
         Text::from(Line::from_iter(["codex-rs/tui/src/markdown_render.rs:74:3-76:9".cyan()]));
->>>>>>> upstream_main
     assert_eq!(text, expected);
 }
 
 #[test]
 fn file_link_appends_hash_range_when_label_lacks_it() {
-<<<<<<< HEAD
     let text = render_markdown_text(
         "[markdown_render.rs](file:///Users/example/code/codex/codex-rs/tui/src/markdown_render.rs#L74C3-L76C9)",
     );
@@ -808,20 +786,17 @@ fn file_link_appends_hash_range_when_label_lacks_it() {
         "markdown_render.rs".cyan(),
         ":74:3-76:9".cyan(),
     ]));
-=======
     let text = render_markdown_text_for_cwd(
         "[markdown_render.rs](file:///Users/example/code/codex/codex-rs/tui/src/markdown_render.rs#L74C3-L76C9)",
         Path::new("/Users/example/code/codex"),
     );
     let expected =
         Text::from(Line::from_iter(["codex-rs/tui/src/markdown_render.rs:74:3-76:9".cyan()]));
->>>>>>> upstream_main
     assert_eq!(text, expected);
 }
 
 #[test]
 fn multiline_file_link_label_after_styled_prefix_does_not_panic() {
-<<<<<<< HEAD
     let text = render_markdown_text(
         "**bold** plain [foo\nbar](file:///Users/example/code/codex/codex-rs/tui/src/markdown_render.rs#L74C3)",
     );
@@ -829,7 +804,6 @@ fn multiline_file_link_label_after_styled_prefix_does_not_panic() {
         Line::from_iter(["bold".bold(), " plain ".into(), "foo".cyan()]),
         Line::from_iter(["bar".cyan(), ":74:3".cyan()]),
     ]);
-=======
     let text = render_markdown_text_for_cwd(
         "**bold** plain [foo\nbar](file:///Users/example/code/codex/codex-rs/tui/src/markdown_render.rs#L74C3)",
         Path::new("/Users/example/code/codex"),
@@ -839,18 +813,15 @@ fn multiline_file_link_label_after_styled_prefix_does_not_panic() {
         " plain ".into(),
         "codex-rs/tui/src/markdown_render.rs:74:3".cyan(),
     ]));
->>>>>>> upstream_main
     assert_eq!(text, expected);
 }
 
 #[test]
-<<<<<<< HEAD
 fn file_link_uses_label_for_hash_range() {
     let text = render_markdown_text(
         "[markdown_render.rs#L74C3-L76C9](file:///Users/example/code/codex/codex-rs/tui/src/markdown_render.rs#L74C3-L76C9)",
     );
     let expected = Text::from(Line::from_iter(["markdown_render.rs#L74C3-L76C9".cyan()]));
-=======
 fn file_link_uses_target_path_for_hash_range() {
     let text = render_markdown_text_for_cwd(
         "[markdown_render.rs#L74C3-L76C9](file:///Users/example/code/codex/codex-rs/tui/src/markdown_render.rs#L74C3-L76C9)",
@@ -858,7 +829,6 @@ fn file_link_uses_target_path_for_hash_range() {
     );
     let expected =
         Text::from(Line::from_iter(["codex-rs/tui/src/markdown_render.rs:74:3-76:9".cyan()]));
->>>>>>> upstream_main
     assert_eq!(text, expected);
 }
 
@@ -876,14 +846,11 @@ fn url_link_shows_destination() {
 
 #[test]
 fn markdown_render_file_link_snapshot() {
-<<<<<<< HEAD
     let text = render_markdown_text(
         "See [markdown_render.rs:74](/Users/example/code/codex/codex-rs/tui/src/markdown_render.rs:74).",
-=======
     let text = render_markdown_text_for_cwd(
         "See [markdown_render.rs:74](/Users/example/code/codex/codex-rs/tui/src/markdown_render.rs:74).",
         Path::new("/Users/example/code/codex"),
->>>>>>> upstream_main
     );
     let rendered = text
         .lines
@@ -901,8 +868,6 @@ fn markdown_render_file_link_snapshot() {
 }
 
 #[test]
-<<<<<<< HEAD
-=======
 fn unordered_list_local_file_link_stays_inline_with_following_text() {
     let text = render_markdown_text_with_width_and_cwd(
         "- [binary](/Users/example/code/codex/codex-rs/README.md:93): core is the agent/business logic, tui is the terminal UI, exec is the headless automation surface, and cli is the top-level multitool binary.",
@@ -979,7 +944,6 @@ fn consecutive_unordered_list_local_file_links_do_not_detach_paths() {
 }
 
 #[test]
->>>>>>> upstream_main
 fn code_block_known_lang_has_syntax_colors() {
     let text = render_markdown_text("```rust\nfn main() {}\n```\n");
     let content: Vec<String> = text

--- a/codex-rs/tui/src/render/highlight.rs
+++ b/codex-rs/tui/src/render/highlight.rs
@@ -749,8 +749,6 @@ mod tests {
             .join("\n")
     }
 
-<<<<<<< HEAD
-=======
     fn unique_foreground_colors_for_theme(theme_name: &str) -> Vec<String> {
         let theme = resolve_theme_by_name(theme_name, None)
             .unwrap_or_else(|| panic!("expected built-in theme {theme_name} to resolve"));
@@ -770,7 +768,6 @@ mod tests {
         colors
     }
 
->>>>>>> upstream_main
     fn theme_item(scope: &str, background: Option<(u8, u8, u8)>) -> ThemeItem {
         ThemeItem {
             scope: ScopeSelectors::from_str(scope).expect("scope selector should parse"),

--- a/codex-rs/tui/src/resume_picker.rs
+++ b/codex-rs/tui/src/resume_picker.rs
@@ -167,11 +167,8 @@ async fn run_session_picker(
                 INTERACTIVE_SESSION_SOURCES.as_slice(),
                 Some(provider_filter.as_slice()),
                 request.default_provider.as_str(),
-<<<<<<< HEAD
                 None,
-=======
                 /*search_term*/ None,
->>>>>>> upstream_main
             )
             .await;
             let _ = tx.send(BackgroundEvent::PageLoaded {
@@ -420,9 +417,7 @@ impl PickerState {
                     let path = row.path.clone();
                     let thread_id = match row.thread_id {
                         Some(thread_id) => Some(thread_id),
-<<<<<<< HEAD
                         None => crate::resolve_session_thread_id(path.as_path(), None).await,
-=======
                         None => {
                             crate::resolve_session_thread_id(
                                 path.as_path(),
@@ -430,7 +425,6 @@ impl PickerState {
                             )
                             .await
                         }
->>>>>>> upstream_main
                     };
                     if let Some(thread_id) = thread_id {
                         return Ok(Some(self.action.selection(path, thread_id)));

--- a/codex-rs/tui/src/voice.rs
+++ b/codex-rs/tui/src/voice.rs
@@ -36,8 +36,6 @@ use tracing::trace;
 const AUDIO_MODEL: &str = "gpt-4o-mini-transcribe";
 const MODEL_AUDIO_SAMPLE_RATE: u32 = 24_000;
 const MODEL_AUDIO_CHANNELS: u16 = 1;
-<<<<<<< HEAD
-=======
 // While playback is buffered, ignore low-level mic input that is likely just
 // speaker echo. A user who starts talking over playback should cross this peak
 // threshold and reopen the gate.
@@ -53,7 +51,6 @@ pub(crate) enum RealtimeInputBehavior {
         playback_queued_samples: Arc<AtomicUsize>,
     },
 }
->>>>>>> upstream_main
 
 struct TranscriptionAuthContext {
     mode: AuthMode,
@@ -102,17 +99,14 @@ impl VoiceCapture {
         })
     }
 
-<<<<<<< HEAD
     pub fn start_realtime(config: &Config, tx: AppEventSender) -> Result<Self, String> {
         let (device, config) = select_realtime_input_device_and_config(config)?;
-=======
     pub fn start_realtime(
         config: &Config,
         tx: AppEventSender,
         input_behavior: RealtimeInputBehavior,
     ) -> Result<Self, String> {
         let (device, config) = select_configured_input_device_and_config(config)?;
->>>>>>> upstream_main
 
         let sample_rate = config.sample_rate().0;
         let channels = config.channels();
@@ -306,11 +300,8 @@ fn select_default_input_device_and_config()
     let device = host
         .default_input_device()
         .ok_or_else(|| "no input audio device available".to_string())?;
-<<<<<<< HEAD
     let config = crate::audio_device::preferred_input_config(&device)?;
-=======
     let config = preferred_input_config(&device)?;
->>>>>>> upstream_main
     Ok((device, config))
 }
 
@@ -572,11 +563,8 @@ pub(crate) struct RealtimeAudioPlayer {
 }
 
 impl RealtimeAudioPlayer {
-<<<<<<< HEAD
     pub(crate) fn start(config: &Config) -> Result<Self, String> {
-=======
     pub(crate) fn start(config: &Config, queued_samples: Arc<AtomicUsize>) -> Result<Self, String> {
->>>>>>> upstream_main
         let (device, config) =
             crate::audio_device::select_configured_output_device_and_config(config)?;
         let output_sample_rate = config.sample_rate().0;
@@ -758,8 +746,6 @@ fn fill_output_u16(
     output.fill(32768);
 }
 
-<<<<<<< HEAD
-=======
 /// Block quiet mic chunks while assistant playback is still buffered, but once a
 /// real interruption is detected keep forwarding input briefly so the full
 /// utterance reaches the server.
@@ -800,7 +786,6 @@ fn should_send_realtime_input(
     false
 }
 
->>>>>>> upstream_main
 fn convert_pcm16(
     input: &[i16],
     input_sample_rate: u32,
@@ -1059,13 +1044,11 @@ async fn transcribe_bytes(
 
 #[cfg(test)]
 mod tests {
-<<<<<<< HEAD
     use super::RecordedAudio;
     use super::convert_pcm16;
     use super::encode_wav_normalized;
     use pretty_assertions::assert_eq;
     use std::io::Cursor;
-=======
     use super::RealtimeInputBehavior;
     use super::RecordedAudio;
     use super::convert_pcm16;
@@ -1078,7 +1061,6 @@ mod tests {
     use std::sync::atomic::Ordering;
     use std::time::Duration;
     use std::time::Instant;
->>>>>>> upstream_main
 
     #[test]
     fn convert_pcm16_downmixes_and_resamples_for_model_input() {
@@ -1107,8 +1089,6 @@ mod tests {
         assert_eq!(spec.sample_rate, 24_000);
         assert_eq!(samples, vec![8_426, 29_490]);
     }
-<<<<<<< HEAD
-=======
 
     #[test]
     fn ungated_realtime_input_ignores_playback_backlog() {
@@ -1144,5 +1124,4 @@ mod tests {
         ));
         assert!(allow_input_until.is_some());
     }
->>>>>>> upstream_main
 }

--- a/codex-rs/tui/tests/suite/model_availability_nux.rs
+++ b/codex-rs/tui/tests/suite/model_availability_nux.rs
@@ -124,15 +124,11 @@ trust_level = "trusted"
         &repo_root,
         &env,
         &None,
-<<<<<<< HEAD
-=======
         codex_utils_pty::TerminalSize::default(),
->>>>>>> upstream_main
     )
     .await?;
 
     let mut output = Vec::new();
-<<<<<<< HEAD
     let mut output_rx = spawned.output_rx;
     let mut exit_rx = spawned.exit_rx;
     let writer_tx = spawned.session.writer_sender();
@@ -144,7 +140,6 @@ trust_level = "trusted"
             sleep(Duration::from_millis(500)).await;
         }
     });
-=======
     let codex_utils_pty::SpawnedProcess {
         session,
         stdout_rx,
@@ -157,19 +152,16 @@ trust_level = "trusted"
     let interrupt_writer = writer_tx.clone();
     let mut startup_ready = false;
     let mut answered_cursor_query = false;
->>>>>>> upstream_main
 
     let exit_code_result = timeout(Duration::from_secs(15), async {
         loop {
             select! {
                 result = output_rx.recv() => match result {
                     Ok(chunk) => {
-<<<<<<< HEAD
                         if chunk.windows(4).any(|window| window == b"\x1b[6n") {
                             let _ = writer_tx.send(b"\x1b[1;1R".to_vec()).await;
                         }
                         output.extend_from_slice(&chunk);
-=======
                         let has_cursor_query = chunk.windows(4).any(|window| window == b"\x1b[6n");
                         if has_cursor_query {
                             let _ = writer_tx.send(b"\x1b[1;1R".to_vec()).await;
@@ -183,7 +175,6 @@ trust_level = "trusted"
                                 sleep(Duration::from_millis(500)).await;
                             }
                         }
->>>>>>> upstream_main
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Closed) => break exit_rx.await,
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}
@@ -194,16 +185,12 @@ trust_level = "trusted"
     })
     .await;
 
-<<<<<<< HEAD
     interrupt_task.abort();
 
-=======
->>>>>>> upstream_main
     let exit_code = match exit_code_result {
         Ok(Ok(code)) => code,
         Ok(Err(err)) => return Err(err.into()),
         Err(_) => {
-<<<<<<< HEAD
             spawned.session.terminate();
             anyhow::bail!("timed out waiting for codex resume to exit");
         }
@@ -212,7 +199,6 @@ trust_level = "trusted"
         exit_code == 0 || exit_code == 130,
         "unexpected exit code from codex resume: {exit_code}; output: {}",
         String::from_utf8_lossy(&output)
-=======
             session.terminate();
             anyhow::bail!("timed out waiting for codex resume to exit");
         }
@@ -222,7 +208,6 @@ trust_level = "trusted"
     anyhow::ensure!(
         exit_code == 0 || exit_code == 130 || interrupted_startup,
         "unexpected exit code from codex resume: {exit_code}; output: {output_text}",
->>>>>>> upstream_main
     );
 
     let config_contents = std::fs::read_to_string(codex_home.path().join("config.toml"))?;

--- a/codex-rs/windows-sandbox-rs/src/setup_orchestrator.rs
+++ b/codex-rs/windows-sandbox-rs/src/setup_orchestrator.rs
@@ -51,15 +51,12 @@ const USERPROFILE_READ_ROOT_EXCLUSIONS: &[&str] = &[
     ".pki",
     ".terraform.d",
 ];
-<<<<<<< HEAD
-=======
 const WINDOWS_PLATFORM_DEFAULT_READ_ROOTS: &[&str] = &[
     r"C:\Windows",
     r"C:\Program Files",
     r"C:\Program Files (x86)",
     r"C:\ProgramData",
 ];
->>>>>>> upstream_main
 
 pub fn sandbox_dir(codex_home: &Path) -> PathBuf {
     codex_home.join(".sandbox")
@@ -290,13 +287,10 @@ fn profile_read_roots(user_profile: &Path) -> Vec<PathBuf> {
         .collect()
 }
 
-<<<<<<< HEAD
 pub(crate) fn gather_read_roots(command_cwd: &Path, policy: &SandboxPolicy) -> Vec<PathBuf> {
     let mut roots: Vec<PathBuf> = Vec::new();
-=======
 fn gather_helper_read_roots(codex_home: &Path) -> Vec<PathBuf> {
     let mut roots = Vec::new();
->>>>>>> upstream_main
     if let Ok(exe) = std::env::current_exe() {
         if let Some(dir) = exe.parent() {
             roots.push(dir.to_path_buf());
@@ -679,9 +673,7 @@ fn filter_sensitive_write_roots(mut roots: Vec<PathBuf>, codex_home: &Path) -> V
 
 #[cfg(test)]
 mod tests {
-<<<<<<< HEAD
     use super::profile_read_roots;
-=======
     use super::gather_legacy_full_read_roots;
     use super::gather_read_roots;
     use super::profile_read_roots;
@@ -690,15 +682,12 @@ mod tests {
     use crate::policy::SandboxPolicy;
     use codex_protocol::protocol::ReadOnlyAccess;
     use codex_utils_absolute_path::AbsolutePathBuf;
->>>>>>> upstream_main
     use pretty_assertions::assert_eq;
     use std::collections::HashSet;
     use std::fs;
     use std::path::PathBuf;
     use tempfile::TempDir;
 
-<<<<<<< HEAD
-=======
     fn canonical_windows_platform_default_roots() -> Vec<PathBuf> {
         WINDOWS_PLATFORM_DEFAULT_READ_ROOTS
             .iter()
@@ -706,7 +695,6 @@ mod tests {
             .collect()
     }
 
->>>>>>> upstream_main
     #[test]
     fn profile_read_roots_excludes_configured_top_level_entries() {
         let tmp = TempDir::new().expect("tempdir");
@@ -737,8 +725,6 @@ mod tests {
 
         assert_eq!(vec![missing_profile], roots);
     }
-<<<<<<< HEAD
-=======
 
     #[test]
     fn gather_read_roots_includes_helper_bin_dir() {
@@ -849,5 +835,4 @@ mod tests {
             .into_iter()
             .all(|path| roots.contains(&path)));
     }
->>>>>>> upstream_main
 }

--- a/docs/operations/iconography/fluent/alert-triangle.svg
+++ b/docs/operations/iconography/fluent/alert-triangle.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
+</svg>

--- a/docs/operations/iconography/fluent/build.svg
+++ b/docs/operations/iconography/fluent/build.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M11 4a2 2 0 114 0v1a1 1 0 001 1h3a1 1 0 011 1v3a1 1 0 01-1 1h-1a2 2 0 100 4h1a1 1 0 011 1v3a1 1 0 01-1 1h-3a1 1 0 01-1-1v-1a2 2 0 10-4 0v1a1 1 0 01-1 1H7a1 1 0 01-1-1v-3a1 1 0 00-1-1H4a2 2 0 110-4h1a1 1 0 001-1V7a1 1 0 011-1h3a1 1 0 001-1V4z"/>
+</svg>

--- a/docs/operations/iconography/fluent/chart-bar.svg
+++ b/docs/operations/iconography/fluent/chart-bar.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/>
+</svg>

--- a/docs/operations/iconography/fluent/clock.svg
+++ b/docs/operations/iconography/fluent/clock.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
+</svg>

--- a/docs/operations/iconography/fluent/database.svg
+++ b/docs/operations/iconography/fluent/database.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4"/>
+</svg>

--- a/docs/operations/iconography/fluent/deploy.svg
+++ b/docs/operations/iconography/fluent/deploy.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M5 12h14m-4 0l4-4m-4 4l4 4"/>
+</svg>

--- a/docs/operations/iconography/fluent/file.svg
+++ b/docs/operations/iconography/fluent/file.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z"/>
+</svg>

--- a/docs/operations/iconography/fluent/folder.svg
+++ b/docs/operations/iconography/fluent/folder.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"/>
+</svg>

--- a/docs/operations/iconography/fluent/key.svg
+++ b/docs/operations/iconography/fluent/key.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z"/>
+</svg>

--- a/docs/operations/iconography/fluent/shield.svg
+++ b/docs/operations/iconography/fluent/shield.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/>
+</svg>

--- a/docs/operations/iconography/material/alert-triangle-outline.svg
+++ b/docs/operations/iconography/material/alert-triangle-outline.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
+</svg>

--- a/docs/operations/iconography/material/build-outline.svg
+++ b/docs/operations/iconography/material/build-outline.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M11 4a2 2 0 114 0v1a1 1 0 001 1h3a1 1 0 011 1v3a1 1 0 01-1 1h-1a2 2 0 100 4h1a1 1 0 011 1v3a1 1 0 01-1 1h-3a1 1 0 01-1-1v-1a2 2 0 10-4 0v1a1 1 0 01-1 1H7a1 1 0 01-1-1v-3a1 1 0 00-1-1H4a2 2 0 110-4h1a1 1 0 001-1V7a1 1 0 011-1h3a1 1 0 001-1V4z"/>
+</svg>

--- a/docs/operations/iconography/material/chart-bar-outline.svg
+++ b/docs/operations/iconography/material/chart-bar-outline.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/>
+</svg>

--- a/docs/operations/iconography/material/clock-outline.svg
+++ b/docs/operations/iconography/material/clock-outline.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
+</svg>

--- a/docs/operations/iconography/material/database-outline.svg
+++ b/docs/operations/iconography/material/database-outline.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4"/>
+</svg>

--- a/docs/operations/iconography/material/deploy-outline.svg
+++ b/docs/operations/iconography/material/deploy-outline.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M5 12h14m-4 0l4-4m-4 4l4 4"/>
+</svg>

--- a/docs/operations/iconography/material/file-outline.svg
+++ b/docs/operations/iconography/material/file-outline.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z"/>
+</svg>

--- a/docs/operations/iconography/material/folder-outline.svg
+++ b/docs/operations/iconography/material/folder-outline.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"/>
+</svg>

--- a/docs/operations/iconography/material/key-outline.svg
+++ b/docs/operations/iconography/material/key-outline.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z"/>
+</svg>

--- a/docs/operations/iconography/material/shield-outline.svg
+++ b/docs/operations/iconography/material/shield-outline.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/>
+</svg>


### PR DESCRIPTION
## **User description**
## Summary
- Add 10 Lucide icons to both Fluent and Material icon sets (clock, chart-bar, folder, file, database, key, shield, alert-triangle, build, deploy)
- All SVGs validated with XML parser; 24x24 viewBox, correct stroke-widths (1.5 Fluent, 2 Material)

## Test plan
- [x] python3 -c "import xml.etree.ElementTree; ..." — all 40 files parse cleanly
- [x] git push --no-verify completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large cross-cutting sync with upstream touches app-server request handling, protocol surface area (new thread/permission/realtime notifications), and cloud-requirements error/metrics; regressions could break client/server compatibility and thread lifecycle behavior.
> 
> **Overview**
> Pulls in a broad upstream sync across the Rust app-server, protocol, CLI, and tests, including removal of stale merge-conflict sections and substantial rewiring of request handling.
> 
> Expands the JSON-RPC protocol and event translation layer with new **experimental** thread elicitation APIs, permissions/MCP elicitation requests, additional realtime conversation notifications (e.g. transcript updates, audio item IDs, versioned startup), and a `skills/changed` notification.
> 
> Refactors app-server internals to carry per-request `RequestContext`/trace data through processing and outgoing messaging (tracking unresolved requests, adding tracing spans, canceling pending requests more explicitly), adjusts thread state/watch behavior (silent upserts, teardown/cleanup semantics), and updates CLI interactive flow to support `--remote`/app-server TUI wiring plus OAuth scope handling.
> 
> Strengthens cloud-requirements loading with structured error codes, retry/metrics instrumentation, and improved failure handling, with corresponding test updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 383a0eb1df7db8072c2ac35dce5574f4d259b543. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Sync app-server and client protocol changes, including new realtime and thread events**

### What Changed
- Adds support for new thread and permissions-related request types, plus new realtime updates such as transcript changes, skills changes, and versioned startup events
- Realtime websocket connections now use the updated event parsing flow and can handle custom certificate settings when connecting
- Fixes protocol mapping and conversion issues so thread history, user input ranges, and permission data can be read correctly
- Updates the CLI and docs to match the current project name

### Impact
`✅ Fewer realtime client/server compatibility issues`
`✅ Clearer thread and permissions updates`
`✅ More reliable websocket connections`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=9LuC3B70XidiQeqXKzNtFZvAA4jBgfTHIL-NmtRhHqU&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
