### PR TITLE
fix(ci): pin codeql upload-sarif to valid v3.37.6 SHA

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -37,7 +37,7 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@fca7ace96b7d713c7035881819e25a804e825323  # v3.28.18
+        uses: github/codeql-action/upload-sarif@c4dd10e44af883a891fe31ced449bcb4a6728b9b  # v3.37.6
         with:
           sarif_file: results.sarif
 


### PR DESCRIPTION
## **User description**
scorecard.yml pinned github/codeql-action/upload-sarif@fca7ace96b7d713c7035881819e25a804e825323 (claimed v3.28.18), which does not exist upstream (GitHub API 422, verified). Same class as the invalid SHAs fixed in #48/#622/#623.

Pins to the verified v3.37.6 commit c4dd10e44af883a891fe31ced449bcb4a6728b9b (consistent with security-deep-scan.yml). Scheduled workflow only; no required checks affected.


___

## **CodeAnt-AI Description**
Pin Scorecard SARIF uploads to a valid CodeQL action release

### What Changed
- Scorecard analysis now uploads its security results using the verified CodeQL action v3.37.6 commit instead of an invalid, unavailable version

### Impact
`✅ Reliable scheduled security scans`
`✅ Successful SARIF result uploads`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
