### PR TITLE
chore(ci): adopt reusable workflow templates

### DIFF
--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -1,27 +1,9 @@
 name: cargo-deny
-
 on:
-  workflow_dispatch:
   pull_request:
   push:
     branches:
       - main
-
 jobs:
   cargo-deny:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./codex-rs
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Run cargo-deny
-        uses: EmbarkStudios/cargo-deny-action@v2
-        with:
-          rust-version: stable
-          manifest-path: ./codex-rs/Cargo.toml
+    uses: KooshaPari/phenotype-tooling/.github/workflows/reusable/cargo-deny.yml@main

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -1,17 +1,9 @@
 name: Trufflehog Secrets Scan
 on:
-  push:
-    branches: [main]
   pull_request:
-
+  push:
+    branches:
+      - main
 jobs:
   trufflehog:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-        with:
-          fetch-depth: 0
-      - uses: trufflehog/actions/setup@main
-      - run: trufflehog github --only-verified --no-update
-        env:
-          GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}
+    uses: KooshaPari/phenotype-tooling/.github/workflows/reusable/trufflehog.yml@main


### PR DESCRIPTION
## **User description**
Use shared reusable trufflehog/cargo-deny workflows from phenotype-tooling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only refactor with no application code changes; behavior now depends on external reusable workflows pinned to `@main`.
> 
> **Overview**
> **cargo-deny** and **Trufflehog** workflows no longer run their steps inline. Each job now delegates to shared reusable workflows in `KooshaPari/phenotype-tooling` on `main`, matching the pattern already used for SBOM refresh.
> 
> For **cargo-deny**, the local checkout, Rust toolchain, and `EmbarkStudios/cargo-deny-action` steps (including `./codex-rs` defaults) are removed, and the **`workflow_dispatch`** trigger is dropped so only PR and push-to-`main` runs remain.
> 
> For **Trufflehog**, the checkout, setup, and `trufflehog github --only-verified` run are replaced by the reusable workflow; trigger coverage stays PR plus push to **`main`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0e2291746e539060d6896cf7c1673c019eedc94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Move secret and dependency scans to shared CI workflows**

### What Changed
- Trufflehog and cargo-deny now run through shared reusable workflows instead of being defined inline in this repo
- cargo-deny no longer has a manual trigger; it runs on pull requests and pushes to `main`
- Trufflehog still runs on pull requests and pushes to `main`

### Impact
`✅ Consistent security checks across repositories`
`✅ Fewer CI maintenance updates`
`✅ Less chance of missed secret and dependency scan runs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
