### PR TITLE
fix(ci): add missing scripts/asciicheck.py and readme_toc.py from upstream

### DIFF
--- a/scripts/asciicheck.py
+++ b/scripts/asciicheck.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+
+import argparse
+import sys
+from pathlib import Path
+
+"""
+Utility script that takes a list of files and returns non-zero if any of them
+contain non-ASCII characters other than those in the allowed list.
+
+If --fix is used, it will attempt to replace non-ASCII characters with ASCII
+equivalents.
+
+The motivation behind this script is that characters like U+00A0 (non-breaking
+space) can cause regexes not to match and can result in surprising anchor
+values for headings when GitHub renders Markdown as HTML.
+"""
+
+
+"""
+When --fix is used, perform the following substitutions.
+"""
+substitutions: dict[int, str] = {
+    0x00A0: " ",  # non-breaking space
+    0x2011: "-",  # non-breaking hyphen
+    0x2013: "-",  # en dash
+    0x2014: "-",  # em dash
+    0x2018: "'",  # left single quote
+    0x2019: "'",  # right single quote
+    0x201C: '"',  # left double quote
+    0x201D: '"',  # right double quote
+    0x2026: "...",  # ellipsis
+    0x202F: " ",  # narrow non-breaking space
+}
+
+"""
+Unicode codepoints that are allowed in addition to ASCII.
+Be conservative with this list.
+
+Note that it is always an option to use the hex HTML representation
+instead of the character itself so the source code is ASCII-only.
+For example, U+2728 (sparkles) can be written as `&#x2728;`.
+"""
+allowed_unicode_codepoints = {
+    0x2728,  # sparkles
+}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Check for non-ASCII characters in files."
+    )
+    parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="Rewrite files, replacing non-ASCII characters with ASCII equivalents, where possible.",
+    )
+    parser.add_argument(
+        "files",
+        nargs="+",
+        help="Files to check for non-ASCII characters.",
+    )
+    args = parser.parse_args()
+
+    has_errors = False
+    for filename in args.files:
+        path = Path(filename)
+        has_errors |= lint_utf8_ascii(path, fix=args.fix)
+    return 1 if has_errors else 0
+
+
+def lint_utf8_ascii(filename: Path, fix: bool) -> bool:
+    """Returns True if an error was printed."""
+    try:
+        with open(filename, "rb") as f:
+            raw = f.read()
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as e:
+        print("UTF-8 decoding error:")
+        print(f"  byte offset: {e.start}")
+        print(f"  reason: {e.reason}")
+        # Attempt to find line/column
+        partial = raw[: e.start]
+        line = partial.count(b"\n") + 1
+        col = e.start - (partial.rfind(b"\n") if b"\n" in partial else -1)
+        print(f"  location: line {line}, column {col}")
+        return True
+
+    errors = []
+    for lineno, line in enumerate(text.splitlines(keepends=True), 1):
+        for colno, char in enumerate(line, 1):
+            codepoint = ord(char)
+            if char == "\n":
+                continue
+            if (
+                not (0x20 <= codepoint <= 0x7E)
+                and codepoint not in allowed_unicode_codepoints
+            ):
+                errors.append((lineno, colno, char, codepoint))
+
+    if errors:
+        for lineno, colno, char, codepoint in errors:
+            safe_char = repr(char)[1:-1]  # nicely escape things like \u202f
+            print(
+                f"Invalid character at line {lineno}, column {colno}: U+{codepoint:04X} ({safe_char})"
+            )
+
+    if errors and fix:
+        print(f"Attempting to fix {filename}...")
+        num_replacements = 0
+        new_contents = ""
+        for char in text:
+            codepoint = ord(char)
+            if codepoint in substitutions:
+                num_replacements += 1
+                new_contents += substitutions[codepoint]
+            else:
+                new_contents += char
+        with open(filename, "w", encoding="utf-8") as f:
+            f.write(new_contents)
+        print(f"Fixed {num_replacements} of {len(errors)} errors in {filename}.")
+
+    return bool(errors)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/readme_toc.py
+++ b/scripts/readme_toc.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+
+"""
+Utility script to verify (and optionally fix) the Table of Contents in a
+Markdown file. By default, it checks that the ToC between `<!-- Begin ToC -->`
+and `<!-- End ToC -->` matches the headings in the file. With --fix, it
+rewrites the file to update the ToC.
+"""
+
+import argparse
+import sys
+import re
+import difflib
+from pathlib import Path
+from typing import List
+
+# Markers for the Table of Contents section
+BEGIN_TOC: str = "<!-- Begin ToC -->"
+END_TOC: str = "<!-- End ToC -->"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Check and optionally fix the README.md Table of Contents."
+    )
+    parser.add_argument(
+        "file", nargs="?", default="README.md", help="Markdown file to process"
+    )
+    parser.add_argument(
+        "--fix", action="store_true", help="Rewrite file with updated ToC"
+    )
+    args = parser.parse_args()
+    path = Path(args.file)
+    return check_or_fix(path, args.fix)
+
+
+def generate_toc_lines(content: str) -> List[str]:
+    """
+    Generate markdown list lines for headings (## to ######) in content.
+    """
+    lines = content.splitlines()
+    headings = []
+    in_code = False
+    for line in lines:
+        if line.strip().startswith("```"):
+            in_code = not in_code
+            continue
+        if in_code:
+            continue
+        m = re.match(r"^(#{2,6})\s+(.*)$", line)
+        if not m:
+            continue
+        level = len(m.group(1))
+        text = m.group(2).strip()
+        headings.append((level, text))
+
+    toc = []
+    for level, text in headings:
+        indent = "  " * (level - 2)
+        slug = text.lower()
+        # normalize spaces and dashes
+        slug = slug.replace("\u00a0", " ")
+        slug = slug.replace("\u2011", "-").replace("\u2013", "-").replace("\u2014", "-")
+        # drop other punctuation
+        slug = re.sub(r"[^0-9a-z\s-]", "", slug)
+        slug = slug.strip().replace(" ", "-")
+        toc.append(f"{indent}- [{text}](#{slug})")
+    return toc
+
+
+def check_or_fix(readme_path: Path, fix: bool) -> int:
+    if not readme_path.is_file():
+        print(f"Error: file not found: {readme_path}", file=sys.stderr)
+        return 1
+    content = readme_path.read_text(encoding="utf-8")
+    lines = content.splitlines()
+    # locate ToC markers
+    try:
+        begin_idx = next(i for i, l in enumerate(lines) if l.strip() == BEGIN_TOC)
+        end_idx = next(i for i, l in enumerate(lines) if l.strip() == END_TOC)
+    except StopIteration:
+        # No ToC markers found; treat as a no-op so repos without a ToC don't fail CI
+        print(
+            f"Note: Skipping ToC check; no markers found in {readme_path}.",
+        )
+        return 0
+    # extract current ToC list items
+    current_block = lines[begin_idx + 1 : end_idx]
+    current = [l for l in current_block if l.lstrip().startswith("- [")]
+    # generate expected ToC from content without current ToC
+    toc_content = lines[:begin_idx] + lines[end_idx + 1 :]
+    expected = generate_toc_lines("\n".join(toc_content))
+    if current == expected:
+        return 0
+    if not fix:
+        print(
+            "ERROR: README ToC is out of date. Diff between existing and generated ToC:"
+        )
+        # Show full unified diff of current vs expected
+        diff = difflib.unified_diff(
+            current,
+            expected,
+            fromfile="existing ToC",
+            tofile="generated ToC",
+            lineterm="",
+        )
+        for line in diff:
+            print(line)
+        return 1
+    # rebuild file with updated ToC
+    prefix = lines[: begin_idx + 1]
+    suffix = lines[end_idx + 1 :]
+    new_lines = prefix + [""] + expected + [""] + suffix
+    readme_path.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
+    print(f"Updated ToC in {readme_path}.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
CI build-test step calls `./scripts/asciicheck.py` and `scripts/readme_toc.py` but both were missing. Ported from openai/codex upstream (parent repo). Fixes build-test gate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds dev/CI lint utilities only; no runtime product or security-sensitive logic changes.
> 
> **Overview**
> Adds **`scripts/asciicheck.py`** and **`scripts/readme_toc.py`**, which CI already invokes in `.github/workflows/ci.yml` but were absent locally—restoring the **build-test** gate.
> 
> **`asciicheck.py`** scans listed files for disallowed non-ASCII (with a small allowlist and optional **`--fix`** substitutions for typographic spaces/dashes/quotes). **`readme_toc.py`** validates or **`--fix`**es the README table of contents between `<!-- Begin ToC -->` / `<!-- End ToC -->` from `##`–`######` headings (skips when markers are missing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 521fee821aa557def029eec79f4914f38039d134. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->