### PR TITLE
fix(ci): resolve ci.yml merge conflicts and action ref syntax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       NODE_OPTIONS: --max-old-space-size=4096
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
@@ -20,7 +20,7 @@ jobs:
           run_install: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e@8f152de45cc393bb48ce5d89d36b731f54556e65
+        uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v6.9.0
         with:
           node-version: 22
 
@@ -38,11 +38,7 @@ jobs:
         run: |
           set -euo pipefail
           # Use a rust-release version that includes all native binaries.
-<<<<<<< HEAD
-          CODEX_VERSION=0.107.0
-=======
           CODEX_VERSION=0.115.0
->>>>>>> upstream_main
           OUTPUT_DIR="${RUNNER_TEMP}"
           python3 ./scripts/stage_npm_packages.py \
             --release-version "$CODEX_VERSION" \
@@ -52,12 +48,8 @@ jobs:
           echo "pack_output=$PACK_OUTPUT" >> "$GITHUB_OUTPUT"
 
       - name: Upload staged npm package artifact
-<<<<<<< HEAD
         if: steps.stage_npm_package.outcome == 'success'
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
-=======
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
->>>>>>> upstream_main
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v5.0.0
         with:
           name: codex-npm-staging
           path: ${{ steps.stage_npm_package.outputs.pack_output }}


### PR DESCRIPTION
## **User description**
Fixes workflow-load failure: git conflict markers left in ci.yml and invalid `@sha@sha` checkout refs.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow edits with no application runtime or security logic changes.
> 
> **Overview**
> Repairs **`.github/workflows/ci.yml`** so GitHub Actions can load and run again after broken merge resolution left conflict markers and invalid action pins.
> 
> **Action references** now use a single commit SHA with a version comment (`# v6.0.2`, `# v6.9.0`, `# v5.0.0`) instead of duplicated `@sha@sha` strings on checkout and setup-node.
> 
> The **npm staging** step keeps **`CODEX_VERSION=0.115.0`** (upstream) and still uploads the artifact only when staging succeeds via **`if: steps.stage_npm_package.outcome == 'success'`**, using **`actions/upload-artifact@043fb46d...`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 084657b000a9a0b0fb42a89f11eed66ccdbc2a2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Restore the CI workflow so builds can run again**

### What Changed
- Fixed broken merge-conflict leftovers in the CI workflow so GitHub Actions can load it again
- Corrected the action references so dependency checkout, Node setup, and artifact upload use valid pinned versions
- Kept npm staging on the newer release version, and still upload the package artifact only after staging succeeds

### Impact
`✅ CI runs without workflow load failures`
`✅ Fewer broken release staging jobs`
`✅ Reliable npm package artifact uploads`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
