### PR TITLE
feat(absorb): helioscope into helios-cli (rationalization)

### DIFF
--- a/docs/rationalization/helioscope-absorption.md
+++ b/docs/rationalization/helioscope-absorption.md
@@ -1,0 +1,52 @@
+# helioscope → helios-cli absorption assessment
+
+**Status:** Blocked (do not subtree-merge full repo)  
+**Plan reference:** `phenotype-registry/RATIONALIZATION_PLAN.md` — helioscope retires to helios-cli (canonical codex fork)  
+**Date:** 2026-05-31
+
+## Verdict
+
+| Criterion | Result |
+|-----------|--------|
+| Same upstream (openai/codex) | Yes — both are codex-monorepo forks |
+| Canonical absorber | **helios-cli** (`main`) — active Phenotype fork with CVE/workspace fixes |
+| Retire candidate | **helioscope** (`master`) — legacy fork; README still references `heliosCLI` |
+| `git merge-base` | **None** — unrelated histories after divergent rebases |
+| Unique commits on helioscope | ~283 (sample: harness version bumps, deny.toml, fleet docs) |
+| Unique commits on helios-cli | ~4169 ahead of helioscope tip |
+| Full-tree `git subtree add --squash` | **Mechanically succeeds** but adds **~5,134 files** (~790k LOC) — duplicate codex monorepo, not consolidation |
+
+## Why full subtree merge is rejected
+
+1. **No merge-base** — cannot do a normal merge; only squash-subtree of entire tree.
+2. **Duplicate payload** — subtree places a second full codex workspace under `vendor/` with no deduplication against existing `codex-rs/`.
+3. **Plan intent** — Step 2 in `RATIONALIZATION_PLAN.md` lists helioscope retirement as **`gh repo archive` + husk README**, not code merge.
+4. **helios-cli is strictly ahead** — Phenotype-specific security and workspace fixes (#522–#527) live on helios-cli only.
+
+## Recommended path (reversible, PR-only)
+
+1. **Archive** `KooshaPari/helioscope` with README redirect → `KooshaPari/helios-cli` (separate ops PR; not done in code-absorb PR).
+2. **Cherry-pick audit** — if any of the ~283 helioscope-only commits contain unique fixes not on helios-cli, open targeted cherry-pick PRs (do not bulk subtree).
+3. **Optional:** add `helioscope` to `phenotype-registry` redirect table when archive lands.
+
+## Build verification (absorber)
+
+Run on `helios-cli` `main` (or this branch) with target dir on `E:`:
+
+```powershell
+$env:CARGO_TARGET_DIR = 'E:\cargo-target\helios-cli'
+cargo check --workspace --manifest-path codex-rs/Cargo.toml
+```
+
+CI on this repo (`rust-ci.yml`) is the authoritative green gate before any archive.
+
+**Local check (2026-05-31, Windows):** `cargo check --workspace` in `codex-rs/` failed on pre-existing `codex-windows-sandbox` parse error (`setup_orchestrator.rs:838` unclosed delimiter) — not introduced by this assessment doc. Linux CI remains the merge gate.
+
+## helioscope-only commit sample (for cherry-pick triage)
+
+```
+32e097e docs(fleet): branch protection audit report
+028627f fix(pheno-cli): add missing README; fix(guardis): correct repo URL
+0e0ae3d chore(helioscope): update harness crate versions
+74be1c4 fix(helioscope): remove broken symlink CONSTITUTION.yaml
+```


### PR DESCRIPTION
## **User description**
## Summary

Assessment PR for **helioscope → helios-cli** per `phenotype-registry/RATIONALIZATION_PLAN.md`.

**Verdict: blocked for code merge** — unrelated git histories (no merge-base); full `git subtree add --squash` duplicates ~5,134 files. Canonical path is archive helioscope + redirect to helios-cli; cherry-pick only if unique commits are found.

## Changes

- Adds `docs/rationalization/helioscope-absorption.md` with divergence stats, rejection rationale, and recommended archive-first path.

## Test plan

- [x] Document-only change
- [ ] Linux CI (`rust-ci.yml`) on merge (local Windows `cargo check` hit pre-existing `codex-windows-sandbox` parse error on `main`)

## Do not merge

Rationalization policy: PR-only, no merge until green + review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime, auth, or build logic changes.
> 
> **Overview**
> Adds **`docs/rationalization/helioscope-absorption.md`** to record the **helioscope → helios-cli** rationalization decision under `phenotype-registry/RATIONALIZATION_PLAN.md`.
> 
> The doc **blocks a full code merge**: no `git merge-base`, and a squash subtree would duplicate ~5k files (~790k LOC) instead of consolidating. **helios-cli** stays canonical; **helioscope** is the retire candidate.
> 
> It recommends **archive + README redirect**, optional **cherry-pick audit** of ~283 helioscope-only commits, and notes **Linux CI** (`rust-ci.yml`) as the merge gate (local Windows `cargo check` failure called out as pre-existing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74ffe91629f61ea89f6bf8bb9c9235e63110df1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Document the decision to block a full helioscope merge into helios-cli**

### What Changed
- Adds an assessment document that says the full repo merge should not proceed because the two codebases have unrelated histories.
- Explains that a full subtree merge would duplicate the entire codex workspace instead of consolidating it.
- Recommends the safer path: archive helioscope, add a README redirect to helios-cli, and cherry-pick only any unique fixes if needed.
- Notes helios-cli as the canonical branch and points to Linux CI as the merge gate.

### Impact
`✅ Clearer repository migration path`
`✅ Fewer accidental duplicate code imports`
`✅ Safer helioscope retirement process`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
