### PR TITLE
fix(workspace): unblock codex-rs cargo resolution

### DIFF
--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -229,6 +229,8 @@ rustls = { version = "0.23", default-features = false, features = [
     "ring",
     "std",
 ] }
+rustls-native-certs = "0.8"
+rustls-pki-types = "1.10"
 schemars = "0.8.22"
 seccompiler = "0.5.0"
 semver = "1.0"

--- a/codex-rs/core/Cargo.toml
+++ b/codex-rs/core/Cargo.toml
@@ -72,10 +72,7 @@ eventsource-stream = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
 iana-time-zone = { workspace = true }
-<<<<<<< HEAD
-=======
 image = { workspace = true, features = ["jpeg", "png", "webp"] }
->>>>>>> upstream_main
 indexmap = { workspace = true }
 libc = { workspace = true }
 notify = { workspace = true }


### PR DESCRIPTION
## **User description**
Stabilize wave: declare missing workspace deps so codex-rs resolves under cargo check.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest-only changes with no runtime logic; risk is limited to dependency/version alignment for TLS-related crates.
> 
> **Overview**
> Unblocks **`cargo check`** for `codex-rs` by fixing workspace dependency declarations and clearing a merge conflict in **`codex-core`**.
> 
> The root **`Cargo.toml`** adds **`rustls-native-certs`** and **`rustls-pki-types`** under **`[workspace.dependencies]`**, alongside the existing **`rustls`** entry, so crates that reference those workspace keys can resolve consistently.
> 
> In **`core/Cargo.toml`**, leftover **`<<<<<<<` / `>>>>>>>`** markers around the **`image`** dependency are removed and the **`upstream_main`** side is kept: **`image`** with **`jpeg`**, **`png`**, and **`webp`** features via the workspace **`image`** crate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15819bff5d195420eb5cc2fc5bac56c575c5cd50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Unblock `cargo check` for the codex-rs workspace**

### What Changed
- Removed a leftover merge conflict marker from `codex-core` so the workspace manifest loads cleanly again
- Kept the `image` dependency with JPEG, PNG, and WebP support in `codex-core`
- Added missing workspace dependency declarations for `rustls-native-certs` and `rustls-pki-types` so `codex-client` can resolve its TLS-related dependencies

### Impact
`✅ Fewer workspace load failures`
`✅ Successful codex-rs cargo checks`
`✅ Clearer dependency resolution for TLS-related crates`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
