### PR TITLE
chore(cargo-deny): clean stale advisory ignores

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -27,9 +27,6 @@ unknown-git = "deny"
 
 [advisories]
 ignore = [
-    # No safe upgrade available - rustls-pemfile deprecated, migration requires async-nats update
     # No safe upgrade available - gix = "0.71" pinned in Cargo.toml, requires major version bump
     { id = "RUSTSEC-2025-0140", reason = "No safe upgrade available. gix = 0.71 pinned in Cargo.toml, requires breaking API change." },
-    # No safe upgrade available - async-nats 0.46.0 still uses rustls-webpki 0.102.x
-    { id = "RUSTSEC-2026-0049", reason = "No safe upgrade available. async-nats 0.46.0 still uses vulnerable rustls-webpki." },
 ]


### PR DESCRIPTION
## **User description**
Remove RUSTSEC-2026-0049 ignore — advisory no longer detected on origin/main per live audit 2026-05-04 (was producing non-fatal advisory-not-detected warning).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: config-only change to `deny.toml` that just tightens advisory ignore rules and should only affect `cargo deny` audit results in CI.
> 
> **Overview**
> Cleans up `cargo-deny` configuration by removing the ignored `RUSTSEC-2026-0049` advisory (previously causing an *advisory-not-detected* warning) and leaving only the `RUSTSEC-2025-0140` ignore for the pinned `gix` dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1979c98b10fa0e3fa5d615e6296257cbbd1bd78e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Remove a stale advisory ignore from dependency checks

### What Changed
- Removed an outdated security advisory ignore that was no longer needed
- Kept the remaining ignore for the pinned `gix` dependency
- `cargo deny` now matches the current dependency audit results, avoiding an unnecessary warning in CI

### Impact
`✅ Fewer false security warnings in CI`
`✅ Cleaner dependency audit results`
`✅ Less confusion during release checks`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=9T2MDR5y9b0ELdGLISDTbM3UogQNz6dg3aDeIP206io&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
