### PR TITLE
fix(ci): use python3 explicitly for script invocations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,12 +59,12 @@ jobs:
           path: ${{ steps.stage_npm_package.outputs.pack_output }}
 
       - name: Ensure root README.md contains only ASCII and certain Unicode code points
-        run: ./scripts/asciicheck.py README.md
+        run: python3 scripts/asciicheck.py README.md
       - name: Check root README ToC
         run: python3 scripts/readme_toc.py README.md
 
       - name: Ensure codex-cli/README.md contains only ASCII and certain Unicode code points
-        run: ./scripts/asciicheck.py codex-cli/README.md
+        run: python3 scripts/asciicheck.py codex-cli/README.md
       - name: Check codex-cli/README ToC
         run: python3 scripts/readme_toc.py codex-cli/README.md
 


### PR DESCRIPTION
## **User description**
Scripts added via GitHub API don't get the execute bit set, causing exit 126 when called as ./scripts/asciicheck.py. Fix: call as 'python3 scripts/asciicheck.py' and 'python3 scripts/readme_toc.py' instead.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change to how two CI steps invoke existing Python scripts; no application or security logic affected.
> 
> **Overview**
> Fixes CI failures (exit 126) when running README validation by **not** executing `scripts/asciicheck.py` directly.
> 
> Both ASCII checks now run as **`python3 scripts/asciicheck.py`** for the root and `codex-cli` README paths, matching how `readme_toc.py` is already invoked. This avoids relying on the script execute bit, which GitHub-added files may lack.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8371e741f93917dc99734d9f95bca9922d747e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Fix README checks in CI when script files are not executable**

### What Changed
- CI now runs the README ASCII checks with `python3` instead of calling the scripts directly
- This prevents failures when GitHub-added scripts do not have execute permission
- Root and `codex-cli` README checks are both covered

### Impact
`✅ Fewer CI failures from missing script permissions`
`✅ Reliable README validation in GitHub Actions`
`✅ Fewer broken pipeline runs on fresh checkouts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
