### PR TITLE
docs(governance): add AGENTS.md with ratatui fork SOTA exception (L5-104)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,91 @@
+# AGENTS.md — helios-cli
+
+**Repo:** [KooshaPari/helios-cli](https://github.com/KooshaPari/helios-cli)
+**Branch this AGENTS.md is maintained on:** `main`
+**Date:** 2026-06-19 (L5-104 ratatui fork verification shard)
+
+---
+
+## Project Overview
+
+`helios-cli` is the **Phenotype-org multi-runtime CLI scaffold** — a fork of [openai/codex](https://github.com/openai/codex).
+
+**Work state:** **SCAFFOLD** (per `README.md` work-state header, 10% progress, 2026-06-02). The `codex-rs/` workspace declares its member crates in `Cargo.toml` (and the dependency manifest is committed), but the source code for those workspace members is **NOT committed** in this repo. `helios-cli` is governance + CI skeleton only — it does not build.
+
+When source is vendored from upstream `openai/codex`, the pins in `codex-rs/Cargo.toml` (including the ratatui fork below) become authoritative.
+
+See `README.md` for the work-state header and `docs/` for project docs.
+
+---
+
+## SOTA exceptions
+
+This repo has **one SOTA exception** carried in `codex-rs/Cargo.toml` `[patch.crates-io]` (lines 387-393):
+
+### `ratatui` — `nornagon-v0.29.0-patch` git fork
+
+**Verdict (verified 2026-06-19, L5-104):** **KEEP** the fork pin. The patch has **not** landed upstream as a `pub fn`. Drop the pin when the upstream ratatui release (next minor, likely 0.31.x) exposes `set_viewport_area` as `pub` or an equivalent public API on `Terminal` is added; revisit on every upstream ratatui release.
+
+#### What the fork actually contains
+
+The fork `nornagon/ratatui` branch `nornagon-v0.29.0-patch` (HEAD `9b2ad1298408c45918ee9f8241a6f95498cdbed2`) adds **2 commits** on top of upstream `ratatui v0.29.0` (`28732176e1`):
+
+| SHA | Date | Subject |
+|---|---|---|
+| `bca287ddc5` | 2025-07-26 | **expose set_viewport_area** — the patch (changes `fn` → `pub fn` + 1-line docstring in `src/terminal/terminal.rs`) |
+| `9b2ad12984` | 2025-08-03 | Merge PR #1: bump `unicode-width` 0.2.0 → 0.2.1 (transitive dep bump) |
+
+> **Note:** the SOTA research doc `findings/sota-research-2026-06-19.md` § 7 / § 10 frames this as a "renderer bug fix". That framing is inaccurate. The patch is an **API visibility change** (private → public), not a rendering bug. The Codex TUI needs to call `Terminal::set_viewport_area()` directly from outside the ratatui crate, which the upstream API does not allow.
+
+#### Upstream state (ratatui 0.30.x, verified 2026-06-19)
+
+- **Latest stable:** `ratatui-v0.30.2` (released 2026-06-19, today). Also: `ratatui-v0.30.1` (2026-06-05), `ratatui-v0.30.0`, `ratatui-v0.29.0`.
+- **The literal patch (`fn` → `pub fn`) has NOT been applied upstream.** In `ratatui-v0.30.2/ratatui-core/src/terminal/resize.rs:78`, the same method exists as `pub(crate) fn set_viewport_area(&mut self, area: Rect)` — accessible only within the `ratatui-core` crate, not from external crates like Codex.
+- **Upstream's chosen solution:** expose viewport-area control through higher-level public API: `Terminal::with_options(Viewport::Inline(area))` (constructor) and `Terminal::resize(area)` (runtime). The internal `set_viewport_area` helper stays crate-internal.
+- **Implication for bumping:** to drop the fork pin and move to `ratatui = "0.30.2"` will require a **Codex TUI refactor** — replace direct `terminal.set_viewport_area(area)` calls with the appropriate `Terminal::with_options(Viewport::Inline(area))` (construction-time) or `terminal.resize(area)` (runtime) calls. This is a code change, not a Cargo.toml bump.
+
+#### Cargo.lock evidence (this branch)
+
+```
+$ grep -A 3 'name = "ratatui"' codex-rs/Cargo.lock
+name = "ratatui"
+version = "0.29.0"
+source = "git+https://github.com/nornagon/ratatui?branch=nornagon-v0.29.0-patch#9b2ad1298408c45918ee9f8241a6f95498cdbed2"
+```
+
+The fork pin is the **active** resolved source — not a no-op override.
+
+#### Sibling SOTA exceptions in the same `[patch.crates-io]` section (out of scope for this shard)
+
+For audit completeness only — not addressed by the L5-104 shard. Track separately:
+
+| Package | Pin | Status |
+|---|---|---|
+| `crossterm` | `nornagon/crossterm` branch `nornagon/color-query` | unverified |
+| `tokio-tungstenite` | `openai-oss-forks/tokio-tungstenite` rev `132f5b39...` | unverified |
+| `tungstenite` | `openai-oss-forks/tungstenite-rs` rev `9200079d...` (double-pinned via SSH + HTTPS) | unverified |
+
+---
+
+## Stack
+
+- **Languages:** Rust (primary — codex-rs workspace)
+- **Build system:** Cargo workspace (`codex-rs/Cargo.toml`)
+- **Upstream lineage:** `openai/codex` (the Codex CLI from OpenAI) — this repo is a Phenotype-org fork
+
+## Conventions
+
+- **Branch naming:** `chore/<req-id>-<slug>-<date>` for chore work; `feat/<req-id>-<slug>-<date>` for features.
+- **Commit messages:** Conventional Commits (`feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `build:`, `ci:`) with optional scope.
+- **PR labels:** `governance` for cleanup, `L<n>-#<n>` for tracking against DAG level.
+- **Meta-bundle for a release-ready crate:** `AGENTS.md` + `llms.txt` + `WORKLOG.md` + `CHANGELOG.md` + `LICENSE-MIT`.
+- **SOTA artifacts:** `findings/`, `plans/`, `worklogs/`, `docs/adr/<date>/`.
+
+## Related
+
+- `README.md` — work-state header + project overview
+- `CHANGELOG.md` — release notes
+- `codex-rs/Cargo.toml` — workspace manifest with the SOTA-exception `[patch.crates-io]` section (lines 387-393)
+- `codex-rs/Cargo.lock` — resolved dependency graph (confirms fork is active)
+- `findings/sota-research-2026-06-19.md` § 7 (ratatui) and § 10 (SOTA exception log) — source SOTA research; see also the revisit trigger note above
+- `findings/2026-06-19-L5-104-ratatui-fork-verification.md` — verification log for this shard (TODO; see "Shard release" below)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
--
+- `AGENTS.md` — repo governance file documenting the ratatui SOTA exception (verified 2026-06-19, L5-104 ratatui fork verification shard). The `nornagon-v0.29.0-patch` fork pin in `codex-rs/Cargo.toml` `[patch.crates-io]` is **kept** (the patch has not landed upstream; upstream 0.30.x kept `set_viewport_area` as `pub(crate)`). Revisit on next ratatui release.
 
 ### Changed
 


### PR DESCRIPTION
## **User description**
## L5-104 ratatui fork verification (2026-06-19) — verdict B

Closes the L5-104 P1 verification shard from `findings/sota-research-2026-06-19.md` § 7 / § 10: verify whether the `nornagon/ratatui` fork patch for the renderer/API issue has been upstreamed into ratatui 0.30.x.

### Verdict: **B — keep the fork pin**

### What was verified

1. **Fork state** (branch `nornagon-v0.29.0-patch`, HEAD `9b2ad1298408c45918ee9f8241a6f95498cdbed2`):
   - 2 commits on top of upstream v0.29.0:
     - `bca287ddc5` (2025-07-26) — **expose set_viewport_area** (the patch; changes `fn` → `pub fn` + 1-line docstring in `src/terminal/terminal.rs`)
     - `9b2ad12984` (2025-08-03) — Merge PR #1: bump `unicode-width` 0.2.0 → 0.2.1

2. **Upstream ratatui releases:** 0.30.2 (2026-06-19, today), 0.30.1 (2026-06-05), 0.30.0, 0.29.0.

3. **Upstream 0.30.2 inspection:** `set_viewport_area` exists at `ratatui-core/src/terminal/resize.rs:78` as `pub(crate) fn set_viewport_area(&mut self, area: Rect)` — **crate-internal, NOT publicly accessible**. Upstream exposes the same functionality via the public API `Terminal::with_options(Viewport::Inline(area))` and `Terminal::resize(area)`.

4. **Cargo.lock evidence** confirms the fork is the active resolved source:
   ```
   ratatui 0.29.0
   source = git+https://github.com/nornagon/ratatui?branch=nornagon-v0.29.0-patch#9b2ad1298408c45918ee9f8241a6f95498cdbed2
   ```

5. **The literal patch (`fn` → `pub fn`) has NOT landed upstream as a `pub fn`.** Upstream's chosen solution is to keep the internal helper `pub(crate)` and force callers to use the higher-level public API.

### Implication for dropping the fork pin

To drop the fork pin and move to `ratatui = "0.30.2"` requires a **Codex TUI refactor**: replace direct `terminal.set_viewport_area(area)` calls with `Terminal::with_options(Viewport::Inline(area))` (construction-time) or `terminal.resize(area)` (runtime). This is a code change, not a Cargo.toml bump.

### SOTA research framing note

The SOTA research doc `findings/sota-research-2026-06-19.md` § 7 / § 10 calls this a "renderer bug fix". The actual patch is an **API visibility change** (private → public), not a rendering bug. The Codex TUI needs to call `Terminal::set_viewport_area()` directly from outside the ratatui crate, which the upstream API does not allow. The new `AGENTS.md` corrects this framing.

### Sibling SOTA exceptions (out of scope, noted for follow-up)

`[patch.crates-io]` in `codex-rs/Cargo.toml` has 3 other fork pins not addressed by this shard: `crossterm` (nornagon/color-query), `tokio-tungstenite` (openai-oss-forks), `tungstenite` (openai-oss-forks, double-pinned).

### Files changed

- `AGENTS.md` (new) — repo governance file documenting the ratatui fork exception
- `CHANGELOG.md` — `[Unreleased] / Added` entry

### Revisit trigger

Re-run this verification on every upstream ratatui release. Drop the fork pin when upstream exposes `set_viewport_area` as `pub` OR adds an equivalent public API on `Terminal`.


___

## **CodeAnt-AI Description**
**Document the ratatui fork exception and keep the fork pin**

### What Changed
- Added `AGENTS.md` as a repo governance file describing the ratatui exception and when to revisit it
- Recorded that the `nornagon-v0.29.0-patch` ratatui fork stays pinned because the upstream change has not been released publicly
- Updated the changelog to note the new governance document and the decision to keep the fork pin

### Impact
`✅ Clearer dependency ownership`
`✅ Fewer surprises when reviewing future ratatui upgrades`
`✅ Faster fork verification for maintainers`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
