### PR TITLE
ci(cargo-deny): add workflow_dispatch trigger for on-demand verification

### DIFF
--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -1,6 +1,7 @@
 name: cargo-deny
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches:


### PR DESCRIPTION
Draft PR opened during branch cleanup inventory.

Branch compare against main: ahead 1, behind 63, status diverged.

This PR needs normal review/CI before merge.