### PR TITLE
docs: add work-state header to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> **Work state:** SCAFFOLD · **Progress:** `█░░░░░░░░░ 10%`
+> Intended multi-runtime CLI (codex fork). Currently governance/CI skeleton only — codex-rs workspace members declared but source NOT committed; does not build. Needs source vendored or re-scope. · updated 2026-06-02
+
 # helios-cli
 
 Phenotype-org multi-runtime CLI - a fork of [openai/codex](https://github.com/openai/codex).


### PR DESCRIPTION
Adds the org-standard work-state header (state + 10-block progress bar + focus line + date) to the top of the README, per the org-wide README work-state convention. State/percent set honestly from the dom-cli-ax coherence audit. Doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README edit with no runtime or security impact.
> 
> **Overview**
> Adds the org-standard **work-state** block at the top of `README.md`: **SCAFFOLD** status, a **10%** progress bar, a short honesty line that the repo is still a governance/CI skeleton (codex-rs members declared but source not committed, does not build), and an **updated 2026-06-02** stamp.
> 
> No code, CI, or build behavior changes—documentation only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa179152919d34955c95f6592bc73188e69d30ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->