### PR TITLE
chore(deps): inline ffi_utils to parking_lot (phenotype-shared deleted)

### DIFF
--- a/crates/harness_pyo3/Cargo.toml
+++ b/crates/harness_pyo3/Cargo.toml
@@ -19,7 +19,7 @@ pyo3 = { version = "0.28", features = ["extension-module", "auto-initialize"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 parking_lot = "0.12"
-ffi_utils = { path = "../../../phenotype-shared/crates/ffi_utils" }
+
 
 [profile.release]
 opt-level = 3

--- a/crates/harness_pyo3/src/lib.rs
+++ b/crates/harness_pyo3/src/lib.rs
@@ -7,7 +7,7 @@
 use pyo3::prelude::*;
 use pyo3::types::PyModule;
 use std::collections::HashMap;
-use ffi_utils::FfiMutex;
+use parking_lot::Mutex as FfiMutex;
 use std::time::{Duration, Instant};
 
 static CACHE: FfiMutex<Option<PyCache>> = FfiMutex::new(None);


### PR DESCRIPTION
## **User description**
## Summary

Inline the trivial `ffi_utils` crate (3 lines: re-export of `parking_lot::Mutex as FfiMutex`) into helios-cli directly. phenotype-shared is deleted.

## Change

- `crates/harness_pyo3/Cargo.toml`: drop `ffi_utils` path dep
- `crates/harness_pyo3/src/lib.rs`: `use parking_lot::Mutex as FfiMutex;`

## Why not create a new repo

Per operator constraint: 'this process should NOT create swathes of new repos NOR dump tars or other unsemantic restores/integrations into a new repo'. ffi_utils is one type alias; promoting it to a crate would be over-engineering.

## Stats

2 files, 2 insertions(+), 2 deletions(-)


___

## **CodeAnt-AI Description**
Remove the unavailable shared dependency from the Python harness

### What Changed
- The Python harness now uses its existing mutex dependency directly instead of relying on the deleted shared `ffi_utils` package
- The harness can build without a local dependency on the removed `phenotype-shared` repository
- Cache synchronization behavior remains unchanged

### Impact
`✅ Restored Python harness builds`
`✅ Fewer dependency resolution failures`
`✅ Unchanged cache behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
